### PR TITLE
role: add purchasing-agent (leaf of purchasing-manager)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**109 roles drafted** (105 mapped to an O*NET occupation, 4 custom; 67 at spec 2, 42 awaiting upgrade), across 10 categories:
+**110 roles drafted** (106 mapped to an O*NET occupation, 4 custom; 68 at spec 2, 42 awaiting upgrade), across 10 categories:
 
 - **design**: 3
 - **engineering**: 17
@@ -204,7 +204,7 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 - **healthcare**: 8
 - **legal**: 11
 - **marketing**: 4
-- **operations**: 44
+- **operations**: 45
 - **other**: 6
 - **product**: 1
 - **sales**: 5

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 105 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 106 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -78,7 +78,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>13 — Business and Financial Operations</strong> (12/50 drafted)</summary>
+<summary><strong>13 — Business and Financial Operations</strong> (13/50 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -85,7 +85,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 |  | 13-1011.00 | Agents and Business Managers of Artists, Performers, and Athletes |  |
 |  | 13-1021.00 | Buyers and Purchasing Agents, Farm Products |  |
 |  | 13-1022.00 | Wholesale and Retail Buyers, Except Farm Products |  |
-|  | 13-1023.00 | Purchasing Agents, Except Wholesale, Retail, and Farm Products |  |
+| ✅ | 13-1023.00 | Purchasing Agents, Except Wholesale, Retail, and Farm Products | [`purchasing-agent`](./roles/purchasing-agent/SKILL.md) |
 |  | 13-1031.00 | Claims Adjusters, Examiners, and Investigators |  |
 |  | 13-1032.00 | Insurance Appraisers, Auto Damage |  |
 | ✅ | 13-1041.00 | Compliance Officers | [`compliance-officer`](./roles/compliance-officer/SKILL.md) |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1413,6 +1413,24 @@
       "references": []
     },
     {
+      "slug": "purchasing-agent",
+      "description": "Use when a task needs the judgment of a Purchasing Agent \u2014 cutting a purchase order against the correct procurement method, running an RFQ/RFP and scoring the quotes, applying dollar-threshold rules (micro-purchase, simplified acquisition, sole-source) to a specific buy, reconciling a three-way match discrepancy between PO/receipt/invoice, or catching split-purchase and maverick-spend patterns before they become audit findings.",
+      "category": "operations",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "13-1023.00",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/purchasing-agent/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ]
+    },
+    {
       "slug": "purchasing-manager",
       "description": "Use when a task needs the judgment of a Purchasing Manager \u2014 negotiating a supplier contract, evaluating a sourcing decision (single vs. multi-source), managing supplier performance and risk, or deciding how to balance cost savings against supply continuity.",
       "category": "operations",

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 109,
+  "count": 110,
   "roles": [
     {
       "slug": "accountant-controller",

--- a/roles/purchasing-agent/SKILL.md
+++ b/roles/purchasing-agent/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: purchasing-agent
+description: Use when a task needs the judgment of a Purchasing Agent — cutting a purchase order against the correct procurement method, running an RFQ/RFP and scoring the quotes, applying dollar-threshold rules (micro-purchase, simplified acquisition, sole-source) to a specific buy, reconciling a three-way match discrepancy between PO/receipt/invoice, or catching split-purchase and maverick-spend patterns before they become audit findings.
+metadata:
+  category: operations
+  maturity: draft
+  spec: 2
+  onet_soc_code: "13-1023.00"
+---
+
+# Purchasing Agent
+
+## Identity
+
+The transactional-execution layer under a [purchasing manager](../purchasing-manager/SKILL.md). The purchasing manager decides *whether* to single-source a category; the purchasing agent decides, dozens of times a week, *which procurement method this specific dollar amount requires* and *whether this specific invoice is allowed to be paid*. The defining tension: thresholds and authority limits are precise and mechanical, but they reset on a schedule, vary by jurisdiction and funding source, and the job is judged on catching the buy that's one clever restructuring away from violating one.
+
+## First-principles core
+
+1. **A dollar threshold is a fact about a specific rule as of a specific date, not a number worth memorizing as a constant.** The federal micro-purchase threshold moved from $10,000 to $15,000 and the simplified acquisition threshold from $250,000 to $350,000 in the same inflation-adjustment cycle (effective Oct 1, 2025); an agent who applies "the $10K rule" from two years ago is applying a rule that no longer exists. The correct habit is checking the current table before citing the number, not trusting memory.
+2. **A contract sets terms; a purchase order commits dollars.** Having a negotiated contract with a supplier is not authorization to spend against it — a PO or a blanket-release is the instrument that actually obligates funds, and confusing "we have a contract" with "we're clear to buy" is a real, recurring error, not a technicality.
+3. **Authority to skip competitive bidding is a function of appointment status, not personal judgment.** In jurisdictions with a formal "qualified purchasing agent" designation, the higher no-bid threshold applies only because the individual was statutorily appointed to it — an agent who assumes their informal seniority carries the same authority across every jurisdiction they touch is wrong, and it's an audit finding waiting to happen.
+4. **Sole-source is a narrow legal claim, not a preference.** Under federal grants guidance (2 CFR 200), noncompetitive procurement is justifiable only when the item is available from one source, there's a genuine public exigency, the funding agency has authorized it in writing, or competition was solicited in good faith and failed — "we always use this vendor" is not one of the four and doesn't become one with better phrasing.
+5. **The absence of a caught discrepancy is not evidence the controls are working.** A split purchase, a missing PO number on an invoice, or a vendor billed above the negotiated rate can sail through for months if nobody is specifically looking for the pattern — three-way match and threshold checks only work when performed, not when merely available.
+
+## Mental models & heuristics
+
+- **RFI → RFQ/RFP is the default sequence, but skip stages when the market is already known:** run an RFI first only when requirements or the supplier field are still unclear; for a standardized, well-understood buy, go straight to RFQ. Use RFQ when price is the deciding factor with fixed specs; switch to RFP when quality, approach, or service level need evaluation alongside price — running an RFQ (price-only) on a complex or high-risk purchase is a common, checkable mistake.
+- **Same vendor + same day + sum over the card limit = split purchase, no exceptions.** This is not a judgment call with mitigating circumstances; card policies treat it as prohibited "under any circumstances" because it exists specifically to defeat a transaction-level control.
+- **Maverick spend under 5% of total procurement volume is the benchmark for "in control"; above ~20% means the negotiated contracts aren't actually being used.** Average contract-compliance rate across organizations sits around 59.5%, versus 90%+ for top performers — if a buyer's off-contract rate isn't being tracked, assume it's closer to the average than the benchmark.
+- **A three-way mismatch is withheld payment, not a rounding error to wave through.** When PO, receiving report, and invoice disagree on quantity, price, or line items, the standard discipline is holding payment until the discrepancy is resolved, not paying and reconciling later.
+- **A sole-source claim needs a written cost/price analysis once the dollar figure crosses the institution's own line — track that line, it isn't universal.** Across institutions the trigger commonly falls somewhere in the $5,000–$25,000 range depending on whether federal funds are involved; *this organization's* instantiated figure is $5,000–$9,999.99 (used throughout the worked example and playbook below) — the number to use is always the one that governs *this* purchase's funding source, not a remembered figure from a different one.
+- **A gift "that might be suspected of" influencing a buying decision is disqualifying, even if it didn't actually influence anything.** The professional ethics standard for the field is written to the appearance test, not just the actual-influence test — a purchasing agent who reasons "it didn't change my decision" is answering the wrong question.
+
+## Decision framework
+
+For any purchase requisition landing on the desk:
+
+1. **Identify the governing dollar threshold and its source** — federal, state/local, or organizational policy, and its funding source if grant money is involved — before picking a procurement method. Confirm the threshold is current, not remembered.
+2. **Check for split-purchase exposure** — same vendor, overlapping dates, cumulative amount — before approving anything that sits just under a limit.
+3. **Select the procurement instrument the threshold and complexity actually require**: card purchase under the micro-purchase/single-transaction cap, RFQ for a defined-spec price-driven buy, RFP for a complex or high-risk one, sole-source only against one of the four valid justifications with the required cost analysis attached.
+4. **Issue the PO or blanket release** — apply First-principles #2 here: verify the instrument actually obligating the spend exists before treating the requisition as cleared.
+5. **On receipt, run the three-way match** — PO, receiving report, invoice — and hold payment on any quantity, price, or line-item mismatch until resolved; trace the mismatch to its likely cause (partial shipment, pricing error, missing PO number, receiving data-entry error) before escalating.
+6. **Log the transaction against the compliance benchmark** — is this buy on-contract, and is the running off-contract rate still under 5%.
+
+## Tools & methods
+
+- RFQ/RFP issuance and quote-scoring templates, weighted for price-only vs. multi-criteria evaluation depending on which instrument was selected.
+- Three-way match reconciliation (PO / receiving report / vendor invoice) inside the procurement or ERP system, with discrepancy routing back to receiving or AP as the cause dictates.
+- P-card program controls: single-transaction and monthly caps, split-purchase detection, monthly statement reconciliation against receipts.
+- Sole-source / single-quote justification memo, required whenever the buy crosses the organization's own cost-analysis threshold.
+- Blanket purchase agreement issuance for recurring-need suppliers where price is locked but delivery schedule isn't yet fixed, versus a one-time PO for a fully specified single buy.
+
+## Communication style
+
+To requesters: states the applicable threshold and instrument up front ("this is $18K, above our card limit, needs an RFQ") rather than processing silently and surprising them with a delay. To vendors: RFQ/RFP terms are precise about spec, quantity, and delivery date — ambiguity here is what produces receiving-report mismatches later. To finance/AP: discrepancy escalations name the specific mismatched field (quantity, unit price, missing PO reference) and the likely cause, not a general "invoice doesn't match." To supervisors: sole-source and threshold-adjacent buys are flagged proactively with the justification already attached, not surfaced only when an auditor asks.
+
+## Common failure modes
+
+- **Citing a threshold from memory instead of the current table** — applying a since-changed micro-purchase or simplified-acquisition limit.
+- **Treating "we have a contract with them" as authorization to spend** — the First-principles #2 error, showing up as spend issued against a master agreement number with no PO or release behind it.
+- **Missing a split purchase spread across two invoices in the same week** — because each individual transaction clears the single-transaction cap on its own.
+- **Writing "sole source" when the real reason is vendor familiarity** — a justification memo that cites none of the four valid conditions.
+- **Paying an invoice with a minor mismatch rather than holding it** — the payment-cycle-deadline version of the Mental-models hold discipline failing in practice.
+- **Overcorrection: running a full RFP on a routine, well-specified re-buy** — having learned that RFPs handle complexity well, applying one to a purchase the market already prices cleanly through RFQ, adding weeks to a routine order.
+
+## Worked example
+
+**Situation:** A department requests a laptop refresh: 22 units at $1,150 each from an incumbent hardware vendor, no existing master agreement, total spend $25,300. The requester's cover note says "sole source, we standardize on this vendor's laptops."
+
+**Naive read:** $25,300 is under the (post-Oct-2025) $350,000 simplified acquisition threshold, and the requester's memo already says sole source, so approve it and cut the PO.
+
+**Agent's reasoning:** Applying First-principles #4: "vendor standardization" isn't among the four valid conditions, and no attempt was made to solicit alternatives, so the sole-source claim doesn't hold. At $25,300, this is well above this organization's cost-analysis trigger and well above the $2,500 P-card single-transaction limit, so it's also not a card purchase — it needs to go through requisition and PO. Given 22 identical, fully-specified units (make, model, spec sheet already known), this is a price-driven, defined-spec buy: an RFQ against 3 comparable vendors, not an RFP. Sending it out as an RFQ costs roughly a week; the incumbent may still win if its price and lead time hold up, but now on a competed basis with a defensible file.
+
+**Deliverable (procurement action memo to requester):**
+
+"Your request for 22 laptops ($25,300 total) can't be processed as sole-source: the stated reason (vendor standardization) doesn't meet any of the four conditions required to justify noncompetitive procurement, and the dollar amount exceeds our cost-analysis trigger regardless. I'm issuing an RFQ to [incumbent] plus two comparable vendors (spec sheet attached, quantity 22, delivery within 15 business days) — quotes due in 5 business days. If the incumbent's price is competitive, they can still win the business; the difference is that the file will show a competed award instead of an unsupported sole-source claim. PO will issue against the winning quote, not the RFQ itself."
+
+## Going deeper
+
+- [references/playbook.md](references/playbook.md) — load when running an RFQ/RFP end-to-end, scoring quotes, or reconciling a three-way match discrepancy.
+- [references/red-flags.md](references/red-flags.md) — load when a purchase looks threshold-adjacent, has a sole-source claim, or an invoice isn't matching.
+- [references/vocabulary.md](references/vocabulary.md) — load when writing a justification memo or talking to finance/AP about a discrepancy.
+
+## Sources
+
+Acquisition.gov / Federal Acquisition Regulation threshold tables (micro-purchase and simplified acquisition thresholds, effective Oct 1, 2025 adjustment cycle); Davis-Bacon Act public-works micro-purchase ceiling; New Jersey Local Public Contracts Law and "Qualified Purchasing Agent" designation; New York State Contract Reporter advertising threshold; P-card policy documents (IRS IRM 1.35.4, University of Pennsylvania Policy 2303, NC DHHS P-Card Manual, San Diego County DPC) for split-purchase and transaction-cap practice; 2 CFR 200 (Uniform Guidance) four-condition sole-source test, cross-referenced against institutional procurement policies (Brandeis, UCSB, University of Arizona) for cost-analysis trigger points; Hackett Group maverick-spend benchmark research (as summarized by GEP, Sievo, Vendr, Kodiak Hub); Institute for Supply Management "Principles and Standards of Ethical Supply Management Conduct" (CPSM); three-way match practice as documented by Ramp, NetSuite, and AvidXchange; RFI/RFQ/RFP selection guidance from GEP, Coupa, and GSA's federal contracting terms glossary; PO vs. blanket PO vs. contract distinction per Oracle Procurement Cloud and ProcureDesk documentation. Cost-analysis trigger dollar figures are institution-dependent examples, not a universal rule — flagged as [heuristic — needs practitioner check] for which figure applies in a given organization. No direct practitioner review yet.

--- a/roles/purchasing-agent/references/playbook.md
+++ b/roles/purchasing-agent/references/playbook.md
@@ -1,0 +1,120 @@
+# Procurement execution playbook
+
+Filled templates for the five recurring purchasing-agent tasks: threshold lookup, RFQ/RFP quote scoring, three-way match reconciliation, split-purchase detection, and sole-source justification.
+
+## 1. Current dollar-threshold table (check before every buy — do not cite from memory)
+
+| Threshold | Amount (effective Oct 1, 2025 cycle) | Instrument required above this line |
+|---|---|---|
+| Micro-purchase (federal) | $15,000 | Above: competition generally required (soliciting price/rate quotes from 2+ sources) |
+| Simplified acquisition threshold (federal) | $350,000 | Above: full sealed bid / negotiated procurement procedures |
+| Davis-Bacon public-works micro-purchase ceiling | $2,000 | Above: prevailing-wage requirements attach regardless of instrument |
+| P-card single-transaction limit (org example) | $2,500 | Above: requisition + PO required, card declined by policy |
+| P-card monthly cap (org example) | $10,000 | Above: card suspended pending review, not a hard stop on the buy itself |
+| Cost/price analysis trigger (org example range) | $5,000–$9,999.99 | Above: written cost/price analysis required regardless of procurement method |
+
+Lookup procedure: (1) identify funding source — federal grant, state/local, or purely organizational; (2) pull the current table for that source, not last year's; (3) apply the org policy threshold only if it is stricter than the funding-source threshold (stricter always wins).
+
+## 2. RFQ vs. RFP selection and quote-scoring worksheet
+
+Selection rule:
+
+```
+Spec fully defined + price is the only variable      -> RFQ
+Spec has options, service-level, or approach variance -> RFP
+Requirements/supplier field still unclear             -> RFI first, then RFQ or RFP
+```
+
+**RFQ scoring (price-driven, fixed spec)** — lowest total landed cost wins unless a vendor fails a pass/fail gate:
+
+| Vendor | Unit price | Qty | Freight | Total landed cost | Lead time (bus. days) | Meets spec (Y/N) | Rank |
+|---|---|---|---|---|---|---|---|
+| Incumbent Corp | $1,150 | 22 | $0 (included) | $25,300 | 12 | Y | 1 |
+| Vendor B | $1,090 | 22 | $340 | $24,320 | 18 | Y | — (fails lead-time gate of 15 days) |
+| Vendor C | $1,205 | 22 | $0 | $26,510 | 10 | Y | 2 |
+
+Rule: a lower total landed cost is disqualified, not just down-ranked, if it fails a stated pass/fail gate (lead time, spec compliance, certification) — rank only among vendors that clear every gate.
+
+**RFP scoring (multi-criteria, weighted)** — use when quality, approach, or service level vary across bids:
+
+| Criterion | Weight | Vendor A score (1–10) | Vendor A weighted | Vendor B score (1–10) | Vendor B weighted |
+|---|---|---|---|---|---|
+| Price | 40% | 7 | 2.8 | 9 | 3.6 |
+| Technical approach | 25% | 9 | 2.25 | 6 | 1.5 |
+| Past performance | 20% | 8 | 1.6 | 7 | 1.4 |
+| Delivery schedule | 15% | 6 | 0.9 | 8 | 1.2 |
+| **Total** | 100% | — | **7.55** | — | **7.70** |
+
+Award to highest weighted total, not lowest price — document the weighting scheme in the solicitation before quotes come in, never after, to avoid a defensibility gap.
+
+## 3. Three-way match reconciliation sequence
+
+Run on every invoice before releasing payment:
+
+1. Pull PO, receiving report, and invoice side by side.
+2. Compare **quantity**: PO qty vs. receiving report qty vs. invoice qty.
+3. Compare **unit price**: PO price vs. invoice price.
+4. Compare **line items**: every invoice line traces to a PO line.
+5. If all three agree within tolerance (organization example: unit price variance ≤ $0.50 or ≤1%, whichever is greater) — release for payment.
+6. If any field disagrees beyond tolerance — **hold payment**, do not pay-and-reconcile-later, and route by likely cause:
+
+| Mismatch pattern | Most likely cause | Route to |
+|---|---|---|
+| Invoice qty > receiving report qty | Partial shipment billed as full, or receiving miscount | Receiving, to confirm actual count |
+| Invoice unit price > PO unit price | Vendor billed at list instead of negotiated rate | AP, with PO copy attached, for vendor correction |
+| Invoice missing PO reference | AP can't match without it | Return to vendor for corrected invoice, do not manually force-match |
+| Receiving report shows qty received but invoice not yet in system | Timing lag, not a true mismatch | Hold in pending queue, recheck in 5 business days before escalating |
+
+Example: PO for 22 units at $1,150 ($25,300 total); receiving report confirms 22 units received; invoice bills 22 units at $1,175 each ($25,850). Unit price variance is $25 (>1% tolerance) — hold payment, route to AP with note: "invoice unit price $1,175 vs. PO $1,150, variance $25/unit ($550 total), request corrected invoice or vendor confirmation of price change with documentation."
+
+## 4. Split-purchase detection check
+
+Run monthly against p-card statement, or immediately when two invoices from the same vendor land in the same week:
+
+```
+Flag if: same vendor + transactions within same day (or same week for invoice-based buys)
+         AND sum of transactions > single-transaction cap
+```
+
+| Vendor | Date | Amount | Card limit | Cumulative same-day/vendor total | Flag |
+|---|---|---|---|---|---|
+| Office Supply Co | 3/14 | $2,400 | $2,500 | $2,400 | No |
+| Office Supply Co | 3/14 | $2,150 | $2,500 | $4,550 | **Yes — split purchase, no exception** |
+| Tech Distributors | 3/10 | $2,300 | $2,500 | $2,300 | No |
+| Tech Distributors | 3/12 | $2,450 | $2,500 | $4,750 (same week) | **Yes — escalate, review both transactions together** |
+
+Action on flag: do not approve or process either transaction independently — combine into a single requisition retroactively reviewed against the correct threshold and document the finding (no-exception rule per SKILL.md's Mental models).
+
+## 5. Sole-source / single-quote justification memo template
+
+Use only when one of the four conditions is met — fill the template with the actual condition cited, not a paraphrase of vendor preference:
+
+```
+Requisition #: <ID>
+Vendor: <name>          Amount: <$>
+Condition claimed (check exactly one):
+  [ ] (a) Item available from only one source — attach market-scan evidence
+  [ ] (b) Public exigency/emergency — attach dated description of the exigency
+  [ ] (c) Funding agency authorized noncompetitive procurement in writing — attach authorization
+  [ ] (d) Competition solicited in good faith and failed — attach solicitation record and no-bid/no-response documentation
+Cost/price analysis attached (required if amount > org trigger): <yes/no, attach>
+Approving official: <name, title>
+```
+
+Reject-and-return trigger: if none of (a)–(d) is checked with attached evidence, the requisition is not sole-source — reroute to RFQ/RFP per Section 2 regardless of the requester's stated preference.
+
+## 6. Maverick-spend / on-contract logging
+
+Log every completed transaction against the running compliance rate:
+
+```
+Running off-contract rate = (off-contract $ this period) ÷ (total procurement $ this period)
+```
+
+| Threshold | Status |
+|---|---|
+| < 5% | In control — no action |
+| 5%–20% | Investigate which categories are drifting off-contract, flag to purchasing manager |
+| > 20% | Contract compliance program is not functioning — escalate as a program-level finding, not a transaction-level one |
+
+Compare against the reported cross-organization average of ~59.5% off-contract compliance (i.e., ~40.5% on-contract) as a reality check: if your own off-contract rate isn't being tracked at all, assume it is closer to the average than to the <5% benchmark until measured.

--- a/roles/purchasing-agent/references/red-flags.md
+++ b/roles/purchasing-agent/references/red-flags.md
@@ -1,0 +1,63 @@
+# Red flags — what a purchasing agent checks reflexively
+
+Smell tests with thresholds. Any one can be innocent; two or three together on the same requisition is a pattern worth escalating even below a mandatory referral trigger.
+
+### Same vendor, two or more invoices in the same 5 business days, summing above the card single-transaction limit
+- **Usually means:** a split purchase engineered (or backed into unintentionally) to keep each transaction under the P-card cap, rather than one requisition routed through the proper threshold.
+- **First question:** "Why weren't these combined into a single PO before purchase?"
+- **Data to pull:** P-card statement filtered by vendor and cardholder for the billing cycle, requisition history for the same vendor/department in the prior 30 days.
+
+### Requisition cover note says "sole source" with no competing quotes attached and spend over $10,000
+- **Usually means:** vendor familiarity or standardization preference dressed up as one of the four valid 2 CFR 200 conditions, when no genuine attempt to solicit alternatives occurred.
+- **First question:** "Which of the four sole-source conditions applies here, specifically?"
+- **Data to pull:** sole-source justification memo, market-research or vendor-search log (if any), prior awards to this vendor for the same category.
+
+### PO issued citing a master agreement or contract number with no separate release or line-item authorization
+- **Usually means:** the SKILL.md First-principles #2 error in the wild — contract-as-authorization instead of an instrument that actually obligates funds.
+- **First question:** "Is this PO drawing against an active blanket release, or is the contract itself being treated as the authorization?"
+- **Data to pull:** the master agreement's release mechanism clause, current blanket PO balance and expiration, this PO's line-item detail.
+
+### Invoice quantity or unit price differs from the PO by any amount and payment is due within 3 days
+- **Usually means:** AP is under deadline pressure to clear the payment cycle — the three-way-match hold discipline from SKILL.md's Mental models failing under a deadline.
+- **First question:** "Has this mismatch been traced to receiving, pricing, or a data-entry error before we pay it?"
+- **Data to pull:** PO line items, receiving report, vendor invoice, side-by-side field comparison (quantity, unit price, PO reference number).
+
+### Procurement method selected is RFQ (price-only) for a purchase with no fixed spec sheet
+- **Usually means:** the buyer defaulted to the faster instrument without confirming the requirement is standardized enough for price to be the sole deciding factor, likely to produce quotes that aren't comparable.
+- **First question:** "Is the spec fixed enough that three vendors would quote on the identical item, or does this need an RFP?"
+- **Data to pull:** the requisition's spec sheet or statement of work, comparable past buys in this category and which instrument they used.
+
+### Cumulative departmental spend with one vendor crosses the simplified-acquisition or organizational competitive-bid threshold mid-fiscal-year with no aggregate tracking
+- **Usually means:** individual POs were each authorized correctly on their own, but nobody rolled up the running total against the vendor, so the threshold was crossed without triggering the required competitive process.
+- **First question:** "What's this vendor's year-to-date cumulative spend across all departments, not just this PO?"
+- **Data to pull:** vendor-level spend report across all cost centers for the fiscal year, threshold table currently in effect.
+
+### Requisition references a "qualified purchasing agent" no-bid exemption without confirming the approver's designation status
+- **Usually means:** the First-principles #3 error — an elevated no-bid authority assumed from informal seniority or role title rather than an actual statutory appointment.
+- **First question:** "Is the approving agent formally designated under this jurisdiction's statute, or assumed to be?"
+- **Data to pull:** the jurisdiction's qualified-purchasing-agent designation record, the specific statute's threshold for the exemption.
+
+### Off-contract (maverick) spend in a category exceeds roughly 20% of that category's total volume this quarter
+- **Usually means:** a negotiated contract exists but isn't being used as the default purchasing path, either because it isn't visible to requesters or because a preferred non-contract vendor is being routed around it.
+- **First question:** "Why are requisitions in this category not defaulting to the negotiated contract vendor?"
+- **Data to pull:** category-level contract-compliance report (on-contract vs. off-contract spend), list of non-contract vendors used and requester justification if any.
+
+### Vendor invoice unit price exceeds the negotiated contract rate by any margin, on a contract PO
+- **Usually means:** a price increase was applied by the vendor without a corresponding contract amendment, or the wrong price list/version was used when cutting the PO.
+- **First question:** "Does the vendor's invoiced rate match the currently executed contract amendment, or an earlier one?"
+- **Data to pull:** current contract pricing schedule with amendment history, PO unit price, invoice unit price.
+
+### Gift, meal, or event invitation from a vendor arrives while their quote is under active evaluation
+- **Usually means:** the appearance-of-influence standard (Mental models bullet 6) is triggered here regardless of whether the buyer's judgment actually changed.
+- **First question:** "Would a reasonable outside observer see this as capable of influencing the award, regardless of intent?"
+- **Data to pull:** organization's gift/ethics policy threshold, timing of the gift relative to the RFQ/RFP evaluation window, current status of that vendor's bid.
+
+### Sole-source cost/price analysis missing on a requisition above the organization's own trigger dollar amount
+- **Usually means:** the buyer applied a remembered threshold from a different funding source or a prior policy version instead of checking the one that governs this purchase's actual funding source.
+- **First question:** "Which policy's trigger amount governs this requisition's funding source, and is this figure current?"
+- **Data to pull:** current organizational procurement policy threshold table, funding source designation on the requisition (federal grant vs. general fund vs. other).
+
+### Receiving report logged but no corresponding invoice after 45+ days
+- **Usually means:** either the vendor hasn't billed yet (routine) or goods were received against a PO that's since been closed or modified, leaving an open obligation nobody is tracking toward resolution.
+- **First question:** "Is this PO still open, and has the vendor been contacted about the missing invoice?"
+- **Data to pull:** PO status (open/closed) in the ERP, receiving report date, vendor billing history and standard invoice lag for this vendor.

--- a/roles/purchasing-agent/references/vocabulary.md
+++ b/roles/purchasing-agent/references/vocabulary.md
@@ -1,0 +1,68 @@
+# Vocabulary — terms of art generalists misuse
+
+Not a glossary of lookup-able definitions. These are terms a generalist has heard and will use confidently in the wrong situation — each entry exists because the misuse, not the definition, is the recurring failure.
+
+**Blanket purchase agreement (BPA) / blanket release**
+A standing agreement that locks price and terms with a vendor for recurring, not-yet-scheduled needs, drawn down by individual releases as the need arises — one of the three instruments distinguished in the "Blanket PO vs. one-time PO vs. contract" entry below.
+- *In use:* "We have a BPA with this office-supply vendor at $4.50/case — cut a release for this month's order, not a new PO from scratch."
+- *Misuse:* Citing the BPA number on an invoice with no release/line-item tied to it is the contract-as-authorization error (SKILL.md First-principles #2) applied to this specific instrument.
+
+**Simplified acquisition threshold (SAT)**
+The federal dollar ceiling below which agencies may use streamlined, less-than-full-competition procurement procedures instead of sealed bidding or full negotiated procurement.
+- *In use:* "This buy is $180K — under the $350K SAT, so we can use simplified procedures instead of a formal solicitation."
+- *Misuse:* Treated as a fixed number instead of a value that resets on a schedule (current figure and adjustment history in SKILL.md First-principles #1). Citing last cycle's figure from memory is applying a rule that no longer exists.
+
+**Micro-purchase threshold**
+The dollar ceiling below which a purchase can be made without soliciting competitive quotes at all — the lowest tier of procurement, typically via card.
+- *In use:* "$8,400 is under the $15,000 micro-purchase threshold, so a P-card buy with no quotes is fine."
+- *Misuse:* Conflated with the P-card's own single-transaction limit, which is a separate, organization-set number (often much lower, e.g. $2,500) layered underneath the federal threshold. A buy can be under the micro-purchase threshold and still be barred by the card program's own cap — checking one and not the other is a common gap.
+
+**Sole source (noncompetitive procurement)**
+A procurement made without competitive bidding, justifiable only under the four conditions enumerated in SKILL.md First-principles #4 — not a label for "we prefer this vendor."
+- *In use:* "This doesn't qualify as sole source — vendor standardization isn't one of the four conditions, so it needs to go out for competitive quotes."
+- *Misuse:* The single most common misuse in the role: writing "sole source" on a requisition to describe vendor familiarity, past relationship, or convenience. The justification memo doesn't become valid with better phrasing — it needs an actual condition checked and evidenced.
+
+**Three-way match**
+The reconciliation of purchase order, receiving report, and vendor invoice before payment is released — checking quantity, unit price, and line items agree across all three documents.
+- *In use:* "Three-way match failed on unit price — PO says $1,150, invoice says $1,175 — hold payment and route to AP."
+- *Misuse:* Generalists assume a "close enough" match (off by a few dollars, or a missing PO reference) is a rounding error to wave through under payment-cycle deadline pressure — the hold-until-resolved discipline covered in SKILL.md's Mental models.
+
+**Maverick spend (off-contract spend)**
+Purchases made outside an existing negotiated contract, even when the purchase itself is otherwise properly authorized and paid.
+- *In use:* "Off-contract spend in office supplies is running 28% this quarter — that's a program-level compliance finding, not a one-off."
+- *Misuse:* Assumed to mean something improper or unauthorized happened. It doesn't necessarily — a fully legitimate, correctly-approved PO can still be maverick spend if it bypasses a contract that was available and should have been used. The metric is about contract-utilization discipline, not about catching fraud.
+
+**Split purchase**
+Breaking what should be one purchase into multiple smaller transactions, same vendor and overlapping dates, specifically to keep each one under a per-transaction dollar cap.
+- *In use:* "Two invoices from the same vendor, same week, summing to $4,550 against a $2,500 card limit — that's a split purchase, no exception, regardless of whether it was intentional."
+- *Misuse:* Generalists look for evidence of *intent* to game the limit before flagging it. Per SKILL.md's Mental models, the rule doesn't require proving intent — same vendor, overlapping timeframe, cumulative sum over the cap gets flagged either way.
+
+**RFQ vs. RFP**
+Request for Quotation (price is the only variable, spec is fully fixed) versus Request for Proposal (quality, technical approach, or service level must be evaluated alongside price).
+- *In use:* "22 identical laptops, make and model already specified — that's an RFQ, not an RFP; there's nothing to evaluate but price and lead time."
+- *Misuse:* Used interchangeably as "the bid process" by generalists. Running an RFQ on a purchase with no fixed spec produces quotes that aren't actually comparable (vendors quote different things); running a full RFP on a routine, well-specified re-buy adds weeks of unnecessary evaluation to a purchase the market already prices cleanly.
+
+**Qualified purchasing agent (QPA)**
+A formal statutory designation (jurisdiction-specific, e.g. under certain state local-contracts laws) that grants an individual — not a role or seniority level — an elevated no-bid purchase authority.
+- *In use:* "Is the approving agent formally designated QPA under this jurisdiction's statute, or is that being assumed from their title?"
+- *Misuse:* Assumed to transfer with seniority or job title (see SKILL.md First-principles #3) — an informal "I've been doing this 15 years" does not carry the statutory weight of an actual QPA appointment in that specific jurisdiction.
+
+**P-card single-transaction limit vs. monthly cap**
+Two distinct P-card controls: a per-transaction dollar ceiling (above which the card is declined/prohibited by policy) and a separate cumulative monthly ceiling (above which the card is suspended pending review).
+- *In use:* "This is $2,300 — under the $2,500 single-transaction limit — but it's her ninth card purchase this month, check the monthly cap before approving another."
+- *Misuse:* Treated as one number. A transaction can individually clear the single-transaction limit while still tripping the monthly cap, and clearing both still doesn't clear split-purchase exposure if the same-vendor/same-period pattern is present.
+
+**Cost/price analysis**
+A written analysis justifying that a quoted or sole-sourced price is fair and reasonable, required once a purchase crosses an organization- or funding-source-specific dollar trigger — separate from, and required in addition to, the sole-source justification itself.
+- *In use:* "At $25,300 this is well above our $9,999.99 cost-analysis trigger — the sole-source memo alone isn't sufficient, a written price analysis has to be attached too."
+- *Misuse:* Assumed to be the same document as the sole-source justification, or assumed to have one universal trigger dollar amount — the trigger is institution- and funding-source-dependent (see SKILL.md's Mental models for the general range vs. this organization's instantiated figure). Using a remembered figure from a different organization or grant is applying the wrong rule to this purchase.
+
+**Blanket PO vs. one-time PO vs. contract**
+Three distinct instruments: a contract sets negotiated terms, a one-time PO obligates funds for a single fully-specified buy, and a blanket PO obligates funds against a recurring need where price is locked but exact delivery timing isn't yet fixed. (See SKILL.md First-principles #2 for why only the PO/release side of this actually commits dollars.)
+- *In use:* "We don't need a new one-time PO — issue a release against the existing blanket PO, the price and vendor are already locked."
+- *Misuse:* Generalists use "PO" and "contract" interchangeably, picking the wrong one of the three when scoping a new buy — e.g. drafting a fresh one-time PO for a need a blanket release already covers, or vice versa.
+
+**Appearance-of-influence standard**
+The ethics test applied to gifts, meals, or hospitality from a vendor — judged on whether a reasonable outside observer could see it as *capable* of influencing the award, not on whether it actually changed the buyer's decision.
+- *In use:* "Decline the dinner invitation while their RFP is under evaluation — it doesn't matter that it wouldn't change my scoring, it fails the appearance test."
+- *Misuse:* Generalists defend accepting a gift by reasoning "it didn't actually affect my decision" — the wrong-question error named in SKILL.md's Mental models (the ISM/CPSM standard is written to appearance, not actual effect).


### PR DESCRIPTION
Rubric score: 18/18

## Resolution rationale

purchasing-manager's Decision framework, Tools & methods, and Worked example all sit at the department/category-strategy altitude: Kraljic-matrix category segmentation, SRM systems tracking supplier relationships over time, single- vs multi-source policy decisions, and negotiating org-level supplier contracts with failure-scenario terms — decisions a purchasing agent (O*NET 13-1023.00) does not make. A Purchasing Agent's actual job is transactional/tactical: soliciting and comparing bids/quotes against a spec for a specific purchase, negotiating price/delivery/terms on that PO within a defined authority limit, verifying vendor compliance with contract specs, expediting/tracking open orders, and resolving invoice-vs-PO discrepancies — day-to-day execution against policies the manager already set, not the sourcing-strategy or supplier-risk-program decisions purchasing-manager's framework addresses. A practitioner given a concrete agent task ('evaluate these three vendor quotes against spec and issue the PO' or 'this delivery came in short, what do I do against the PO terms') would get manager-altitude non-answers (TCO modeling, Kraljic segmentation, ongoing SRM risk monitoring) rather than the tactical bid-evaluation/PO-management guidance the task needs — a real decision-framework and tool mismatch, not just less detail. purchasing-manager is a reasonable parent since the agent role is a tactical specialization/subordinate function of the same purchasing domain, so new_leaf under purchasing-manager rather than new_parent. Slug 'purchasing-agent' follows the existing '<role>-manager' sibling-naming convention in roles/ (no existing buyer/procurement/agent slug found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the `purchasing-agent` role to cover procurement execution (threshold checks, RFQ/RFP selection, three-way match, split-purchase detection, sole-source justification). Updates counts and roadmap to reflect 110 total roles and expanded coverage in operations.

- **New Features**
  - Added `roles/purchasing-agent/SKILL.md` (spec 2, O*NET `13-1023.00`) with references: `playbook.md`, `red-flags.md`, `vocabulary.md`.
  - Registered the role in `data/roles.json` and updated `README.md` and `ROADMAP.md` (role listed as drafted; operations count increased).
  - Included practical templates and checks for quote scoring, three-way match reconciliation, split-purchase flags, and sole-source memos.

<sup>Written for commit 97cd4050ae43fc8c9a798bd2cd4e5c5f3ef69c41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

