### PR TITLE
role: add claims-adjuster

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,11 +196,11 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**110 roles drafted** (106 mapped to an O*NET occupation, 4 custom; 68 at spec 2, 42 awaiting upgrade), across 10 categories:
+**111 roles drafted** (107 mapped to an O*NET occupation, 4 custom; 69 at spec 2, 42 awaiting upgrade), across 10 categories:
 
 - **design**: 3
 - **engineering**: 17
-- **finance**: 10
+- **finance**: 11
 - **healthcare**: 8
 - **legal**: 11
 - **marketing**: 4

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 106 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 107 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -78,7 +78,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>13 — Business and Financial Operations</strong> (13/50 drafted)</summary>
+<summary><strong>13 — Business and Financial Operations</strong> (14/50 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -86,7 +86,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 |  | 13-1021.00 | Buyers and Purchasing Agents, Farm Products |  |
 |  | 13-1022.00 | Wholesale and Retail Buyers, Except Farm Products |  |
 | ✅ | 13-1023.00 | Purchasing Agents, Except Wholesale, Retail, and Farm Products | [`purchasing-agent`](./roles/purchasing-agent/SKILL.md) |
-|  | 13-1031.00 | Claims Adjusters, Examiners, and Investigators |  |
+| ✅ | 13-1031.00 | Claims Adjusters, Examiners, and Investigators | [`claims-adjuster`](./roles/claims-adjuster/SKILL.md) |
 |  | 13-1032.00 | Insurance Appraisers, Auto Damage |  |
 | ✅ | 13-1041.00 | Compliance Officers | [`compliance-officer`](./roles/compliance-officer/SKILL.md) |
 |  | 13-1041.01 | Environmental Compliance Inspectors |  |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 110,
+  "count": 111,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -269,6 +269,24 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/civil-engineer/SKILL.md",
+      "references": [
+        "artifacts.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ]
+    },
+    {
+      "slug": "claims-adjuster",
+      "description": "Use when a task needs the judgment of a senior property & casualty claims adjuster \u2014 scoping a water-damage or auto-collision loss, deciding total-loss vs. repair on a damaged vehicle, drafting or checking a reservation-of-rights letter, deciding when a claim needs an SIU fraud referral vs. a routine recorded statement, or working out whether a coverage dispute should go to appraisal or litigation. A reasoning aid, not licensed adjusting authority.",
+      "category": "finance",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "13-1031.00",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/claims-adjuster/SKILL.md",
       "references": [
         "artifacts.md",
         "red-flags.md",

--- a/roles/claims-adjuster/SKILL.md
+++ b/roles/claims-adjuster/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: claims-adjuster
+description: Use when a task needs the judgment of a senior property & casualty claims adjuster — scoping a water-damage or auto-collision loss, deciding total-loss vs. repair on a damaged vehicle, drafting or checking a reservation-of-rights letter, deciding when a claim needs an SIU fraud referral vs. a routine recorded statement, or working out whether a coverage dispute should go to appraisal or litigation. A reasoning aid, not licensed adjusting authority.
+metadata:
+  category: finance
+  maturity: draft
+  spec: 2
+  onet_soc_code: "13-1031.00"
+---
+
+# Claims Adjuster (Property & Casualty)
+
+> **Scope disclaimer.** This skill is a reasoning aid for claims handling and does not constitute licensed adjusting authority, legal advice, or a coverage determination. Adjuster licensing, unfair-claims-practices timelines, and total-loss formulas vary by state — defaults below are the common multi-state pattern, not a specific jurisdiction's rule. A licensed adjuster or coverage counsel signs off before any coverage decision, denial, or payment is finalized.
+
+## Identity
+
+A desk or field adjuster handling first-party property and auto claims for a carrier or as an independent adjuster (IA), typically carrying 40–60 open property/casualty files or 100–150 open auto physical-damage files at a time [heuristic — needs practitioner check, self-reported ranges]. Accountable to a clock set by state unfair-claims-practices regulation rather than by the claimant's patience, on files where the dollar amount is only ever half the job. The defining tension: the adjuster works for the carrier that pays their salary, but every acknowledgment, delay, and denial is later read by a regulator or a bad-faith attorney as if it were written by a neutral fact-finder.
+
+## First-principles core
+
+1. **The claim file is written for a reader who wasn't in the room — a market-conduct examiner or a bad-faith plaintiff's attorney, months later.** Every entry needs to independently justify the decision it documents; "handled per phone conversation" with no note of what was said or why is functionally an unexplained decision, and unexplained decisions are what regulators and juries punish.
+2. **Category and severity are two different axes, and conflating them causes both under-scoping and over-scoping.** A water loss's contamination level (clean, grey, or grossly contaminated) is independent of how hard it is to dry (an unfinished basement vs. hardwood floors and plaster). A clean loss can still be the most expensive drying job on the desk.
+3. **A reservation of rights is a legal instrument, not a formality — generic language is worse than none.** A carrier that reserves rights with boilerplate ("all terms and conditions apply") without naming the specific exclusion and the facts that trigger it has often reserved nothing; the letter itself becomes evidence of bad faith rather than protection from it.
+4. **Every day of "still investigating" without a written explanation is a day that reads as stalling later.** Silence between acknowledgment and decision is the single most common documented violation in market-conduct exams — not wrong coverage calls, which are at least defensible on the merits.
+5. **The claimant's story is data, and its shape over time matters more than its content at any one telling.** A narrative that grows more severe or more convenient with each retelling is a stronger fraud signal than any single suspicious detail, because genuine memories don't systematically escalate.
+
+## Mental models & heuristics
+
+- **When a proof of loss is received, default to a written decision (pay, deny, or request more information) within 21 days** — if the file isn't resolvable in that window, send a written status letter explaining specifically what's outstanding, and repeat that letter roughly every 45 days until closed. Silence past either checkpoint is the exposure, not the length of the investigation itself.
+- **When scoping a water loss, default to treating Category 1 (clean) water that has sat more than 24–48 hours or crossed multiple room temperatures as a Category 2 candidate** — category can deteriorate with time and temperature; re-inspect before finalizing scope on any loss more than a day or two old.
+- **When the claimant's account changes materially in severity between the first notice of loss and the recorded statement, or the same address/repair shop shows up across multiple unrelated claims, default to an SIU referral tied to the specific named indicator** — "claimant seemed evasive" is not a referral basis; "estimated loss amount increased more than the 25% documented threshold between FNOL and recorded statement with no new damage identified" is (see `references/red-flags.md`).
+- **When deciding between a recorded statement and an examination under oath (EUO) on a first-party claim, default to EUO only when the policy's cooperation clause is invoked and the file already shows a specific discrepancy worth sworn testimony** — EUO is adversarial by design (carrier's coverage counsel questions, a court reporter transcribes, the insured's own counsel generally can't participate), and a false statement under oath can void the whole policy, not just the claim. Reach for it, don't default to it.
+- **When a total-loss vehicle sits in a percentage-threshold state, compare repair estimate to actual cash value (ACV) directly against that state's published percentage (commonly 70–75%, ranging 60–100%)** — when it's a Total Loss Formula (TLF) state instead, net salvage value against the repair-plus-ACV comparison first, since the same repair estimate can total a car in a TLF state and not in a flat-percentage state at a similar nominal threshold.
+- **When a dispute is purely about the dollar amount of a covered loss, default to invoking the policy's appraisal clause rather than litigating** — each side names an appraiser within the policy's notice window (commonly 20 days of written demand), the two appraisers try to agree, and if they can't, a neutral umpire breaks the tie; any two of the three signatures bind. Appraisal only resolves amount — the moment the real dispute is whether the loss is covered at all, appraisal is the wrong tool and the file needs coverage counsel instead.
+- **Independent adjusters paid per closed file, not salary, carry a structural incentive to close volume over accuracy** — when reviewing IA-produced estimates or reopened files, weight that incentive into how much independent verification the number gets, not just how experienced the IA is.
+
+## Decision framework
+
+1. **Confirm coverage before touching damages.** Read the policy against the loss facts — named perils, exclusions, conditions, limits, deductible — before scoping a single repair item; a well-scoped estimate on an excluded loss is wasted work and a documentation liability.
+2. **Interview while the account is fresh, and record the first version verbatim.** Claimant, witnesses, first responders, treating physicians as applicable — the file needs the unprompted first telling to compare every later version against.
+3. **Scope the loss before authorizing anything.** For property, apply the category/class distinction from First-principles #2; for auto, run the repair-vs-ACV or TLF math before committing to a repair authorization.
+4. **Set and document the reserve, then revisit it against new facts, not against the passage of time alone.** A reserve is a decision with a rationale, not a placeholder number.
+5. **Screen for the named fraud indicators, not a gut feeling** — narrative escalation, repeat names or addresses across claims, verification inconsistencies on deeper review. Route a hit to SIU with the specific indicator named, not a general suspicion.
+6. **Decide the resolution track.** Straightforward: pay per policy terms and close. Amount dispute only: appraisal. Coverage question: reservation of rights citing the specific provision and facts, then coverage counsel. Suspected fraud: SIU referral before any further payment.
+7. **Close the file so a stranger could reconstruct the decision** — every acknowledgment, status letter, and reserve change dated and reasoned (First-principles #1).
+
+## Tools & methods
+
+- **Reservation-of-rights letter** citing the specific exclusion/provision and the facts triggering it, addressing duty to defend and duty to indemnify separately where both apply. See `references/artifacts.md`.
+- **Xactimate-style line-item estimate** for property and auto scoping — the deep dive gives the structure, not filled real pricing (no verified public price-list figures were sourced).
+- **Total-loss worksheet** comparing repair estimate, ACV, and (in TLF states) salvage value against the applicable threshold.
+- **SIU referral form** naming the specific red-flag indicator and the file evidence behind it, per the practitioner material on documented-indicator requirements.
+- **Appraisal demand letter** invoking the policy clause, naming the adjuster's own appraiser.
+
+## Communication style
+
+To the claimant: plain-language explanation of what's covered, what's being investigated, and the specific next date something happens — never a bare "your claim is under review." To coverage counsel or the SIU desk: the specific policy provision or fraud indicator plus the facts behind it, not a summary of unease. To the claimant's attorney or in an EUO transcript: precise and literal — sworn statements and reservation letters are read back verbatim in disputes, so hedged or padded language becomes the thing being cross-examined. Internally, reserve changes and status letters name the specific fact and date driving the entry rather than a conclusory label like "handled" or "under review."
+
+## Common failure modes
+
+- **Leaving the file's diary/task-alert unset so the 21-/45-day checkpoints pass with no one flagging it** — the aging claim surfaces only when a regulator's file sample or the claimant's attorney pulls the record, not when it was still fixable.
+- **Under-scoping a Class 3/4 drying job on a Category 1 (clean) loss** — skipping mitigation equipment because the water tested clean, rather than scoping drying difficulty on its own evidence.
+- **Writing a reservation-of-rights letter with generic "all terms and conditions" language** instead of naming the provision and facts.
+- **Reaching for EUO as a default escalation tool** rather than only when a specific discrepancy justifies the adversarial process, burning goodwill and inviting a bad-faith argument on claims that didn't need it.
+- **Having learned the SIU red-flag list, referring every claim with any single indicator present** — one changed detail in a long recorded statement is normal memory reconstruction; referral is for a documented pattern, not a single flagged word.
+- **Invoking appraisal when the real dispute is coverage, not amount** — burns the decision clock that should have gone to a coverage opinion, and produces an appraisal award neither side can use once the coverage question surfaces anyway.
+
+## Worked example
+
+**Auto claim, first-party collision coverage, percentage-threshold state (75% total-loss threshold).**
+
+Facts: 2019 sedan, actual cash value (ACV) $9,200 per valuation report. Body shop repair estimate: $6,900 for frame and quarter-panel work. Naive read: $6,900 repair cost is less than the $9,200 ACV, so it "looks repairable" — a generalist authorizes the repair.
+
+Adjuster's math: $6,900 / $9,200 = 75.0% — exactly at the state's 75% percentage threshold, which triggers a mandatory total-loss designation, not a discretionary one. (If this were a TLF state instead, the test is different: repair estimate + salvage value vs. ACV. At an estimated salvage value of $2,000, that's $6,900 + $2,000 = $8,900 vs. $9,200 ACV — $8,900 is *less than* $9,200, so this same vehicle would **not** total under a TLF test, despite crossing the flat 75% threshold here. Full breakdown in `references/artifacts.md` §1.)
+
+Reserve entry: initial reserve set at ACV ($9,200) less salvage value once a salvage bid is obtained, with a file note: "Repair estimate $6,900 vs. ACV $9,200 = 75.0%, meets state total-loss threshold per [statute cite]. Total-loss valuation to follow; salvage bid requested [date]."
+
+Deliverable — total-loss notification to claimant:
+
+> "Based on the repair estimate of $6,900.00 and the actual cash value of $9,200.00 for your vehicle, the estimated cost of repair equals 75.0% of actual cash value. Under [state] law, this meets the total-loss threshold. We are declaring your vehicle a total loss. You will receive a settlement offer of $9,200.00, less your $500.00 deductible and less salvage value if you retain the vehicle, within [X] business days, along with the valuation report supporting the ACV figure."
+
+The reasoning that overturns the naive read: repair cost being numerically less than ACV is not the test: the *ratio* against the state's specific threshold is, and at exactly 75.0% this claim crosses it in a percentage-threshold state where a TLF state running the same numbers with salvage netted in might land differently.
+
+## Going deeper
+
+- [`references/artifacts.md`](references/artifacts.md) — filled reservation-of-rights letter, total-loss worksheet, SIU referral form, and appraisal demand letter templates.
+- [`references/red-flags.md`](references/red-flags.md) — fraud and bad-faith-exposure smell tests with the specific threshold or pattern that triggers each.
+- [`references/vocabulary.md`](references/vocabulary.md) — terms of art generalists misuse, with the practitioner sentence and the common mistake.
+
+## Sources
+
+- NAIC Unfair Claims Settlement Practices Model Act (Model #900) and companion timeline commentary — Steven Plitt, "A Roadmap for the NAIC's Unfair Claims Settlement Practices Act"; Backus & Woodrow, "A Roadmap for 50 States" (propertyinsurancecoveragelaw.com).
+- IICRC S500 Standard for Professional Water Damage Restoration (iicrc.org/s500); category/class explainer, experiencedpublicadjusters.com.
+- United Policyholders, "Examinations Under Oath — EUO"; Greenspan, "A Private Adjuster's Perspective: Examination Under Oath."
+- California Department of Insurance, Special Investigative Unit Regulations (eff. Oct. 7, 2005); ethosrisk.com, "5 Red Flags That Should Trigger SIU Investigations"; Shuchart & Frederick, "SIU/FRAUD: Red Flag!" (25th Insurance Symposium).
+- WalletHub, "Total Loss Thresholds by State: 2026 Guide"; carinsurance.com, "Total Loss Thresholds by State."
+- totalcsr.com, "Reservation of Rights Letter: Essential Insurance Guide"; lauriebrennan.com, "Reservation of Rights Letters: Tips for Policyholders."
+- propolicyholder.com, "The Appraisal Clause: What It Is, and When to Enforce It"; vpm-legal.com, "What is an Appraisal Clause and How Does it Work?"
+- Caseload figures (fishbowlapp.com, uphelp.org, cgaa.org) and CAT-adjuster pay structure (abtrainingcenter.com, iapath.com) are self-reported industry ranges, not a regulatory or actuarial standard — flagged as heuristics above.
+
+Not reviewed by a licensed practitioner — flag corrections via PR. Route actual coverage, denial, and payment decisions to a licensed adjuster or coverage counsel in the relevant jurisdiction.

--- a/roles/claims-adjuster/references/artifacts.md
+++ b/roles/claims-adjuster/references/artifacts.md
@@ -1,0 +1,139 @@
+# Claims-handling artifacts — filled templates
+
+Working templates an agent can populate. Section 1 continues the auto total-loss claim from `SKILL.md` (2019 sedan, ACV $9,200, repair estimate $6,900, 75% percentage-threshold state) so that arithmetic stays internally consistent. Sections 2–5 use a separate, self-contained water-loss and auto-fraud pair of claims — each section's numbers reconcile within that section.
+
+## 1. Total-loss worksheet (percentage-threshold state)
+
+| Line | Value |
+|---|---|
+| Repair estimate | $6,900.00 |
+| Actual cash value (ACV), per valuation report | $9,200.00 |
+| Repair-to-ACV ratio | 6,900 / 9,200 = **75.0%** |
+| State total-loss threshold (this state) | 75% |
+| Threshold met? | **Yes — mandatory, not discretionary** |
+| Salvage bid (pending, retained by insured) | $2,000.00 (estimate) |
+| Settlement offer (retain vehicle) | 9,200.00 − 2,000.00 (salvage) − 500.00 (deductible) = **$6,700.00** |
+| Settlement offer (surrender vehicle) | 9,200.00 − 500.00 (deductible) = **$8,700.00** |
+
+**If this were a TLF (Total Loss Formula) state instead:** net estimated salvage value against the repair-plus-ACV comparison rather than against ACV alone. Same raw inputs, different test: repair ($6,900) + salvage ($2,000) = $8,900 vs. ACV ($9,200) → $8,900 < $9,200, so the same vehicle would **not** total under a TLF test at this salvage estimate, despite crossing the flat 75% threshold in a percentage-threshold state. The two frameworks are not interchangeable on the same numbers — always confirm which regime the state uses before running either math.
+
+**Reserve entry (file note, verbatim):**
+> "Repair estimate $6,900.00 vs. ACV $9,200.00 = 75.0%, meets [state] total-loss threshold per [statute cite]. Reserve set at $9,200.00 less estimated salvage $2,000.00 = $7,200.00 pending salvage bid confirmation. Salvage bid requested [date]; total-loss valuation letter to follow within [X] business days."
+
+## 2. Xactimate-style line-item estimate (water loss, Category 2 / Class 3)
+
+**Pricing note:** the unit prices below are illustrative, internally-consistent figures chosen to show the estimate's structure — line-item breakdown, O&P treatment, depreciation, net-check math. No verified public regional price-list figures were sourced for this section; don't reuse these unit prices as real pricing.
+
+**Loss:** Washing-machine supply-line failure, kitchen (12' × 14' = 168 sf) and hallway (4' × 18' = 72 sf), hardwood flooring, Category 2 (grey water — contains contaminants, defaults up from Category 1 if source is a failed appliance line rather than a clean supply line break), Class 3 drying (>40% of materials in the affected area are wet, low-permeance assemblies).
+
+| # | Line item | Qty | Unit price | RCV |
+|---|---|---|---|---|
+| 1 | Air mover, per day (5 units × 4 days) | 20 unit-days | $28.50 | $570.00 |
+| 2 | LGR dehumidifier, per day (2 units × 4 days) | 8 unit-days | $65.00 | $520.00 |
+| 3 | Antimicrobial/biocide application | 240 sf | $0.32 | $76.80 |
+| 4 | R&R drywall, 2-ft flood cut | 120 sf | $3.35 | $402.00 |
+| 5 | R&R hardwood flooring, kitchen | 168 sf | $11.85 | $1,990.80 |
+| 6 | R&R baseboard | 60 lf | $4.10 | $246.00 |
+| 7 | Detach & reset base cabinets | 1 ea | $310.00 | $310.00 |
+| 8 | Paint walls, 2 coats | 240 sf | $1.15 | $276.00 |
+| 9 | Haul debris / dumpster fee | 1 ea | $425.00 | $425.00 |
+| 10 | Mitigation mobilization / equipment setup | 1 ea | $185.00 | $185.00 |
+| | **Subtotal (mitigation + repair, before O&P)** | | | **$5,001.60** |
+| 11 | Overhead & Profit, 10%+10% (GC-supervised repair lines 4–8 only: $3,224.80 base) | | 20% | $644.96 |
+| | **Total RCV** | | | **$5,646.56** |
+| 12 | Less recoverable depreciation — flooring line only (12 yrs age / 25-yr life = 48% of line 5) | | 48% of $1,990.80 | ($955.58) |
+| | **ACV payment (issued now)** | | | **$4,690.98** |
+| 13 | Less deductible | | | ($1,000.00) |
+| | **Net check to insured, this cycle** | | | **$3,690.98** |
+
+Recoverable depreciation of **$955.58** is released on submission of a paid invoice or contractor completion certificate showing the flooring was actually replaced — not on a verbal confirmation.
+
+**Category re-check note:** source is a failed appliance supply line (Category 2 by default classification), and the loss sat approximately 18 hours before mitigation began — under the 24–48 hour degradation window, so no upgrade to Category 3 is warranted at this inspection. Re-inspect if drying extends past day 5 without meeting the drying goal (dry standard within 2% of unaffected material moisture content).
+
+## 3. Reservation-of-rights letter (filled excerpt)
+
+**Facts:** Same property, separate loss. Adjuster's moisture-mapping and mold-growth pattern on re-inspection indicate the leak was gradual rather than a sudden pipe burst — wood moisture content gradient (32% at the wall base tapering to 14% eight feet away) is consistent with slow seepage over several weeks, not a single event. Total estimated damage: $22,400. The policy excludes "continuous or repeated seepage or leakage of water... occurring over a period of 14 days or more" (Section I, Exclusion 3.f).
+
+```
+Re: Claim No. [XXXXXX] — Reservation of Rights
+
+Dear [Insured],
+
+We acknowledge your claim reported [date] for water damage at [address].
+We are continuing to investigate this claim, and this letter is to advise
+you that we are doing so under a full reservation of rights.
+
+Specifically, our inspection on [date] found moisture patterns and mold
+growth consistent with a leak occurring over an extended period rather
+than a single sudden event. Your policy, Section I, Exclusion 3.f,
+excludes loss caused by "continuous or repeated seepage or leakage of
+water... occurring over a period of 14 days or more." Based on wood
+moisture-content testing (32% at the source wall, tapering to 14% at
+eight feet), our engineering consultant's preliminary opinion is that
+the leak duration exceeds that 14-day threshold.
+
+This letter reserves our right to deny coverage in whole or in part
+under Exclusion 3.f, and under any other policy term that later proves
+applicable, without waiving any of our rights under the policy or at
+law. We are not denying your claim today. We have retained [engineering
+firm] to determine leak duration and origin, and we expect their report
+by [date]. We will notify you in writing of our coverage decision within
+[X] business days of receiving that report.
+
+Please contact [adjuster name/phone] with any questions or additional
+information relevant to the duration or cause of this loss.
+
+Sincerely,
+[Adjuster], [Carrier]
+```
+
+**Why generic language fails here:** a reservation that only said "all terms and conditions of the policy apply" would not name Exclusion 3.f or the moisture-gradient facts triggering it — on later review that reads as no reservation at all, and the carrier loses the protection the letter was supposed to provide.
+
+## 4. SIU referral form (filled)
+
+**Loss:** Separate auto claim, rear-end collision, FNOL taken [date]; recorded statement taken 12 days later.
+
+| Field | Entry |
+|---|---|
+| **Named indicator** | Narrative/estimate escalation between FNOL and recorded statement |
+| **File evidence** | FNOL: claimant estimated "around $4,200 in damage, mostly the bumper." Recorded statement (day 12): claimant now describes "frame damage and a cracked wheel" with a shop estimate of $6,800 — a 61.9% increase ((6,800 − 4,200) / 4,200 = 0.619) with no new damage identified by the carrier's own inspection between the two dates. |
+| **Secondary indicator** | Repair shop ("Precision Auto Body") appears on 3 unrelated claims filed with this carrier in the trailing 8 months, 2 of which also show post-FNOL estimate increases >40%. |
+| **Verification step taken** | Cross-referenced shop name against carrier's claims database (query: repair-facility name, trailing 12 months) — returned 3 matches. |
+| **NOT used as a standalone basis** | Claimant's demeanor in the recorded statement ("seemed nervous") — noted but explicitly excluded from the referral rationale; not a named indicator on its own. |
+| **Recommended action** | Hold payment pending SIU review. Request supplemental damage photos and a second independent appraisal before authorizing the shop's revised estimate. Do not escalate to EUO at this stage — no cooperation-clause trigger yet, and the file doesn't yet show a specific sworn-testimony-worthy discrepancy beyond the estimate delta. |
+| **Referred by / date** | [Adjuster], [date] |
+
+## 5. Appraisal demand letter (filled)
+
+**Facts:** Same water-loss claim as Section 2. Carrier's estimate: $5,646.56 RCV. Insured's public adjuster estimate: $9,850.00 RCV (74.5% higher: (9,850 − 5,646.56) / 5,646.56 = 0.745). Both estimates agree the loss is covered and agree on scope of rooms affected — the dispute is exclusively the dollar amount of repair, which is what the appraisal clause is for.
+
+```
+Re: Claim No. [XXXXXX] — Demand for Appraisal
+
+Dear [Insured / Public Adjuster],
+
+We have received your estimate of $9,850.00 for the water damage repairs
+at [address], which differs materially from our estimate of $5,646.56
+for the same scope of covered repairs. Because the disagreement between
+us concerns solely the amount of the loss and not whether the loss is
+covered, we are invoking the Appraisal provision of your policy.
+
+Pursuant to that provision, we name [Appraiser Name, firm] as our
+appraiser. Please name your own competent and impartial appraiser in
+writing within 20 days of this letter. The two appraisers will then
+select an umpire; if they cannot agree on an umpire within 15 days, either
+of us may request that a judge of a court of record in [county] appoint
+one. The appraisers will separately set the amount of loss; any
+disagreement will be submitted to the umpire, and an agreement by any
+two of the three will set the amount of loss. Appraisal determines the
+dollar amount only — it does not decide coverage, which is not in
+dispute on this claim.
+
+Please confirm your appraiser's name and contact information within the
+20-day window noted above.
+
+Sincerely,
+[Adjuster], [Carrier]
+```
+
+**Scope check before sending:** confirm the dispute is genuinely amount-only. If the public adjuster's higher estimate rests on a broader damage scope the carrier disputes (e.g., claiming Category 3 remediation the carrier's inspection didn't support), that is a coverage/scope disagreement, not an amount disagreement — appraisal is the wrong tool and the file needs a coverage opinion instead, not an appraisal demand.

--- a/roles/claims-adjuster/references/red-flags.md
+++ b/roles/claims-adjuster/references/red-flags.md
@@ -1,0 +1,61 @@
+# Red Flags — Claims Adjuster
+
+### Loss estimate increases >25% between FNOL and the recorded statement with no new damage identified
+- **Usually means:** the claimant (or a public adjuster coaching them) is anchoring up once they see how the process works, second most likely an initial FNOL intake taker under-scoped the loss and the increase is legitimate discovery during inspection.
+- **First question:** "What specific damage was found during inspection that wasn't visible or mentioned at first notice?"
+- **Data to pull:** FNOL call notes/transcript, initial damage photos timestamped against inspection photos, itemized estimate versions with dates.
+
+### Same repair shop, contractor, or claimant address appears on 3+ unrelated claims within 12 months
+- **Usually means:** an organized staged-loss or inflated-estimate ring using a cooperating vendor, second most likely a legitimately high-volume shop in a small service area with no fraud involved.
+- **First question:** "Do the claims sharing this vendor also share any other common element — same policy inception date, same witnesses, same adjuster?"
+- **Data to pull:** claims-system cross-reference report by address/EIN/phone number, SIU database check, vendor's claim volume relative to other shops in the same ZIP code.
+
+### Policy inception or endorsement adding coverage occurred within 30 days of the loss date
+- **Usually means:** coincidental timing (new homeowner, new car purchase triggering the policy), second most likely the loss occurred before the policy existed and is being misreported, or coverage was purchased with the loss already known.
+- **First question:** "What prompted the policy purchase or coverage change, and is there independent documentation the triggering event predates the loss?"
+- **Data to pull:** policy application file, underwriting file, date-stamped photos or receipts predating the binder date, prior-carrier claims history (CLUE report).
+
+### Category 1 (clean) water loss with no re-inspection after 48 hours
+- **Usually means:** the file was scoped once at FNOL and never revisited, second most likely the loss was dried within the window and genuinely stayed Category 1, but that isn't documented.
+- **First question:** "When was the moisture reading last taken, and does the file show a Category re-confirmation dated after 48 hours from the loss?"
+- **Data to pull:** moisture-meter readings log with timestamps, mitigation vendor's daily drying report, original vs. most recent inspection photos.
+
+### Claimant's account of the loss changes in severity (not just detail) across FNOL, adjuster interview, and recorded statement
+- **Usually means:** narrative escalation consistent with fraud or exaggeration, second most likely normal memory reconstruction where peripheral details shift but the core severity stays constant — the flag is specifically severity drift, not detail drift.
+- **First question:** "Which specific severity claim changed — an injury, a loss amount, a sequence of events — and is the change more consistent with new information or with a story that's grown?"
+- **Data to pull:** verbatim FNOL notes, recorded statement transcript, side-by-side timeline of each version of the account.
+
+### File shows an acknowledgment letter but no written status update in 45+ days since
+- **Usually means:** the file was deprioritized behind newer losses without anyone flagging the aging clock, second most likely a decision was made verbally and never memorialized in writing.
+- **First question:** "What decision is this file waiting on, and why hasn't that been communicated to the claimant in writing?"
+- **Data to pull:** diary/activity log with letter dates, adjuster's open-task queue, state's specific unfair-claims-practices status-letter interval.
+
+### Reservation-of-rights letter cites only boilerplate ("all terms and conditions apply") with no named provision
+- **Usually means:** the letter was generated from a template without the drafting adjuster identifying the specific exclusion or condition at issue, second most likely the coverage question genuinely hasn't been narrowed down yet and the letter went out prematurely.
+- **First question:** "Which policy provision, by section number, and which specific facts trigger it — can that be added before this goes out?"
+- **Data to pull:** the policy's declarations and endorsements, the draft ROR letter, adjuster's coverage-analysis notes.
+
+### Repair estimate lands within 3 percentage points of the state's total-loss threshold
+- **Usually means:** a genuine borderline total-loss call requiring the exact ACV and estimate figures to be verified rather than approximated, second most likely a supplement about to be added that will push the ratio over the line.
+- **First question:** "Are both the ACV and the repair estimate final numbers, or is a supplement still pending that would change the ratio?"
+- **Data to pull:** valuation report (ACV), final line-item repair estimate, any open supplement requests, the state's specific total-loss statute or TLF designation.
+
+### Injury claim on a low-speed (<10 mph delta-v) rear-end collision with a soft-tissue-only diagnosis
+- **Usually means:** a legitimate but hard-to-verify soft-tissue injury, second most likely a staged or exaggerated injury claim — this pattern alone is not a referral basis without a corroborating indicator.
+- **First question:** "Does the treatment timeline start within 24–48 hours of the loss, and does the diagnosis match the vehicle damage photos?"
+- **Data to pull:** vehicle damage estimate and photos, EDR/delta-v data if available, first treatment date and provider, prior claims history for the same claimant.
+
+### EUO demand drafted without a specific documented discrepancy named in the file
+- **Usually means:** the adjuster is reaching for EUO as an escalation tool rather than in response to an actual inconsistency, second most likely the discrepancy exists but hasn't been written down yet.
+- **First question:** "What is the one specific discrepancy this EUO is meant to resolve, and is it in writing in the file already?"
+- **Data to pull:** recorded statement transcript, prior written correspondence, the cooperation-clause provision being invoked.
+
+### Claimant demands appraisal on a file where coverage (not amount) is still in dispute
+- **Usually means:** the claimant or their public adjuster is trying to force a dollar resolution before the coverage question is settled, second most likely genuine confusion about what appraisal covers.
+- **First question:** "Is there an open coverage question on this file, or is the only disagreement the dollar amount of an already-covered loss?"
+- **Data to pull:** the reservation-of-rights letter (if any), the specific coverage determination memo, the appraisal demand letter itself.
+
+### Independent adjuster's estimate closes within 48 hours of assignment on a loss over $10,000
+- **Usually means:** volume-driven speed consistent with per-file pay incentives cutting corners on verification, second most likely a genuinely straightforward loss with clear-cut damage and good documentation.
+- **First question:** "What independent verification — photos, measurements, a second opinion — supports this estimate beyond the IA's own line items?"
+- **Data to pull:** IA's full photo set with timestamps, line-item estimate detail, IA's assignment-to-close time relative to their average, any prior reopened files from the same IA.

--- a/roles/claims-adjuster/references/vocabulary.md
+++ b/roles/claims-adjuster/references/vocabulary.md
@@ -1,0 +1,73 @@
+# Vocabulary — Claims Adjuster
+
+Terms of art generalists commonly misuse — not terms they could just look up, but ones where the *common* usage and the *correct* usage diverge in a way that changes the file's outcome.
+
+### Reservation of rights (ROR)
+A carrier's written notice that it is continuing to handle and investigate a claim while expressly preserving its right to later deny coverage, in whole or in part, under a named provision.
+- **In use:** "We're sending an ROR citing Exclusion 3.f because the moisture gradient suggests a gradual leak, not a sudden pipe burst — we're not ready to deny yet, but we're not waiving the exclusion either."
+- **Misuse:** Treated as a soft denial or a formality that can be satisfied with boilerplate ("all terms and conditions apply"). An ROR that doesn't name the specific provision and the facts triggering it protects nothing — it's read later as no reservation at all, and can itself become evidence of bad faith.
+
+### Actual cash value (ACV) vs. replacement cost value (RCV)
+ACV is repair or replacement cost minus depreciation; RCV is the cost to repair or replace with no depreciation deducted.
+- **In use:** "RCV on the flooring line is $1,990.80; at 48% depreciation for age, ACV on that line is $1,035.22."
+- **Misuse:** Used interchangeably, especially by generalists reading an estimate and assuming the total shown is what the claimant gets paid now. On an RCV policy, the ACV is paid first and the depreciation holdback (recoverable depreciation) is released only after repairs are actually completed — not automatically, and not on a verbal say-so.
+
+### Recoverable vs. non-recoverable depreciation
+Recoverable depreciation is released once the insured completes the repair and submits proof (invoice or completion certificate); non-recoverable depreciation is never paid back under the policy terms.
+- **In use:** "The $955.58 in recoverable depreciation on the flooring releases on a paid invoice or completion certificate — not on the contractor saying the job's done over the phone."
+- **Misuse:** Assumed to be a single "depreciation" bucket, or assumed to release automatically once repairs start. Whether depreciation is recoverable at all is a policy-form question — some policies (and some coverage lines within the same policy) only ever pay ACV.
+
+### Total Loss Formula (TLF) vs. percentage-threshold state
+Two different, non-interchangeable state tests for declaring an auto total loss: a percentage-threshold state compares repair estimate to ACV directly against a fixed percentage; a TLF state nets salvage value against repair-plus-ACV instead.
+- **In use:** "This is a 75% percentage-threshold state — $6,900 repair / $9,200 ACV = 75.0%, so it's a mandatory total loss. Run the same numbers in a TLF state and it might not total, because salvage nets in differently."
+- **Misuse:** Treated as one universal "total loss math" rather than two distinct regimes that can produce opposite outcomes on identical repair and ACV figures. The regime has to be confirmed by state before either calculation is run.
+
+### Examination Under Oath (EUO) vs. recorded statement
+A recorded statement is an informal, non-adversarial account; an EUO is a sworn, transcribed proceeding under the policy's cooperation clause, conducted by coverage counsel, where a false statement can void the entire policy.
+- **In use:** "We're not escalating to EUO — there's no cooperation-clause trigger and no specific documented discrepancy yet worth sworn testimony."
+- **Misuse:** Reached for as a generic "next level" escalation when a claimant seems uncooperative or a recorded statement felt unsatisfying. EUO is adversarial by design and reserved for a specific, already-documented inconsistency — using it as a default pressure tactic burns goodwill and invites its own bad-faith argument.
+
+### Appraisal clause
+A policy provision letting each side name an independent appraiser to resolve a dispute over the *dollar amount* of an already-covered loss; the two appraisers pick a neutral umpire, and any two of the three signatures bind.
+- **In use:** "Both sides agree the loss is covered and agree on scope — the only disagreement is the number, so we're invoking appraisal instead of litigating."
+- **Misuse:** Invoked (often by a claimant or public adjuster) when the real dispute is whether the loss is covered at all, or invoked by an adjuster on a claim with an open coverage question. Appraisal has no power to decide coverage — sending an amount dispute to appraisal when coverage is contested wastes the clock a coverage opinion needed instead.
+
+### Duty to defend vs. duty to indemnify
+Duty to defend is the carrier's obligation to provide a legal defense against a claim; duty to indemnify is the separate obligation to pay a covered judgment or settlement. The duty to defend is broader and can exist even where indemnity ultimately doesn't.
+- **In use:** "The ROR addresses the duty to defend and the duty to indemnify separately, because we may owe a defense here even if it turns out we don't owe the loss."
+- **Misuse:** Assumed to rise and fall together, so a reservation letter covers both by only discussing one. A carrier can end up owing a defense under a reservation while still disputing indemnity — conflating the two in an ROR leaves one duty unaddressed.
+
+### Category (water) vs. class (drying)
+Category is the water's contamination level (1 clean, 2 grey, 3 grossly contaminated); class is the drying difficulty based on how much material is wet and how permeable it is — the two axes are independent.
+- **In use:** "This is Category 2 grey water from the failed supply line, but it's a Class 3 drying job because more than 40% of the low-permeance materials are wet."
+- **Misuse:** Assumed that a "clean" (Category 1) loss is automatically a small or cheap one. A clean-water loss can still be the most expensive drying job on the desk if it's a high class; category and class have to be scoped separately, not read off each other.
+
+### Subrogation
+The carrier's right, after paying its own insured's claim, to pursue recovery from the at-fault third party (or their carrier) who actually caused the loss.
+- **In use:** "We paid the collision claim under our insured's own policy, but subrogation against the other driver's carrier is still open since liability is clear-cut."
+- **Misuse:** Confused with contribution (the sharing of a loss between two carriers that both insure the *same* risk) or with the claimant's own recovery rights. Subrogation is the carrier stepping into its insured's shoes to recover from someone else's insured — it doesn't affect whether or how much the carrier's own insured gets paid first.
+
+### Betterment
+A deduction applied when a repair leaves the insured's property in a materially better condition than before the loss (e.g., a full-system replacement where only a component failed), distinct from age-based depreciation.
+- **In use:** "The plumbing repair replaces the whole supply line instead of the failed section — that's a betterment deduction, not depreciation, since the old line wasn't due for replacement yet."
+- **Misuse:** Used as a synonym for depreciation. Depreciation accounts for the age/wear of the damaged item itself; betterment accounts for an upgrade created by the repair method chosen — the two can apply to the same line item for different reasons and shouldn't be netted together as one number.
+
+### Bad faith
+A legal finding (not just a poor outcome) that a carrier unreasonably denied, delayed, or failed to properly investigate a covered claim, typically evidenced by a pattern in the file rather than a single wrong call.
+- **In use:** "A wrong coverage call that's well-documented and reasoned is defensible; it's the undocumented 45-day silence with no status letter that's the actual bad-faith exposure."
+- **Misuse:** Equated with any denial the claimant disagrees with, or with a coverage position that later turns out wrong. What drives bad-faith exposure in practice is process — silence, boilerplate reservations, undocumented reasoning — more than the substantive coverage call itself.
+
+### Proof of loss
+A formal, often sworn, statement the insured submits itemizing the claimed loss amount, which starts the carrier's statutory clock for a written coverage decision.
+- **In use:** "Once the proof of loss is in, we've got 21 days to send a written pay, deny, or need-more-information decision — not 21 days from first notice."
+- **Misuse:** Conflated with the first notice of loss (FNOL) or with an informal damage estimate. The regulatory decision clock in most jurisdictions runs from receipt of the completed proof of loss, not from when the claimant first called in — mixing these up misstates how much time is actually left on the file.
+
+### Salvage value
+The amount a damaged vehicle or property can be sold for in its post-loss, damaged condition — distinct from its pre-loss market value or ACV.
+- **In use:** "Settlement if the insured retains the vehicle nets ACV minus the salvage value, since they're keeping something still worth selling for parts or scrap."
+- **Misuse:** Confused with resale or trade-in value of a comparable undamaged vehicle. Salvage value is specifically what the wreck itself is worth to a salvage buyer, and it's netted differently depending on whether the state uses a percentage-threshold or TLF total-loss test.
+
+### SIU referral
+A formal escalation of a claim file to the Special Investigative Unit, made on a named, documented fraud indicator (narrative escalation, repeat vendor/address pattern, verification inconsistency) — not on unspecified suspicion.
+- **In use:** "The referral names the 61.9% estimate increase between FNOL and the recorded statement with no new damage found — that's the indicator, not that the claimant 'seemed evasive.'"
+- **Misuse:** Triggered on a gut feeling or a single ambiguous detail (one changed word in a long statement) rather than a documented pattern. A referral without a named indicator tied to specific file evidence isn't a valid referral basis and undermines the ones that are.


### PR DESCRIPTION
## Rubric score

17/18

## Resolution rationale

Read title-examiner (23-2093.00), and skimmed insurance-underwriter (13-2053.00) plus confirmed education-administrator-other and wind-energy-operations-manager have no domain overlap. None of the three suggested candidates is a plausible parent for Claims Adjusters, Examiners, and Investigators (13-1031.00): title-examiner's decision framework is chain-of-title research and defect classification (curable/insurable/fatal) on public land records — it never touches liability determination, coverage interpretation, claim investigation, or settlement negotiation. insurance-underwriter prices and selects risks pre-loss (binding authority, loss ratios, reinsurance capacity) — a fundamentally different, pre-contract decision; it has no post-loss claim-investigation or settlement-authority framework. education-administrator-other and wind-energy-operations-manager share no domain at all. A practitioner adjusting/examining/investigating a claim (determining coverage applicability under a specific policy, apportioning liability among parties, valuing a loss/injury, detecting fraud indicators, negotiating a settlement within reserve/authority limits) would get wrong or absent guidance from every candidate's Decision framework, Tools & methods, and Worked example — these are different decisions and different failure modes, not just less detail. No reasonable parent exists among the candidates or elsewhere in roles/ (grepped for adjust|examiner|investigat|claim — only title-examiner exists, already ruled out; no existing claims-adjuster or claims-examiner role). Proposing new leaf role at the O*NET-listed granularity (13-1031.00 covers adjusters, examiners, and investigators as one occupation) with slug `claims-adjuster`, consistent with existing single-word-role naming (title-examiner, insurance-underwriter).

## Test plan

- [x] `python3 scripts/lint_roles.py claims-adjuster` — 0 errors, 0 warnings
- [x] `python3 scripts/generate_roadmap.py` regenerated README/ROADMAP/data/roles.json role counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new spec‑2 `claims-adjuster` role with practical templates and red‑flag guidance for P&C claims. Updates counts and the roadmap to reflect the new O*NET‑mapped role.

- **New Features**
  - `roles/claims-adjuster` (finance, O*NET 13-1031.00): coverage decision framework, total‑loss math (percentage threshold vs. TLF), SIU referral criteria, and appraisal guidance; includes filled artifacts (`artifacts.md` — ROR letter, total‑loss worksheet, SIU referral form, appraisal demand), `red-flags.md`, and `vocabulary.md`.
  - Updated `data/roles.json`, README, and ROADMAP: 111 roles (107 O*NET‑mapped, 69 spec‑2); finance now 11; Business & Financial Operations 14/50; marks 13‑1031.00 as drafted.

<sup>Written for commit c2204c883546c7e411aa5a04bdc74ef8ffc6f959. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

