### PR TITLE
role: add hr-specialist

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**108 roles drafted** (104 mapped to an O*NET occupation, 4 custom; 66 at spec 2, 42 awaiting upgrade), across 10 categories:
+**109 roles drafted** (105 mapped to an O*NET occupation, 4 custom; 67 at spec 2, 42 awaiting upgrade), across 10 categories:
 
 - **design**: 3
 - **engineering**: 17
@@ -204,7 +204,7 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 - **healthcare**: 8
 - **legal**: 11
 - **marketing**: 4
-- **operations**: 43
+- **operations**: 44
 - **other**: 6
 - **product**: 1
 - **sales**: 5

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 104 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 105 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -78,7 +78,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>13 — Business and Financial Operations</strong> (11/50 drafted)</summary>
+<summary><strong>13 — Business and Financial Operations</strong> (12/50 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -96,7 +96,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 |  | 13-1041.07 | Regulatory Affairs Specialists |  |
 |  | 13-1041.08 | Customs Brokers |  |
 | ✅ | 13-1051.00 | Cost Estimators | [`cost-estimator`](./roles/cost-estimator/SKILL.md) |
-|  | 13-1071.00 | Human Resources Specialists |  |
+| ✅ | 13-1071.00 | Human Resources Specialists | [`hr-specialist`](./roles/hr-specialist/SKILL.md) |
 |  | 13-1074.00 | Farm Labor Contractors |  |
 |  | 13-1075.00 | Labor Relations Specialists |  |
 | ✅ | 13-1081.00 | Logisticians | [`logistician`](./roles/logistician/SKILL.md) |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 108,
+  "count": 109,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -826,6 +826,24 @@
       "audit_score": null,
       "skill": "roles/hr-people-manager/SKILL.md",
       "references": []
+    },
+    {
+      "slug": "hr-specialist",
+      "description": "Use when a task needs the judgment of an HR specialist/HR generalist \u2014 determining FMLA or leave eligibility, running the ADA interactive process, maintaining I-9 and personnel-file compliance, administering benefits enrollment, designing a new-hire onboarding sequence, or handling an EEOC charge or background-check adverse action notice. Distinct from hr-people-manager (owns comp/leveling/termination judgment calls and org design) and technical-recruiter (owns sourcing through offer close) \u2014 this role owns the compliance-and-operations ground floor: the paperwork, deadlines, and recordkeeping that, done wrong, create legal exposure regardless of how good the people decisions above it are.",
+      "category": "operations",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "13-1071.00",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/hr-specialist/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ]
     },
     {
       "slug": "hydroelectric-production-manager",

--- a/roles/hr-specialist/SKILL.md
+++ b/roles/hr-specialist/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: hr-specialist
+description: Use when a task needs the judgment of an HR specialist/HR generalist — determining FMLA or leave eligibility, running the ADA interactive process, maintaining I-9 and personnel-file compliance, administering benefits enrollment, designing a new-hire onboarding sequence, or handling an EEOC charge or background-check adverse action notice. Distinct from hr-people-manager (owns comp/leveling/termination judgment calls and org design) and technical-recruiter (owns sourcing through offer close) — this role owns the compliance-and-operations ground floor: the paperwork, deadlines, and recordkeeping that, done wrong, create legal exposure regardless of how good the people decisions above it are.
+metadata:
+  category: operations
+  maturity: draft
+  spec: 2
+  onet_soc_code: "13-1071.00"
+---
+
+# HR Specialist
+
+## Identity
+
+Runs the operational and compliance machinery of the employee lifecycle — leave administration, I-9 and personnel-file recordkeeping, benefits enrollment, the ADA interactive process, onboarding logistics, and HRIS data integrity — inside a company with no in-house employment counsel on every question. Accountable for procedural correctness under deadlines that don't move: a leave eligibility date, an I-9 retention date, an EEOC filing window. The defining tension is that this role's mistakes are usually invisible until an audit, a charge, or a termination surfaces them, so the job is disciplined process-following on days when nothing appears to be at stake, not just crisis response on the day something is.
+
+## First-principles core
+
+1. **FMLA eligibility is a three-part test computed per employee, not a company-wide policy.** 12 months employed, 1,250 hours worked in the preceding 12 months, and the employee's *worksite* (not the company overall) has 50+ employees within 75 miles — a company with 200 employees company-wide can still have an ineligible worksite. Applying "we're big enough, so everyone's covered" without checking the worksite headcount is the single most common eligibility miss (DOL WHD Fact Sheet #28).
+2. **I-9 retention has a computable expiration, and applying the wrong rule is a per-form liability, not an abstraction.** Retain the later of 3 years after the hire date or 1 year after termination — for anyone who worked under roughly 2 years, the hire-date rule always controls; for longer-tenured employees, the termination-date rule usually does. Civil penalties run $288–$2,861 per form for a first-offense paperwork violation, up to $28,619 per form for knowing/repeat violations (USCIS M-274 §10.0; ICE/DOJ penalty schedule) — an annual I-9 audit is cheaper than one bad quarter of drift.
+3. **The FLSA exemption salary threshold is a floor, not the test, and the federal number is not always the binding one.** As of 2026 the federal EAP exemption threshold is $684/week ($35,568/yr), with the HCE exemption at $107,432/yr total comp plus the $684/wk salary component — but at least 5 states set a higher state-level minimum effective January 1, 2026, and even meeting the salary level classifies no one without also passing the duties test and salary-basis test. Citing salary level alone as proof of exempt status is the classic misclassification pattern to catch before payroll does.
+4. **EEOC filing deadlines run 180 or 300 days depending on state deferral status, with an asymmetric exception for age claims.** The base window is 180 calendar days from the discriminatory act, extended to 300 days where a state or local Fair Employment Practice agency has overlapping jurisdiction — except for age discrimination specifically, where the 300-day extension requires a *state* law or agency, and a local-only ordinance doesn't extend it. Harassment deadlines run from the last incident, though earlier incidents can still be considered as background (EEOC, 29 CFR §1601.13).
+5. **The first 44 days determine retention more than anything that happens afterward, so onboarding is a retention intervention, not orientation logistics.** 70% of new hires decide within the first month whether the job is right, 29% within the first week, and roughly a third leave within 90 days — expectation-mismatch (~30%), no team/culture connection (~20%), and poor onboarding experience (~17%) are the named top reasons. 91% of new hires who report effective culture onboarding feel connected, versus 29% who report onboarding was lacking (BambooHR, 2025) — a 2-week onboarding plan (what ~49% of companies run) is treating a 90-day retention problem as a 2-week logistics problem.
+
+## Mental models & heuristics
+
+- **When a leave request comes in, confirm all three FMLA prongs against the worksite, not the company, before quoting an entitlement** (see first-principles #1 for the test itself) — a wrong "yes" creates an entitlement that's hard to walk back, and a wrong "no" is a denial-of-leave claim.
+- **When a disability accommodation request surfaces, default to opening the interactive process immediately rather than pre-judging feasibility** — the process itself is the legal protection, independent of whether the specific accommodation is ultimately granted.
+- **When an exemption classification is questioned, check the duties test and salary-basis test even if the salary level passes** — salary level alone is the failure mode name for a reason; a well-paid employee performing non-exempt duties is still non-exempt.
+- **When multiple jurisdictions are in play (multi-state workforce, background checks, exemption thresholds), assume the federal number is a floor and check for a stricter state or local rule** — this is true for FLSA salary thresholds, FCRA adverse-action waiting periods, and EEOC filing extensions alike; treating the federal rule as universal is the recurring trap across all three.
+- **For background-check adverse action, sequence pre-adverse notice → wait → final adverse action notice, and check the jurisdiction's wait period rather than defaulting to 5 business days everywhere** — California requires 5 business days from confirmed receipt; Washington's Fair Chance Act (effective July 2026) requires only 2 days for employers with 15+ employees; NYC requires the position stay open 5 business days (FCRA, 15 U.S.C. §1681b(b)(3)).
+- **For ACA employer shared-responsibility calculations, remember penalty A applies to full-time headcount minus 30, not to the number of employees who went to the exchange** — a 60-FTE employer offering no coverage with 3 employees on subsidized exchange coverage owes (60−30)×$3,340 = $100,200/yr, not 3×$3,340; this is the most common ACA-penalty miscalculation.
+- **Treat turnover cost as a real number when a requisition sits unfilled or a marginal hire is kept too long** — replacement cost runs roughly 6–9 months of salary all-in, or 50%–200% of annual salary by seniority; an $80K role at the 6–9-month benchmark costs $40,000–$60,000 to replace, which reframes "we're too busy to backfill properly" as a budget decision, not a scheduling one.
+
+## Decision framework
+
+1. **Classify the request against its governing regulation first** — leave (FMLA/state leave law), accommodation (ADA), classification (FLSA), or discrimination/termination (EEOC) — because each has a different eligibility test, deadline, and documentation requirement, and misrouting a request to the wrong framework is the most common process error.
+2. **Pull the specific facts the governing test requires** — for FMLA: hire date, hours worked in the trailing 12 months, worksite headcount within 75 miles; for FLSA: current salary, primary duties, how pay is structured; for EEOC: date of the act, state FEP agency status. Don't quote an entitlement or a classification from memory before confirming the inputs.
+3. **Check for a stricter state or local rule before applying the federal default** (the floor-not-answer heuristic above) — do this for every one of the facts pulled in step 2, not just the one that seems most likely to vary.
+4. **Document the process, not just the outcome** — an ADA interactive-process conversation, an FMLA eligibility determination, an I-9 reverification date — because in an audit or charge, the documented process is the defense; an undocumented correct outcome is indistinguishable from a lucky guess.
+5. **Compute the retention or reverification deadline and calendar it**, rather than relying on recall — I-9 retention dates, FMLA 12-month lookback windows, and EEOC charge deadlines are all date arithmetic, and the arithmetic is the actual compliance work.
+6. **Escalate to employment counsel when the fact pattern is genuinely ambiguous or the exposure is material** (contested termination with a protected-class angle, a borderline exemption reclassification affecting many employees, a charge that's already been filed) — this role executes the well-defined majority of cases; it isn't a substitute for counsel on the contested minority.
+7. **Close the loop with the employee and the file simultaneously** — every determination (leave approved/denied, accommodation granted/modified/denied, classification confirmed) gets the same-day written confirmation described under Communication style, plus a matching personnel-file entry, so the paper trail and the lived outcome never diverge.
+
+## Tools & methods
+
+- HRIS platforms (Workday, BambooHR, ADP) — data integrity here is the input to every eligibility calculation above, since a wrong hours-worked or hire-date field silently propagates into an FMLA, FLSA, or ACA determination.
+- I-9 management/E-Verify systems for retention-date tracking and reverification triggers, distinct from the general personnel file.
+- Benefits administration platforms for open enrollment, qualifying-life-event processing, and ACA full-time/FTE threshold tracking.
+- Structured interactive-process documentation (ADA accommodation request forms/logs) that capture the back-and-forth, not just the final decision.
+- FCRA-compliant background-check vendor workflows that sequence pre-adverse and final adverse action notices with jurisdiction-specific wait periods built in.
+
+## Communication style
+
+With employees: procedural and specific — cites the actual deadline, the actual entitlement, and what happens next, rather than a vague "we'll look into it"; delivers a denial with the specific test that wasn't met, not just the word no. With managers: translates a regulation into an operational instruction ("this employee is FMLA-eligible as of [date]; here's what changes for scheduling and performance documentation during the leave"), not a legal citation dump. With counsel: presents the fact pattern and the specific ambiguity, pre-organized against the relevant test, rather than an unstructured narrative. Documentation-first in all channels — anything said verbally about an entitlement or accommodation gets confirmed in writing the same day.
+
+## Common failure modes
+
+- **Applying company-wide headcount to the FMLA worksite test** (the inverse of heuristic 1) — the single highest-frequency process error; check which headcount was actually used before trusting any FMLA yes/no.
+- **Treating FLSA salary level as sufficient proof of exempt status** — skipping the duties test and salary-basis test once the salary number clears the threshold, missing misclassifications that expose the company to back-overtime liability.
+- **Applying the federal default in a stricter-state situation** — using the 5-business-day FCRA wait period nationwide when Washington requires 2 or using the federal FLSA threshold in a state that's set a higher one.
+- **Pre-judging an ADA accommodation as infeasible and skipping the interactive process** (the inverse of heuristic 2) — skipping straight to a denial removes the documented good-faith effort that protects the company.
+- **Running onboarding as a 2-week checklist rather than a 90-day retention program** — treating the highest-leverage retention window as an administrative task, then being surprised by first-90-days attrition.
+- **Retention-date drift on I-9s** — keeping forms indefinitely "to be safe" or purging them too early, both of which create exposure: over-retention increases discoverable-document risk in unrelated disputes, under-retention is a straightforward per-form penalty.
+- **Miscalculating the ACA penalty base** — computing penalty A against only the employees who received subsidized exchange coverage instead of full-time headcount minus 30, understating real exposure to leadership.
+
+## Worked example
+
+A 60-FTE employer with no group health plan calls: three employees enrolled in ACA marketplace coverage and received a premium tax credit this year, and leadership wants to know the exposure before deciding whether to add a plan next open enrollment. Naive read: 3 employees got subsidized coverage, so multiply 3 × $3,340 = $10,020 and treat that as the number to budget against. Expert reasoning: ACA employer shared-responsibility penalty A (26 U.S.C. §4980H(a)) is calculated against full-time-equivalent headcount minus a 30-employee reduction, assessed monthly, not against the count of employees who actually received subsidized coverage — the presence of even one full-time employee getting a premium tax credit triggers the penalty against the *entire* FT headcount minus 30. The correct calculation: (60 − 30) × $3,340/yr = $100,200/yr, not $10,020/yr — a nearly 10x understatement if the naive number goes to leadership. The specialist also flags the 95% coverage-offer threshold and the 9.96% affordability ceiling as the two levers that determine whether penalty A or the smaller penalty B (unaffordable/inadequate coverage, $5,010/yr per employee receiving a credit) applies instead, since offering compliant coverage to ≥95% of full-time employees converts this from a penalty-A to a best-case zero-penalty situation.
+
+Deliverable, sent to the CFO and the hiring manager who requested the estimate:
+
+> **Subject: ACA Employer Shared Responsibility exposure — current state**
+>
+> Current exposure under §4980H(a) (no coverage offered, ≥1 employee receiving subsidized marketplace coverage): **(60 FT headcount − 30) × $3,340/yr = $100,200/yr**, assessed monthly at $8,350/month, for as long as this condition holds. This is calculated against full-time headcount, not against the 3 employees currently receiving a credit — headcount is the driver, not enrollment count.
+>
+> If we instead offer a compliant group plan to ≥95% of full-time employees at an employee cost ≤9.96% of household income for the lowest-cost self-only option, penalty A drops to $0. Penalty B would only apply to employees for whom the offered plan is inadequate or unaffordable, at $5,010/yr per affected employee receiving a credit — materially smaller and scoped to actual gaps rather than total headcount.
+>
+> Recommend budgeting the plan-offer cost against the $100,200/yr baseline exposure, not the $10,020 figure from the enrolled-employee count alone.
+
+## Going deeper
+
+- [references/playbook.md](references/playbook.md) — load when running an actual leave determination, ADA interactive-process conversation, ACA penalty calculation, or onboarding-sequence build, and a filled template or worked calculation is needed.
+- [references/red-flags.md](references/red-flags.md) — load when auditing existing HR files or processes for latent compliance exposure before it becomes a charge or a penalty.
+- [references/vocabulary.md](references/vocabulary.md) — load when a term of art (exempt, FTE, adverse action, interactive process) needs a precise, misuse-aware definition.
+
+## Sources
+
+U.S. DOL Wage and Hour Division, FMLA Fact Sheet #28 (dol.gov/agencies/whd/fact-sheets/28-fmla). USCIS Handbook for Employers (M-274), §10.0 Retaining Form I-9, and ICE/DOJ civil penalty schedule for paperwork violations. U.S. DOL FLSA salary-level regulation (dol.gov/agencies/whd/overtime/salary-levels) and 2026 practitioner trackers (Ogletree Deakins, Genova Burns client alerts) on state-level thresholds exceeding the federal floor. SHRM turnover-cost benchmark research (widely reproduced 6–9 months-of-salary and 50–200%-of-salary figures). EEOC, Time Limits for Filing a Charge (eeoc.gov/time-limits-filing-charge) and 29 CFR §1601.13 deferral procedure. ACA Employer Shared Responsibility, 26 U.S.C. §4980H, with 2026 figures via NFP/PeopleKeep/Trusaic client alerts. BambooHR, "First Day Fog" onboarding research (2025). FTC/FCRA adverse-action guidance under 15 U.S.C. §1681b(b)(3), with state variations per DISA/Fisher Phillips practitioner explainers. No direct practitioner review yet — flag via PR if you can confirm or correct; onboarding retention narrative is illustrative industry-aggregate data, not a single named-company incident.

--- a/roles/hr-specialist/references/playbook.md
+++ b/roles/hr-specialist/references/playbook.md
@@ -1,0 +1,196 @@
+# Playbook
+
+Filled templates and step sequences for the recurring HR-specialist processes. Adapt the numbers to the actual case; keep the sequence and the thresholds.
+
+## 1. FMLA eligibility determination worksheet
+
+Run this against every leave request before quoting an entitlement — never from memory.
+
+```
+EMPLOYEE: J. Alvarez                          REQUEST DATE: 2026-03-10
+LEAVE REASON: Own serious health condition (knee surgery, ~6 wks recovery)
+
+TEST 1 — Tenure
+  Hire date: 2024-11-04    →  16 months employed as of request date   PASS (≥12 mo)
+
+TEST 2 — Hours worked, trailing 12 months
+  Payroll hours 2025-03-10 to 2026-03-10: 1,410 hrs                   PASS (≥1,250)
+
+TEST 3 — Worksite headcount (NOT company-wide)
+  Employee's worksite: Denver distribution center
+  Headcount at that worksite: 38
+  Headcount at worksites within 75 mi (incl. Denver): 38 + 19 (Aurora) = 57
+                                                                        PASS (≥50)
+
+DETERMINATION: Eligible. Entitlement: up to 12 workweeks unpaid,
+  job-protected, within a rolling 12-month look-back window anchored
+  to first use.
+
+12-MONTH LOOK-BACK CALC (rolling method):
+  Look back from each day leave is taken; count FMLA weeks already
+  used in the trailing 365 days from that day. Prior use this rolling
+  year: 0 wks. Remaining entitlement: 12 wks (480 hrs at 40 hr/wk).
+
+NEXT ACTIONS:
+  [ ] WH-381 (rights & responsibilities notice) sent within 5 business days
+  [ ] Certification (WH-380-E) requested, 15-calendar-day return window
+  [ ] Designation notice (WH-382) sent within 5 business days of receiving
+      certification, or of the 15-day window lapsing
+  [ ] Calendar entitlement-exhaustion date: start date + 12 wks
+  [ ] Manager notified of schedule impact (not diagnosis) same day
+```
+
+**If Test 3 fails:** check state family/medical leave law (many states use a lower or no worksite-size floor — e.g., some state laws cover employers with 15–25 employees, no 75-mile test). Don't stop at "FMLA doesn't apply" — restate as "federal FMLA doesn't apply; check [state] leave law."
+
+## 2. ADA interactive-process log
+
+Open this the same day an accommodation request or an obvious-need signal (visible impairment, doctor's note limiting duties) arrives — before assessing feasibility.
+
+```
+EMPLOYEE: R. Chen                     ROLE: Warehouse associate
+REQUEST: "I need to avoid repetitive overhead lifting" (verbal, 2026-04-02)
+
+STEP 1 (Day 0): Acknowledge request in writing; request medical
+  documentation of the functional limitation (not the diagnosis).
+  Sent: 2026-04-02.
+
+STEP 2 (Day 0–10): Identify essential functions of the role from the
+  job description, cross-checked against what's actually performed.
+  Essential functions here: pallet staging (yes), overhead restocking
+  (occasional, ~10% of shift), inventory scanning (yes).
+
+STEP 3 (Day 7, doc received 2026-04-09): Medical documentation confirms
+  15-lb overhead lift restriction, 90 days, post-surgical.
+
+STEP 4: Brainstorm accommodation options with employee present, ranked:
+  a) Reassign overhead restocking to team lead during restriction window
+     (no essential-function change, no cost) — SELECTED
+  b) Lift-assist device for overhead tasks ($1,200) — held in reserve
+     if (a) creates coverage gaps
+  c) Temporary reassignment to a non-lifting role — not needed given (a)
+
+STEP 5: Document the selected accommodation, start date, review date,
+  and confirm with employee in writing same day as decision.
+  Accommodation: overhead tasks reassigned 2026-04-10 through 2026-07-09.
+  Review date calendared: 2026-07-02 (before expiration, to reassess).
+
+STEP 6 (review date): Confirm restriction lifted, extended, or made
+  permanent; close the log or reopen Step 4 if circumstances changed.
+```
+
+**Undue-hardship test (only if no viable accommodation found):** document specific cost/disruption against the employer's actual size and budget, not a general "too expensive" — an unsupported hardship claim is functionally the same exposure as skipping the process.
+
+## 3. I-9 retention-date calculator
+
+Run per employee, at hire and again at termination — never estimate.
+
+```
+Rule: retain until the LATER of (hire date + 3 years) OR (termination date + 1 year)
+
+Case A — short tenure (worked 2024-01-15 to 2024-09-30, 8.5 months):
+  Hire + 3 yrs  = 2027-01-15
+  Term + 1 yr   = 2025-09-30
+  Retain until: 2027-01-15  (hire-date rule controls — tenure < ~2 yrs)
+
+Case B — long tenure (worked 2018-06-01 to 2026-02-28, ~7.75 years):
+  Hire + 3 yrs  = 2021-06-01
+  Term + 1 yr   = 2027-02-28
+  Retain until: 2027-02-28  (termination-date rule controls — tenure > ~2 yrs)
+
+Crossover point: roughly 2 years of tenure is where the controlling rule
+flips from hire-date to termination-date — flag any employee near that
+line for manual double-check rather than a shortcut formula.
+```
+
+**Annual audit cadence (minimum):** pull all I-9s past their retention date each January; purge those past date, flag any active employee missing a current I-9 or missing reverification for an expiring work-authorization document (check List A/C expiration dates against today + 90 days).
+
+## 4. ACA employer shared-responsibility penalty calculator
+
+```
+INPUTS
+  Full-time equivalent headcount (FT, monthly avg): 45
+  Coverage offered to ≥95% of FT employees?: No
+  # FT employees receiving marketplace premium tax credit: 4
+  Penalty A rate (annual, per FT employee, 2026 indexed): $3,340
+  Penalty B rate (annual, per affected employee, 2026 indexed): $5,010
+
+PENALTY A (no coverage offered to ≥95% of FT, §4980H(a)):
+  (FT headcount − 30) × $3,340
+  = (45 − 30) × $3,340
+  = $50,100 / yr  →  $4,175 / month while condition holds
+
+PENALTY B (coverage offered but unaffordable/inadequate for some, §4980H(b)):
+  applies only if the 95% offer threshold IS met; scoped to affected employees
+  # affected employees × $5,010
+  = 4 × $5,010 = $20,040 / yr (illustrative, if offer threshold were met)
+
+DECISION RULE: if offer rate < 95% of FT headcount, penalty A applies to
+  the ENTIRE FT headcount minus 30 — not to the count of employees who
+  received a credit (see SKILL.md's worked example for the reasoning and
+  the CFO-facing writeup this calculator feeds). Penalty B only becomes
+  the relevant calculation once the 95% offer threshold is satisfied.
+
+AFFORDABILITY CHECK (per employee, for penalty B applicability):
+  employee's lowest-cost self-only premium contribution ≤ 9.96% of
+  household income (2026 indexed figure; use W-2 safe harbor if household
+  income unknown: box 1 wages × 9.96% ÷ 12 = max monthly contribution).
+```
+
+## 5. FCRA background-check adverse-action sequence
+
+```
+STEP 1: Obtain consumer report; make preliminary decision.
+STEP 2 (if leaning adverse): Send PRE-ADVERSE ACTION notice — includes
+  copy of the report, "A Summary of Your Rights Under the FCRA," and a
+  statement that a final decision hasn't been made.
+STEP 3: WAIT — jurisdiction-specific minimum, from date of confirmed
+  receipt (not send date):
+    California:            5 business days
+    New York City:         5 business days (position must remain open)
+    Washington (FCA, eff. Jul 2026, employers 15+ employees): 2 days
+    No applicable state/local rule:                            5 business
+                                                                 days (federal practitioner norm; FCRA sets no fixed
+                                                                 number — "reasonable period")
+STEP 4: If candidate disputes or submits information during the wait,
+  re-evaluate before proceeding — the wait exists so this can happen.
+STEP 5: Send FINAL ADVERSE ACTION notice — includes name/contact of
+  reporting agency, statement that the agency didn't make the decision,
+  and the right to dispute accuracy/completeness with the agency.
+STEP 6: Log the sequence dates (report received, pre-adverse sent,
+  wait-period end, final notice sent) in the candidate file — the dates
+  are the defense if the timeline is ever challenged.
+```
+
+## 6. 90-day onboarding sequence (retention-framed, not checklist-framed)
+
+```
+BEFORE DAY 1 (logistics — necessary, not sufficient):
+  Equipment shipped/provisioned, accounts created, I-9 Section 1 sent
+  for completion by end of Day 1, Section 2 scheduled within 3 business
+  days of start.
+
+WEEK 1 — target: reduce first-week flight risk (see SKILL.md first-principles
+  #5 for the underlying stats this sequence is built to counter)
+  Day 1: manager 1:1 (role expectations, first 30/60/90 goals drafted
+    together, not handed down); team intro; buddy assigned.
+  Day 3: check-in — "does the job match what you expected?" (targets the
+    expectation-mismatch attrition driver directly).
+  Day 5: HR check-in independent of manager — surfaces issues employees
+    won't raise with their new boss yet.
+
+WEEK 2–4 — target: culture connection, run deliberately rather than left ambient
+  Structured intros to 3–5 cross-functional partners, not just the team.
+  First deliverable assigned, scoped to be completable and reviewed by
+  day 30 — a visible early win, not a first-quarter-sized project.
+
+DAY 30: Manager + HR joint check-in. Explicit go/no-go read on the three
+  attrition drivers: expectation match, team connection, onboarding
+  experience. Any "no" on two or more → escalate to a structured
+  30-60-90 reset, not a wait-and-see.
+
+DAY 60: Goals review against the Day-1 30/60/90 plan; adjust scope if
+  mis-set initially.
+
+DAY 90: Formal review. This is the retention-risk checkpoint — treat a
+  lukewarm 90-day review as an actionable signal, not a formality to file.
+```

--- a/roles/hr-specialist/references/red-flags.md
+++ b/roles/hr-specialist/references/red-flags.md
@@ -1,0 +1,63 @@
+# Red Flags — HR Specialist
+
+Signals worth an audit pass before they become a charge, a penalty, or a lawsuit. Each maps to a specific pull, not a vibe.
+
+### I-9 Section 2 completed more than 3 business days after the employee's first day of work
+- **Usually means:** a new-hire paperwork bottleneck (manager delayed sending the hire packet, or the employee's documents weren't available on day one) rather than willful noncompliance — but ICE doesn't distinguish intent on a first review.
+- **First question:** "What was the actual first day of work, and is there a dated record of when Section 2 was signed?"
+- **Data to pull:** I-9 audit trail/timestamp log from the HRIS or E-Verify system for the affected hire cohort, cross-referenced against payroll's recorded start date.
+
+### More than 5% of active I-9s past their retention or reverification trigger date
+- **Usually means:** no automated reverification calendar — either List B/C documents with expirations (e.g., work authorization) aren't flagged, or terminated-employee forms aren't purged on schedule, both of which are separate exposures (reverification miss vs. over-retention).
+- **First question:** "Is this a reverification gap on an active employee, or a retention-date miss on a termed one?"
+- **Data to pull:** I-9 management system's expiration-date report, filtered to active employees with List C documents expiring within 90 days and to termed employees past (later of 3 years post-hire / 1 year post-termination).
+
+### An exempt employee's job description hasn't been updated in 2+ years but their actual duties have shifted toward non-exempt work
+- **Usually means:** the role drifted (e.g., a shift lead promoted for "manager" duties that quietly became mostly hourly-equivalent tasks) faster than HR's job-architecture review cycle, creating a duties-test gap the salary level doesn't cover.
+- **First question:** "What percentage of this person's actual weekly hours are spent on exempt-level duties (discretion, independent judgment, supervision of 2+ FTEs) versus production/clerical work?"
+- **Data to pull:** current job description, most recent duties-test worksheet (if any), and a manager-completed time-allocation estimate for the role.
+
+### A single manager accounts for more than 2 involuntary terminations of protected-class employees within 12 months
+- **Usually means:** could be legitimate performance management concentrated under a tough manager, or could be a pattern an EEOC investigator would flag on the first data pull — the concentration itself, not any single termination, is the signal.
+- **First question:** "Are the documented performance issues for these terminations comparable in severity and documentation quality to this manager's terminations of non-protected-class employees?"
+- **Data to pull:** termination log filtered by manager and protected-class status over the trailing 12 months, plus the performance-documentation file for each termination in the cluster.
+
+### An ADA accommodation request sits open more than 2 weeks with no documented follow-up
+- **Usually means:** the request fell into a queue behind other priorities, or the manager side of the interactive process stalled waiting on a health-provider form — either way, the absence of documentation (not the delay itself) is what removes the good-faith defense.
+- **First question:** "What was the last documented interaction with the employee, and what is it waiting on right now?"
+- **Data to pull:** the interactive-process log/ticket for the request, including date of initial request, all follow-up dates, and any pending medical-certification deadline.
+
+### Fewer than 95% of full-time employees are offered ACA-compliant coverage in a given month
+- **Usually means:** a headcount-classification error (part-time/variable-hour employees crossing into full-time-equivalent status under the measurement-period rules without being reclassified) rather than a deliberate coverage gap.
+- **First question:** "Which specific employees crossed the 30-hours/week average threshold during the measurement period, and were they offered coverage within the stability period that followed?"
+- **Data to pull:** ACA measurement-period hours report from payroll/HRIS and the benefits-enrollment offer log for the same population.
+
+### A background-check adverse action moves from pre-adverse to final notice in fewer business days than the applicable jurisdiction requires
+- **Usually means:** the background-check vendor's default workflow (often a flat 5-business-day timer) wasn't configured per state, so a jurisdiction with a longer requirement (or, conversely, a shorter one like Washington's 2-day Fair Chance Act minimum for 15+ employee employers) got the wrong wait period.
+- **First question:** "What state is the candidate's position based in, and does the vendor's workflow reflect that state's specific wait-period rule?"
+- **Data to pull:** vendor adverse-action timeline export for the candidate, plus the jurisdiction-specific wait-period reference table used to configure the workflow.
+
+### More than 30% of new hires in a cohort exit within the first 90 days
+- **Usually means:** expectation-mismatch during recruiting or a weak first-30-days onboarding experience rather than a hiring-quality problem — the 90-day window is long enough that "bad hire" is rarely the full explanation.
+- **First question:** "In exit interviews or stay conversations for this cohort, how many cite role/expectation mismatch versus a manager or culture-fit issue?"
+- **Data to pull:** 90-day attrition report by hiring manager and requisition, plus exit-interview or stay-interview notes for the departed cohort.
+
+### An EEOC charge is filed and the underlying personnel file has fewer than 3 documented performance or conduct entries in the 12 months preceding the adverse action
+- **Usually means:** the adverse action (termination, demotion, denial) was undocumented in real time and is now being reconstructed after the fact — which is exactly the fact pattern that turns a defensible decision into a credibility problem in front of an investigator.
+- **First question:** "What is the earliest dated document in this file that reflects the performance or conduct issue driving this action?"
+- **Data to pull:** full personnel file with document creation dates (not just content), and the manager's contemporaneous notes or performance-system entries for the 12 months prior.
+
+### A leave request is denied and the FMLA worksite headcount calculation used the company-wide total instead of the 75-mile radius count
+- **Usually means:** whoever ran the eligibility check applied "we're big enough" shorthand instead of pulling the actual worksite-radius headcount, which is the single most common FMLA eligibility miss.
+- **First question:** "What is the headcount of employees working within 75 miles of this employee's specific worksite, not the company total?"
+- **Data to pull:** HRIS worksite/location report showing active headcount within a 75-mile radius of the employee's assigned location, as of the date leave was requested.
+
+### A non-exempt employee's timesheet shows more than 5 hours of unpaid "off-the-clock" work in a pay period (email responses, setup/teardown, on-call check-ins)
+- **Usually means:** informal expectation-creep from a manager ("just check email before you clock in") that HR didn't catch because it doesn't show up as a formal policy change — it shows up as a pattern in timesheet gaps versus badge/login data.
+- **First question:** "Is there a system timestamp (email, VPN login, badge swipe) that shows work activity outside the clocked hours on the timesheet?"
+- **Data to pull:** timesheet data cross-referenced against email/VPN/badge logs for the same employee over a representative pay period.
+
+### A workers' comp claim's first report of injury is filed more than 5 business days after the employee reported the injury to a supervisor
+- **Usually means:** the supervisor didn't know the reporting deadline or treated a minor-seeming injury as not requiring immediate escalation, which risks a late-filing penalty and weakens the claim's credibility if it develops into something more serious.
+- **First question:** "What date did the employee first tell any supervisor about the injury, versus the date the claim was actually filed with the carrier?"
+- **Data to pull:** the incident report, the claim-filing timestamp from the carrier portal, and any supervisor communication (email/text) referencing the injury before the formal filing.

--- a/roles/hr-specialist/references/vocabulary.md
+++ b/roles/hr-specialist/references/vocabulary.md
@@ -1,0 +1,63 @@
+# HR specialist working vocabulary
+
+Terms an HR specialist uses precisely and generalists conflate. Format: definition → how a practitioner says it → common misuse.
+
+**Exempt vs. non-exempt** — Exempt means excluded from FLSA overtime and minimum-wage requirements because the role passes both the salary-level test and a duties test (executive, administrative, professional, etc.); non-exempt means overtime-eligible regardless of title or pay amount.
+In use: "She's salaried, but salaried isn't the test — her duties are non-exempt, so she's still owed overtime past 40 hours."
+Misuse: treating "salaried" and "exempt" as synonyms; a salaried employee who doesn't pass the duties test is still non-exempt and overtime-eligible.
+
+**Duties test vs. salary-basis test** — The duties test asks whether the employee's actual day-to-day work is executive, administrative, or professional in nature; the salary-basis test asks whether pay is a fixed amount not reduced for variations in quality or quantity of work (improper deductions can destroy exempt status for an entire class of employees, not just one paycheck).
+In use: "The duties test is fine — she manages two direct reports — but docking her pay for a half-day absence last month is a salary-basis violation."
+Misuse: assuming clearing the duties test is the whole analysis; a single improper deduction under the salary-basis test can retroactively convert exempt employees in the same job classification to non-exempt.
+
+**FMLA "worksite"** — The specific physical location (or the location an employee reports to/is assigned from) that must have 50+ employees within a 75-mile radius for FMLA eligibility — a defined term, not a synonym for "the company."
+In use: "Company headcount is 400, but her worksite only has 30 within 75 miles — she's not FMLA-eligible here."
+Misuse: computing eligibility off total company headcount instead of the specific worksite's headcount, producing a wrong eligibility call in either direction.
+
+**Interactive process** — The ADA-required, documented back-and-forth between employer and employee to identify a workable reasonable accommodation, distinct from the accommodation itself; the process is the legal obligation even if it ends in no accommodation being granted.
+In use: "We haven't decided on an accommodation yet, but the interactive process is open and documented as of Tuesday's conversation."
+Misuse: treating "interactive process" as a synonym for "granting an accommodation," or skipping it entirely because the request looks infeasible — an undocumented informal chat isn't the interactive process, and pre-judging feasibility without it removes the employer's legal protection.
+
+**Reasonable accommodation vs. undue hardship** — A reasonable accommodation is a change to the job or environment enabling a qualified individual with a disability to perform essential functions; undue hardship is the employer's affirmative defense that a specific accommodation imposes significant difficulty or expense given its size and resources — it is not a general "that would be inconvenient" claim.
+In use: "We're not denying for undue hardship — we haven't priced it out or explored alternatives yet, so we can't claim that defense."
+Misuse: invoking "undue hardship" informally to justify denying a request without the cost/resource analysis the defense actually requires.
+
+**Adverse action (pre-adverse vs. final)** under FCRA — Pre-adverse action notice is sent before a final decision, giving the candidate the background-check report and a waiting period to dispute; final adverse action notice is sent after the decision is made and confirmed, disclosing the right to dispute and obtain a free additional report.
+In use: "Pre-adverse went out Monday; we can't send final adverse until the jurisdiction's wait period clears, even if we've already decided not to hire."
+Misuse: sending only one "adverse action" notice, or sending final adverse action before the required waiting period expires — the two notices are sequential and legally distinct, not interchangeable paperwork.
+
+**Protected class vs. protected activity** — Protected class refers to a legally protected characteristic (race, sex, age 40+, disability, etc.) that discrimination law shields from adverse treatment; protected activity refers to an action (filing a charge, participating in an investigation, requesting an accommodation) that retaliation law shields independent of whether any protected-class claim succeeds.
+In use: "Even if the underlying discrimination charge gets dismissed, firing her for filing it is retaliation against protected activity — a separate claim."
+Misuse: assuming a retaliation claim automatically fails once the underlying discrimination claim is found meritless; protected activity is protected regardless of the merits of what was reported.
+
+**Disparate treatment vs. disparate impact** — Disparate treatment is intentional differential treatment of an individual or group based on a protected class; disparate impact is a facially neutral policy that produces a statistically disproportionate adverse effect on a protected class, regardless of intent.
+In use: "Nobody intended to screen out older applicants, but the physical test's pass-rate gap is a disparate-impact exposure, not a disparate-treatment one."
+Misuse: defending a challenged policy by pointing to lack of discriminatory intent — that defense answers disparate treatment but is irrelevant to a disparate-impact claim, which doesn't require intent.
+
+**Constructive discharge** — A resignation that's legally treated as an involuntary termination because the employer made conditions so intolerable that a reasonable person would feel compelled to quit; requires more than general dissatisfaction — courts look for a deliberate or seriously mismanaged pattern.
+In use: "This isn't just a bad manager relationship — the demotion, pay cut, and reassignment to a closet office in the same week is a constructive-discharge fact pattern."
+Misuse: treating any resignation following workplace conflict as "constructive discharge"; the bar is a materially intolerable condition, not ordinary friction or a single unpopular decision.
+
+**At-will employment** — The default rule that either party can end employment at any time for any reason (or no reason), except reasons prohibited by law (discrimination, retaliation) or superseded by a contract, CBA, or implied promise (e.g., specific representations in a handbook).
+In use: "We're at-will here, but the offer letter's 'just cause' language may have contractually overridden that — pull the letter before we act."
+Misuse: treating "at-will" as an absolute shield that makes any termination reason-proof; it doesn't override anti-discrimination/retaliation law or a contractual carve-out the company itself created.
+
+**Qualifying life event (QLE)** — A specific, plan-defined change in circumstance (marriage, birth/adoption, loss of other coverage, divorce) that opens a special enrollment window outside open enrollment; the event type determines both the deadline and which elections can change, not a general "something changed" standard.
+In use: "Birth is a QLE — she has 30 days from the birth date to add the dependent, not until next open enrollment."
+Misuse: assuming any life change qualifies, or missing that the QLE's specific window (often 30 or 60 days) has already closed by the time the request reaches HR.
+
+**FTE vs. full-time headcount** for ACA purposes — Full-time headcount counts employees averaging 30+ hours/week; FTE additionally aggregates part-time employees' hours into whole-employee equivalents (total part-time monthly hours ÷ 120) and adds that to full-time headcount to determine applicable large employer (ALE) status — but the §4980H(a) penalty itself is calculated against full-time headcount minus 30, not against the blended FTE count.
+In use: "FTE count puts us over the 50-employee ALE threshold, but the penalty math afterward uses full-time headcount minus 30, not the FTE number."
+Misuse: using the FTE-inclusive count (used only to determine ALE status) as the base for the penalty calculation itself, which uses full-time headcount alone.
+
+**Right-to-sue letter** — The document the EEOC issues (upon request or after 180 days if it hasn't concluded its investigation) that gives the charging party 90 days to file a lawsuit; receiving one doesn't mean the EEOC found merit — it's a procedural gateway to court, not a finding.
+In use: "She got a right-to-sue letter, but that's just the 90-day clock starting — the EEOC didn't find cause on the charge."
+Misuse: treating issuance of a right-to-sue letter as an EEOC finding of discrimination (or of no discrimination); it's neutral procedural machinery, not a merits determination.
+
+**I-9 reverification** — The requirement to re-confirm employment authorization before a specific expiration date on certain List A/C documents (e.g., some visas, EADs) — distinct from the general personnel file and distinct from re-checking a document that has no expiration date, which is never required.
+In use: "Her EAD expires in March — that's a reverification trigger; his List B/C combo has no expiration, so there's nothing to reverify."
+Misuse: reverifying documents that never expire (a common over-compliance error) or missing an actual expiration-triggered reverification date because it wasn't calendared separately from the hire-date I-9 retention clock.
+
+**Retaliation vs. discrimination** — Discrimination requires adverse treatment because of a protected characteristic; retaliation requires adverse treatment because the employee engaged in protected activity (complaint, charge, participation, accommodation request) — the two require different evidence and can exist independently of each other.
+In use: "We may beat the discrimination claim on the merits, but the timing between her complaint and the sudden PIP is exactly the pattern retaliation claims are built on."
+Misuse: assuming that defeating the underlying discrimination allegation also defeats a retaliation allegation arising from the same complaint — they're evaluated separately, and retaliation claims succeed more often than the discrimination claims that triggered them.


### PR DESCRIPTION
## Rubric score

18/18

## Resolution rationale

O*NET 13-1071.00 HR Specialists is a generalist, operational HR practitioner role: recruiting/screening coordination, processing personnel actions, administering (not designing) benefits enrollment, maintaining compliance records, running new-hire orientation. Checked against the three suggested candidates plus discovered adjacent roles (hr-people-manager, technical-recruiter, compensation-benefits-manager) — none is a valid parent. hr-people-manager (11-3121.00) is a management/judgment role centered on precedent-setting decisions (terminations, comp exceptions, org design), wrong guidance for day-to-day administrative HR work. technical-recruiter covers only the recruiting slice, not the full personnel-administration/benefits/compliance scope. compensation-benefits-manager (11-3111.00) designs comp/benefit structures and runs pay-equity audits — a specialist administers enrollment and answers employee questions, a different decision and tool set. The originally-suggested candidates (water-resource-specialist, brownfield-redevelopment-specialist, education-administrator-other) are unrelated domains entirely. No reasonable existing parent exists, so this should be a new top-level role, slug 'hr-specialist' following the repo's kebab-case '<role>-specialist'/'<role>-manager' naming convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the new `hr-specialist` role (O*NET 13-1071.00) focused on compliance and operational HR work. Updates role counts and the Business and Financial Operations checklist.

- **New Features**
  - Introduced `roles/hr-specialist` (spec-2) with SKILL.md covering leave, I-9, ADA, FLSA, onboarding, and ACA decisioning, distinct from `hr-people-manager` and `technical-recruiter`.
  - Added references: `playbook.md` (templates/flows), `red-flags.md` (audit signals), and `vocabulary.md` (precise terms).
  - Registered the role in `data/roles.json` with O*NET 13-1071.00 and linked references.
  - Updated `README.md` and `ROADMAP.md` to reflect +1 role, new operations count, and marked 13-1071.00 as drafted.

<sup>Written for commit e1043a240c8dc8248845c711c857f18448d5fdf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

