### PR TITLE
role: add full-stack developer

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**89 roles drafted** (85 mapped to an O*NET occupation, 4 custom; 47 at spec 2, 42 awaiting upgrade), across 10 categories:
+**90 roles drafted** (86 mapped to an O*NET occupation, 4 custom; 48 at spec 2, 42 awaiting upgrade), across 10 categories:
 
 - **design**: 2
-- **engineering**: 14
+- **engineering**: 15
 - **finance**: 10
 - **healthcare**: 6
 - **legal**: 4

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 85 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 86 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -136,7 +136,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>15 — Computer and Mathematical</strong> (8/38 drafted)</summary>
+<summary><strong>15 — Computer and Mathematical</strong> (9/38 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -155,7 +155,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 |  | 15-1251.00 | Computer Programmers |  |
 | ♻️ | 15-1252.00 | Software Developers | [`software-engineer`](./roles/software-engineer/SKILL.md) |
 |  | 15-1253.00 | Software Quality Assurance Analysts and Testers |  |
-|  | 15-1254.00 | Web Developers |  |
+| ✅ | 15-1254.00 | Web Developers | [`full-stack-developer`](./roles/full-stack-developer/SKILL.md) |
 | ♻️ | 15-1255.00 | Web and Digital Interface Designers | [`ux-designer`](./roles/ux-designer/SKILL.md) |
 |  | 15-1255.01 | Video Game Designers |  |
 |  | 15-1299.00 | Computer Occupations, All Other |  |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 89,
+  "count": 90,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -439,6 +439,20 @@
       "skill": "roles/food-service-manager/SKILL.md",
       "references": [
         "artifacts.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ]
+    },
+    {
+      "slug": "full-stack-developer",
+      "description": "Use when a task needs the judgment of a full-stack developer \u2014 shipping a feature end to end across UI, API, and database; designing the client/server contract; choosing a rendering strategy (SSR/CSR/SSG); diagnosing whether a slow page is network, render, or query; or deciding where a piece of state should live.",
+      "category": "engineering",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "15-1254.00",
+      "skill": "roles/full-stack-developer/SKILL.md",
+      "references": [
+        "playbook.md",
         "red-flags.md",
         "vocabulary.md"
       ]

--- a/roles/full-stack-developer/SKILL.md
+++ b/roles/full-stack-developer/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: full-stack-developer
+description: Use when a task needs the judgment of a full-stack developer — shipping a feature end to end across UI, API, and database; designing the client/server contract; choosing a rendering strategy (SSR/CSR/SSG); diagnosing whether a slow page is network, render, or query; or deciding where a piece of state should live.
+metadata:
+  category: engineering
+  maturity: draft
+  spec: 2
+  onet_soc_code: "15-1254.00"
+---
+
+# Full-Stack Developer
+
+## Identity
+
+A developer who owns a feature from the button a user clicks to the row it writes in the database, not one layer of it. Seniority is measured less by depth in any single layer than by soundness at the seams between them — the network boundary, the auth handoff, the cache. The defining tension: breadth is the whole value (one person ships a vertical slice without a handoff) and the whole trap (competence in a layer you touch monthly is one bad assumption from an incident).
+
+## First-principles core
+
+1. **The client is hostile territory.** Anything the browser touches can be read, modified, and replayed. Validation in the UI is user experience; validation on the server is security. The same rule often has to exist in both places for two different reasons — never assume the request came from your code.
+2. **A full-stack feature is one product across two release cadences.** The browser runs last week's JavaScript against today's API. Every backend change has a window where old clients still call the old shape — additive changes survive it, renames and removals break users you cannot force to refresh.
+3. **The network is a layer, not a gap between layers.** Most cross-stack bugs live in serialization — timezones, float precision, `null` vs `undefined`, snake_case vs camelCase, a number that became a string over JSON — not inside either half where each looks correct alone.
+4. **State that lives in two places will diverge.** Every value cached on the client is a copy that can go stale. The question is never "how do I avoid duplicating it" (you can't, that's what a UI is) but "how do I detect and heal the divergence."
+5. **A type is not a runtime guarantee at the boundary.** TypeScript describes what the data should be; the moment it crosses the wire from a source you don't control, "should" is a hope. Only a runtime check at the edge makes the type true.
+
+## Mental models & heuristics
+
+- **When choosing a rendering strategy, default to server-rendering the first paint unless the page sits behind auth and isn't indexed** — then client-render is fine and simpler. SSR earns its operational cost only when SEO or first-paint latency is a stated requirement, not by reflex.
+- **When a list view is slow, suspect an N+1 before you suspect the database.** 50 rows each firing their own query is 51 round trips; the fix is a join or a dataloader, not another index.
+- **Optimistic UI when the write almost always succeeds and rollback is cheap** (likes, toggles); pessimistic spinner when a wrong-then-corrected value misleads (account balances, inventory counts, prices).
+- **When client and server disagree on a value, the server is authoritative for truth and the client for intent.** Reconcile by refetching from the server, never by trusting the client's copy back into the database.
+- **Agree the API contract before either half is built** — the JSON shapes, the error envelope, the status codes. Then frontend and backend build in parallel against it; skipping this means two people independently guessing at the seam.
+- **Reach for a global state manager only after prop-drilling hurts across 3+ levels.** Most "we need Redux" is server cache in disguise, which a fetch-cache library (React Query / SWR) models better than hand-rolled global state.
+- **Put one validation schema at the boundary and derive both the type and the runtime check from it** (Zod / valibot) — one source of truth beats a type and a hand-written guard that drift apart.
+
+## Decision framework
+
+1. **Draw the data's round trip first** — where it's stored, what shape it takes over the wire, where it renders. Latency and bugs both live on this path, so map it before writing code.
+2. **Define the API contract** — endpoints, request/response JSON, error shape, status codes — and write it down before either side is built.
+3. **Assign each piece of state one owner** — server, URL, client cache, or component. Duplicated ownership with no designated source of truth is the default cross-stack bug.
+4. **Build the unhappy paths at the boundary first**: loading, empty, error, stale, offline, slow connection. The happy path is the small fraction of the code that ever gets demoed and the large fraction that gets skipped.
+5. **Verify across the real seam** — the actual client hitting the actual API — not a mocked client against a mocked server that agree with each other and nothing real.
+6. **Check the two-cadence deploy** before shipping: does the old client still work against the new server for the rollout window? If not, make the change additive and remove the old path in a later release.
+
+## Tools & methods
+
+- Frameworks that own both halves: Next.js, Remix, SvelteKit, Nuxt — routing, data loading, and rendering strategy in one place.
+- TypeScript end to end, with a runtime validator (Zod / valibot) at every network boundary so the types aren't fiction where data enters.
+- API styles chosen by contract needs: REST for cacheable resources, GraphQL when clients need to shape their own payloads, tRPC when one team owns both ends and wants types without a codegen step.
+- Data-fetching caches (React Query / SWR / TanStack Query) instead of hand-rolled loading state; type-safe ORMs (Prisma, Drizzle) instead of string SQL.
+- Client observability is its own discipline: source-mapped error tracking (Sentry) plus real-user Core Web Vitals — LCP, INP, CLS — because the server being fast tells you nothing about what the user's phone rendered.
+- Auth handled as a boundary concern: httpOnly cookies vs bearer tokens, verified server-side on every request; templates in [references/playbook.md](references/playbook.md).
+
+## Communication style
+
+To designers: translates a mock into what's cheap versus expensive ("that hover state is free; the live-collaboration cursor is two weeks and a WebSocket to run"). To backend specialists: leads with the contract, not the UI. To a PM: frames work in user-visible latency and what breaks on a slow connection or an old phone, not in framework names. Pushes back on "just make it real-time" by asking what staleness the user would actually notice.
+
+## Common failure modes
+
+- **Trusting the client** — enforcing a quantity limit or a price only in the form, leaving the endpoint open to a crafted request.
+- **Request waterfalls** — every component fetches on mount, so round trips run serially and the screen is blank for seconds when one combined request would do.
+- **Shipping only the happy path** — no loading, empty, or error state, so the first slow network turns the feature into a frozen white box.
+- **Jack-of-all-stack overreach** (the breadth trap firing): hand-rolling auth, crypto, or payments across the whole stack "because I can," where a specialist or a hosted service is the correct call.
+- **Bundle bloat** — pulling in a 70KB date library and the whole of a utility package for one function, paid by every visitor's download and parse time.
+- **Treating a compile-time type as a runtime contract** at the edge, so malformed API data crashes three layers deep instead of being rejected at the door.
+
+## Worked example
+
+A dashboard page loads in **4.2s**; the PM wants it under **1s**. Naive read: "the database is slow — add indexes or upsize the DB." Tracing the round trip instead:
+
+- **Measure the seam.** The API responds in **180ms**. So the database is not the bottleneck — roughly **4.0s** is client-side.
+- **Find the waterfall.** The page fetches `/user` (**200ms**), then on render fetches `/projects` (**200ms**), then each of **12** project cards fetches its own `/projects/:id/stats` — the browser caps at **6** concurrent connections, so that's 2 batches ≈ **400ms**. Serial chain: 200 + 200 + 400 = **800ms** of network.
+- **Find the render cost.** All 12 cards render a **500-row** table client-side ≈ **2.4s**, and a **900KB** JS bundle parses in ≈ **1.0s** on a mid-tier phone. Check: 0.8 + 2.4 + 1.0 = **4.2s**. Reconciles.
+
+Fixes ranked by impact per unit of effort:
+1. **Collapse the waterfall** into one `/dashboard` endpoint returning user + projects + stats in a single **250ms** response (joins done server-side; 1 round trip replacing 14). Network 800ms → 250ms.
+2. **Virtualize the tables** — render ~20 visible rows, not 500. Render 2.4s → **0.4s**.
+3. **Code-split the charting library** (**300KB**) to load only when a chart opens. Bundle 900 → **600KB**, parse 1.0s → **0.65s**.
+
+New first load: 250ms + 0.4s + 0.65s ≈ **1.3s**; add stale-while-revalidate caching of `/dashboard` for 60s and repeat loads land near **300ms**. Deliverable — the readout filed on the ticket:
+
+> **Dashboard latency: 4.2s → ~1.3s (first load), ~0.3s (cached).** Root cause was not the DB (API is 180ms) — it was a 14-request client waterfall, a 500-row client-side render, and a 900KB bundle. Shipped: one combined `/dashboard` endpoint, table virtualization, lazy-loaded charts. The DB upgrade we were about to buy would have moved 180ms and left the other 4.0s untouched.
+
+## Going deeper
+
+- [references/playbook.md](references/playbook.md) — load when building a feature slice or picking a rendering/state strategy: the contract template, latency budget, state-location and rendering decision tables.
+- [references/red-flags.md](references/red-flags.md) — load when reviewing a slow or flaky full-stack feature: cross-stack smell tests with thresholds.
+- [references/vocabulary.md](references/vocabulary.md) — load when terms of art (hydration, CORS, idempotency, optimistic UI) are in play and being misused.
+
+## Sources
+
+- Web performance numbers (browser 6-connections-per-host cap, LCP/INP/CLS thresholds, parse cost on mid-tier mobile) follow [web.dev](https://web.dev/vitals/) Core Web Vitals guidance and Chrome DevTools' network model; verify current thresholds against web.dev before quoting, as targets are revised.
+- Rendering-strategy tradeoffs (SSR/SSG/ISR/CSR) draw on the [Next.js](https://nextjs.org/docs) and [Remix](https://remix.run/docs) data-loading docs and Patterns.dev's rendering-patterns catalog.
+- "Server cache is not client state" reflects the [TanStack Query](https://tanstack.com/query) design rationale (server state vs client state).
+- Boundary-validation practice (schema at the edge, derive the type) follows the [Zod](https://zod.dev) docs and the "parse, don't validate" principle (Alexis King, 2019).
+- No direct practitioner review of this role file yet — flag via PR to confirm, correct, or sharpen any of the above.

--- a/roles/full-stack-developer/references/playbook.md
+++ b/roles/full-stack-developer/references/playbook.md
@@ -1,0 +1,79 @@
+# Full-Stack Build & Debug Playbook
+
+Filled templates and decision tables for shipping a feature slice. Load when building or reviewing, not for general reasoning (that's SKILL.md).
+
+## The vertical-slice checklist
+
+Order matters — the contract comes before either half, the unhappy paths before the happy one.
+
+1. **Contract** — write the request/response JSON and error shape (below) and paste it where both sides can see it.
+2. **State map** — for each value on the page, one row in the state-location table below.
+3. **Server** — endpoint + boundary validation + auth check + the query (watch for N+1).
+4. **Client** — data fetch through the cache layer, then loading / empty / error / stale states, then the happy path.
+5. **Seam test** — real client against real API on a throttled connection (Fast 3G, 4× CPU slowdown in DevTools).
+6. **Two-cadence check** — does old client + new server survive the rollout window?
+
+## API contract template
+
+Agree this before writing either side. Concrete example — a "create project" endpoint:
+
+```
+POST /api/projects
+Request:  { "name": string(1..80), "visibility": "private" | "team" }
+Response 201: { "id": string, "name": string, "visibility": string, "createdAt": ISO8601-UTC-string }
+Errors (envelope is identical for every endpoint):
+  400 { "error": { "code": "VALIDATION", "field": "name", "message": "1–80 chars" } }
+  401 { "error": { "code": "UNAUTHENTICATED", "message": "..." } }
+  409 { "error": { "code": "DUPLICATE_NAME", "message": "..." } }
+```
+
+Rules that prevent seam bugs: timestamps are ISO 8601 UTC strings (never epoch-vs-string ambiguity, never server-local time); money is integer minor units (cents), never a float; one error envelope shape for every endpoint so the client has one error handler, not twenty.
+
+## State-location decision table
+
+Each value gets exactly one owner. Pick the leftmost column that fits.
+
+| Value | Lives in | Why |
+|---|---|---|
+| Current filter / tab / page number | URL query params | Shareable, survives refresh, back-button works |
+| Logged-in user, projects, any DB-backed data | Server cache (React Query/SWR) | Server is source of truth; cache handles staleness |
+| Form field being typed | Local component state | Ephemeral, dies on unmount, no one else needs it |
+| Theme / sidebar-collapsed | Client persistence (localStorage) | Client preference, never security-relevant |
+| Auth token | httpOnly cookie | JS must not be able to read it (XSS defense) |
+
+If a value seems to need two of these, you have a sync bug waiting — pick one owner and derive the rest.
+
+## Rendering-strategy decision table
+
+| Page shape | Strategy | Because |
+|---|---|---|
+| Marketing / blog / docs, content stable | Static (SSG) | Cheapest, fastest, CDN-cacheable; rebuild on publish |
+| Content changes hourly, still public | Incremental static (ISR) or SSG + revalidate | Static speed, bounded staleness |
+| Public, personalized or SEO-critical, changes per request | Server-render (SSR) | First paint has real content for crawlers + slow devices |
+| Behind auth, not indexed (dashboards, admin) | Client-render (CSR) | No SEO need; ship a shell + fetch, skip SSR's operational cost |
+
+Default: static if it can be, CSR if it's private, SSR only when a public page needs real first-paint content. SSR is the most expensive to operate — make it justify itself.
+
+## Latency budget (mid-tier phone, 4G) — where the 1s goes
+
+| Segment | Target | Common killer |
+|---|---|---|
+| Network round trips | < 300ms | Waterfall of serial fetches (fix: one combined endpoint) |
+| JS bundle parse/execute | < 350ms | 900KB+ bundle (fix: code-split, drop heavy deps) |
+| Render | < 400ms | Rendering 500 rows client-side (fix: virtualize/paginate) |
+| **First contentful, total** | **< ~1.3s** | |
+
+## Debug order for a slow page (fastest signal first)
+
+1. **Open the Network tab, sort by time.** Is one request slow, or are there many serial ones? Many serial ⇒ waterfall (a client-side collapse, not a DB problem).
+2. **Read the slow request's server timing.** API < 200ms means the rest is client-side — stop blaming the database.
+3. **Check bundle size** (coverage tab: how much JS is unused on load). > 500KB parsed ⇒ code-split.
+4. **Profile the render** (Performance tab). Long task > 50ms ⇒ too many DOM nodes; virtualize.
+5. Only after 1–4 point at the server, look at the query plan and indexes.
+
+## Auth handoff template (the boundary that's easy to get wrong)
+
+- Token in an **httpOnly, Secure, SameSite=Lax cookie** — JS can't read it, so an XSS payload can't exfiltrate it.
+- Server **verifies on every request** (signature + expiry + revocation check for sensitive actions); never trusts a client-sent user id or role.
+- Client treats a 401 as "refresh once, then redirect to login" — a single retry, not an infinite loop.
+- CORS: allow only the exact origins you serve; `Access-Control-Allow-Credentials: true` cannot be paired with `Allow-Origin: *` (the browser rejects it) — list origins explicitly.

--- a/roles/full-stack-developer/references/red-flags.md
+++ b/roles/full-stack-developer/references/red-flags.md
@@ -1,0 +1,57 @@
+# Red Flags
+
+Cross-stack smell tests. Format per flag: what it usually means, the first question to ask, the check to run.
+
+## Validation exists in the UI but the endpoint accepts anything
+
+- **Usually means:** the limit (quantity, price, role, file size) was enforced in the form only, so a crafted request bypasses it. The second most likely cause: the server "validates" by trusting a field the client sent (`isAdmin`, `userId`).
+- **First question:** "What happens if I POST this endpoint directly with curl and a value the form would reject?"
+- **Check:** hit the endpoint with the client removed — an out-of-range value, a missing auth cookie, another user's id. If any succeeds, the real validation was never on the server.
+
+## Page makes 10+ requests before it shows anything
+
+- **Usually means:** a request waterfall — components fetch on mount so round trips run serially — or an N+1 where a list renders one request per row.
+- **First question:** "Are these requests parallel or does each wait for the one above it?"
+- **Check:** Network tab, waterfall view. Staircase shape ⇒ serialize into one combined endpoint. Same URL pattern repeated per row ⇒ N+1; batch it server-side.
+
+## API is fast (<200ms) but the page still takes seconds
+
+- **Usually means:** the cost is client-side — bundle parse or render — not the backend everyone is about to optimize.
+- **First question:** "How big is the JS bundle, and how many DOM nodes does this page mount?"
+- **Check:** Coverage tab for unused JS on load (>500KB parsed ⇒ code-split); Performance tab for long tasks (>50ms render ⇒ virtualize the list). Do this before touching the query plan.
+
+## Dates or amounts are wrong by a timezone or a rounding cent
+
+- **Usually means:** a serialization mismatch at the boundary — server-local time sent instead of UTC, or money stored/sent as a float so 0.1 + 0.2 = 0.30000000000000004.
+- **First question:** "Is this an ISO 8601 UTC string end to end, and is money an integer in minor units?"
+- **Check:** inspect the raw JSON on the wire (not the rendered value). A timestamp without `Z`/offset, or a monetary value with a decimal point, is the bug.
+
+## TypeScript types are green but production throws on real API data
+
+- **Usually means:** the type is asserted at the boundary (`as ResponseType`, or an unchecked generic on the fetch) with no runtime validation, so malformed or null data crashes three layers deep instead of being rejected at the door.
+- **First question:** "Is there a runtime schema parsing this response, or is the type a hope?"
+- **Check:** grep the fetch layer for `as ` casts and untyped `.json()`. Add a Zod/valibot parse at the edge; the crash moves to a clear boundary error.
+
+## "It works locally" but breaks in production only
+
+- **Usually means:** an environment gap — CORS origin, a cookie's Secure/SameSite flag, an env var, or an absolute `localhost` URL that shipped.
+- **First question:** "What is different between local and prod for this request — origin, protocol, cookie flags, base URL?"
+- **Check:** the browser console for the CORS/cookie error text (it's specific), and grep for hardcoded `http://localhost`. `SameSite=Lax` cookies won't send on cross-site prod requests that worked same-origin locally.
+
+## State shown in the UI disagrees with the database
+
+- **Usually means:** two owners for one value — an optimistic update that never reconciled, or a client cache never invalidated after a write.
+- **First question:** "Who is the source of truth for this value, and what invalidates the client copy after a mutation?"
+- **Check:** trace the write path — does it invalidate/refetch the affected cache key on success? If the UI updates optimistically and there's no rollback on error, a failed write leaves a lie on screen.
+
+## Bundle grew by hundreds of KB after a small feature
+
+- **Usually means:** a heavy dependency pulled in whole — a date library (~70KB), an entire utility package for one function, or a charting lib imported eagerly instead of lazily.
+- **First question:** "What did this feature add to the bundle, and does it need to load on first paint?"
+- **Check:** a bundle analyzer (source-map-explorer / the framework's analyze mode). Move rarely-used heavy libs behind a dynamic import; replace whole-package imports with the single function or a lighter dep.
+
+## Auth token readable from JavaScript
+
+- **Usually means:** the token is in localStorage or a non-httpOnly cookie, so any XSS payload can read and exfiltrate it — session theft, not just a defaced page.
+- **First question:** "Can `document.cookie` or `localStorage` see the session token in the console right now?"
+- **Check:** open the console on a logged-in page and read them. If the token is there, move it to an httpOnly Secure cookie; the client should never need to read it.

--- a/roles/full-stack-developer/references/vocabulary.md
+++ b/roles/full-stack-developer/references/vocabulary.md
@@ -1,0 +1,63 @@
+# Vocabulary
+
+Terms of art full-stack work turns on that generalists reliably misuse. Format per term: definition, how a practitioner actually uses it, the common misuse.
+
+## Hydration
+
+- **Definition:** attaching client-side JavaScript (event handlers, state) to server-rendered HTML that's already on screen, so the static markup becomes interactive.
+- **In use:** "The page paints instantly from SSR but the buttons are dead for 400ms — that's the hydration gap; the bundle has to download and run before it's interactive."
+- **Common misuse:** treating SSR as "fast and done." SSR gives a fast *paint*; the page isn't *interactive* until hydration finishes, and a heavy bundle makes that lag (measured as INP now, formerly TBT) — a fast-looking page that ignores taps.
+
+## Optimistic UI
+
+- **Definition:** updating the interface as if a write succeeded before the server confirms, then rolling back if it fails.
+- **In use:** "Like is optimistic — the heart fills instantly and we reconcile on the response; if the POST 500s we revert the count."
+- **Common misuse:** applying it to values where a wrong-then-corrected number misleads (a balance, an inventory count), or omitting the rollback so a failed write silently leaves the UI lying about the database.
+
+## Idempotency
+
+- **Definition:** a request that produces the same result whether sent once or five times — safe to retry.
+- **In use:** "Payment submit sends an idempotency key so a double-click or a network retry doesn't charge the card twice."
+- **Common misuse:** assuming GET-is-safe covers it and leaving POST/PATCH un-keyed, so a client retry on a flaky network creates duplicate orders. Retries are normal, not exceptional — the endpoint has to expect them.
+
+## CORS
+
+- **Definition:** a browser security mechanism that blocks a page on origin A from reading responses from origin B unless B's headers opt in.
+- **In use:** "The API 200s in curl but the browser blocks it — CORS. The server needs to echo our exact origin and, since we send cookies, `Allow-Credentials: true`."
+- **Common misuse:** thinking CORS is a server-side auth control (it isn't — it's browser-enforced and curl/mobile ignore it), or "fixing" it with `Allow-Origin: *`, which the browser refuses to combine with credentialed requests.
+
+## Race condition (client-side)
+
+- **Definition:** two async operations whose result depends on which finishes first — classically, a stale response overwriting a fresh one.
+- **In use:** "Typeahead had a race: the 'a' request resolved after 'ab' and clobbered the results. We cancel in-flight requests on each keystroke now."
+- **Common misuse:** assuming responses arrive in the order they were sent. They don't; the slower earlier request can land last, so the UI needs cancellation or last-write-wins keyed to the query.
+
+## Source of truth
+
+- **Definition:** the one place a piece of data is authoritative; every other copy is a cache derived from it.
+- **In use:** "The database is the source of truth for the cart; the client cart is a cache we invalidate on every mutation."
+- **Common misuse:** letting the same value be independently editable in two places (client state and server) with no designated authority, so they drift and "which one is right" becomes a debugging session.
+
+## SSR vs SSG vs CSR
+
+- **Definition:** where and when HTML is built — server-rendered per request (SSR), pre-built at deploy (SSG), or assembled in the browser from JS (CSR).
+- **In use:** "Docs are SSG, the dashboard is CSR behind auth, and the public product page is SSR for the crawler."
+- **Common misuse:** defaulting everything to SSR "for performance." SSR adds server cost and a hydration gap; a private dashboard gains nothing from it, and static content is faster pre-built.
+
+## N+1 query
+
+- **Definition:** fetching a list (1 query) then firing one more query per item (N), when a single join or batched load would do.
+- **In use:** "The feed was an N+1 — 1 query for posts, then one per author. A dataloader batched the authors into a single round trip."
+- **Common misuse:** blaming a slow list on "the database needs an index" when the real cost is 200 sequential round trips an ORM issued lazily; an index doesn't fix the trip count.
+
+## Server state vs client state
+
+- **Definition:** server state is data that lives in the backend and is cached in the browser (users, posts); client state is UI-only and never persisted server-side (a modal being open, a filter).
+- **In use:** "That doesn't belong in Redux — it's server state; React Query owns it with staleness and refetch built in."
+- **Common misuse:** hand-rolling server data into a global store with manual loading flags and cache invalidation, reinventing what a fetch-cache library already handles, and conflating "shared" with "global."
+
+## Content Security Policy (CSP)
+
+- **Definition:** a response header telling the browser which script/style/image sources are allowed to load, limiting the blast radius of XSS.
+- **In use:** "We tightened the CSP to drop `unsafe-inline` for scripts, so an injected `<script>` won't execute even if something gets past input sanitizing."
+- **Common misuse:** treating CSP as a replacement for output encoding and validation (it's defense in depth, the last layer), or shipping `unsafe-inline`/`unsafe-eval` so broadly the policy stops the browser from blocking anything.


### PR DESCRIPTION
## Adds `full-stack-developer` (spec 2)

Fills O*NET **15-1254.00 — Web Developers** (previously uncovered on the roadmap).

### Why it's not a duplicate of `software-engineer`
`software-engineer` is scoped backend/senior — service ownership, reliability, boring-tech. This role centers what a full-stack dev actually owns that a backend specialist doesn't: **the seam**. The client/server contract, where each piece of state lives, rendering strategy (SSR/SSG/CSR as a real tradeoff), and the network boundary where serialization/auth/cache bugs live. First-principles core leads with "the client is hostile territory" and "a feature is one product across two release cadences" — non-derivable from the title.

### Worked example
Traces a dashboard **4.2s → ~1.3s** fix by measuring the seam: API is 180ms, so the DB everyone wanted to upgrade wasn't the problem — a 14-request client waterfall, a 500-row client render, and a 900KB bundle were. Numbers reconcile (0.8 + 2.4 + 1.0 = 4.2s). Ends with the actual ticket readout quoted.

### Contents
- `SKILL.md` — 10 sections, dedup-checked, no banned phrases
- `references/playbook.md` — vertical-slice checklist, API-contract template, state-location + rendering decision tables, latency budget, debug order, auth-handoff template
- `references/red-flags.md` — 9 cross-stack smell tests (client-trust bypass, waterfall/N+1, timezone/float serialization, type-vs-runtime, works-locally, XSS-readable token…)
- `references/vocabulary.md` — 10 misuse-aware terms (hydration, optimistic UI, idempotency, CORS, N+1, server-vs-client state, CSP…)

### Checklist
- [x] `python3 scripts/lint_roles.py full-stack-developer` → 0 errors, 0 warnings
- [x] `generate_roadmap.py` re-run (README count 89→90, roadmap marks 15-1254.00 ✅, `data/roles.json` regenerated)
- [x] `node bin/cli.js list` parses all 90 roles
- [x] Worked example numbers reconcile; deliverable quoted
- [x] No idea stated twice; no banned patterns

**rubric: 16/18** (self-scored). `maturity: draft` — happy to bump to reviewed-by-practitioner if a full-stack dev reviews it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a spec‑2 `full-stack-developer` role mapped to O*NET 15‑1254.00 (Web Developers) to cover end‑to‑end feature work across UI, API, and DB. Updates counts and roadmap; focuses on the client/server seam, rendering strategy, state ownership, and boundary validation.

- **New Features**
  - Added `roles/full-stack-developer/SKILL.md` (seam ownership, SSR/SSG/CSR decisions, state placement, runtime validation at the edge).
  - Added references: `references/playbook.md` (contract template, decision tables, latency budget), `references/red-flags.md`, `references/vocabulary.md`.
  - Included worked example: dashboard 4.2s → ~1.3s via collapsing request waterfall, table virtualization, and bundle code‑splitting.
  - Updated `data/roles.json` with `slug: full-stack-developer` (`spec: 2`, `maturity: draft`, `onet_soc_code: 15-1254.00`).
  - Updated `README.md` and `ROADMAP.md` counts and mapping (engineering roles 14→15; 85→86 O*NET drafted; links to the new role).

<sup>Written for commit bfcaf11653de2a9285faf85adfe47e1e50730375. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

