### PR TITLE
role: add talent-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**118 roles drafted** (114 mapped to an O*NET occupation, 4 custom; 76 at spec 2, 42 awaiting upgrade), across 10 categories:
+**119 roles drafted** (115 mapped to an O*NET occupation, 4 custom; 77 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `██░░░░░░░░░░░░░░░░░░` 11.2% (114 / 1,016 occupations)
+**O\*NET coverage:** `██░░░░░░░░░░░░░░░░░░` 11.3% (115 / 1,016 occupations)
 
 - **design**: 3
 - **engineering**: 17
@@ -207,7 +207,7 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 - **legal**: 11
 - **marketing**: 4
 - **operations**: 48
-- **other**: 6
+- **other**: 7
 - **product**: 1
 - **sales**: 5
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 114 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 115 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -78,11 +78,11 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>13 — Business and Financial Operations</strong> (20/50 drafted)</summary>
+<summary><strong>13 — Business and Financial Operations</strong> (21/50 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
-|  | 13-1011.00 | Agents and Business Managers of Artists, Performers, and Athletes |  |
+| ✅ | 13-1011.00 | Agents and Business Managers of Artists, Performers, and Athletes | [`talent-agent`](./roles/talent-agent/SKILL.md) |
 |  | 13-1021.00 | Buyers and Purchasing Agents, Farm Products |  |
 |  | 13-1022.00 | Wholesale and Retail Buyers, Except Farm Products |  |
 | ✅ | 13-1023.00 | Purchasing Agents, Except Wholesale, Retail, and Farm Products | [`purchasing-agent`](./roles/purchasing-agent/SKILL.md) |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 118,
+  "count": 119,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -1779,6 +1779,24 @@
       "audit_score": null,
       "skill": "roles/supply-chain-manager/SKILL.md",
       "references": []
+    },
+    {
+      "slug": "talent-agent",
+      "description": "Use when a task needs the judgment of a talent agent or business manager for artists, performers, or athletes \u2014 negotiating a representation or performance contract, structuring commission on a deal, checking whether a procurement act crosses into licensed-agent territory, tracking a contract's termination/renewal clock, or flagging a conflict-of-interest in how the agency gets paid.",
+      "category": "other",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "13-1011.00",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/talent-agent/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ]
     },
     {
       "slug": "tax-preparer",

--- a/roles/talent-agent/SKILL.md
+++ b/roles/talent-agent/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: talent-agent
+description: Use when a task needs the judgment of a talent agent or business manager for artists, performers, or athletes — negotiating a representation or performance contract, structuring commission on a deal, checking whether a procurement act crosses into licensed-agent territory, tracking a contract's termination/renewal clock, or flagging a conflict-of-interest in how the agency gets paid.
+metadata:
+  category: other
+  maturity: draft
+  spec: 2
+  onet_soc_code: "13-1011.00"
+---
+
+# Talent Agent / Business Manager
+
+## Identity
+
+Typically runs a roster of 3–30 clients within a single vertical (film/TV, music touring, professional sports, or publishing) because the regulatory regime, commission caps, and buyer relationships in each vertical are different enough that cross-vertical generalism is a liability, not a strength. Paid on commission out of the client's earnings — which means the single defining tension of the job is structural: the agent's fiduciary duty runs to the client, but in several common deal structures (packaging fees, dual-payer arrangements, non-refundable up-front fees) the agent's own payday is easiest to maximize by *not* maximizing the client's.
+
+## First-principles core
+
+1. **"Agent" vs. "manager" is a legal line, not a job-title choice.** Under California's Talent Agencies Act, "procuring, offering, promising, or attempting to procure employment" is the licensable act — broadly interpreted to include negotiating deal terms, not just cold-soliciting — and a personal manager who crosses it without a license has historically had the resulting contract voided retroactively under the illegal-agent doctrine. The manager/agent distinction is a compliance boundary with real teeth, not a matter of preference.
+2. **Whoever the money passes through first owns the conflict.** A commission calculated as a percentage of the client's pay aligns the agent with the client; a packaging fee, endorsement override, or dual client-and-buyer fee paid *around* the client's pay does not. The WGA's 2019 mass firing of 7,000+ agents happened because packaging fees (paid by the studio, including up to 10% of a show's future profits) let agencies profit from keeping the writer's episodic fee low — same budget pool, opposite incentive.
+3. **Registration and certification thresholds are numeric gates that decide whether a deal is even valid, not paperwork.** NBPA and NFLPA agent certification, CA talent agency licensure, and UAAA athlete-agent registration all carry specific fees, deadlines, and grace periods; missing one doesn't just risk a fine, it can retroactively unwind the representation.
+4. **Termination and renewal clocks are the real leverage in an ongoing deal, not the headline commission rate.** SAG-AFTRA's Rule 16(g) inactivity-termination test — after the first 151 days of a TV/theatrical contract, the artist can terminate if the preceding 91 days show fewer than 10 days of work (commercials: under $4,000 earned in 91 days) — is a clock every agent on that roster should be tracking before the client ever thinks to ask about it.
+5. **Commission caps are ceilings the market rarely charges.** A regulated maximum (e.g., NBPA's 4% of pay above the minimum) bounds what's legal, not what's competitive — see the cap-vs-market heuristic below for the actionable form and the specific gap size.
+
+## Mental models & heuristics
+
+- **"Scale plus 10":** because SAG-AFTRA commission (up to 10%) comes out of the performer's wage, negotiate the base fee above scale specifically so the commission doesn't eat into the guaranteed minimum — the fee negotiation and the commission structure are one negotiation, not two.
+- **When a termination-inactivity clock is within 30 days of tripping, default to securing any bona fide offer before the deadline** — a bona fide offer in the first 120 days resets the full 151-day clock regardless of activity since, so timing an offer is a legitimate lever, not just a compliance date to track.
+- **When the buyer pays the agency directly (packaging, franchise fee, dual agency-and-client fee), default to disclosing the arrangement and modeling the client's outcome as if the agent were unpaid by them** — if the recommendation changes once the agent's side-payment is removed from the model, the conflict is real, not theoretical.
+- **Cap-vs-market gap as a pricing signal:** when a regulated cap exists (NBPA 4%, SAG-AFTRA 10%), default to quoting the market rate below the cap (NBPA ≈3%) unless the client's leverage or the deal's complexity genuinely justifies charging up to the ceiling.
+- **Upfront fees are close to a categorical red flag, not a negotiable term.** Literary and modeling agencies are paid from the client's proceeds, never before them; a "reading fee," "administrative fee," or recurring retainer charged ahead of any placement is a scam pattern in both verticals, not an aggressive-but-legitimate business model.
+- **Tiered commission by leverage, not by effort alone:** live-booking commission runs 15–20% for emerging artists (more agent effort per booking) and compresses to 10–12% for established, high-demand acts — when a client's demand curve shifts, default to renegotiating the rate down rather than treating the original rate as fixed for the relationship's life.
+- **The unregulated recording-contract carve-out is a known loophole, not an oversight.** Procuring a recording contract specifically does not, by itself, trigger CA talent-agency licensure — personal managers in music route through this gap deliberately, and knowing it exists changes how you evaluate whether a given manager's activity is compliant.
+
+## Decision framework
+
+1. **Identify the governing regime before anything else.** Entertainment (state talent-agency statute + guild rules), pro sports (league players'-association certification + state UAAA/RUAAA registration), music touring, publishing, and modeling each have different licensing bodies, commission caps, and voidability risk — the same negotiating action can be routine in one vertical and unlicensed procurement in another.
+2. **Confirm registration/license status and any live grace-period clock** before making or accepting an offer on the client's behalf; under UAAA, contact initiated by the athlete grants a narrow exception to act (short of signing the agency contract) only if registration is filed within 7 days.
+3. **Map every payment flow in the deal**, not just the headline commission: who pays the agency, does any payment come from the buyer's side (packaging, referral, dual fee), and does the fee schedule change if the client's earnings change.
+4. **Check the deal against every live contractual clock** — termination-for-inactivity windows, renewal deadlines, certification renewal dates — before negotiating new terms, since a lapsed clock changes who has leverage in the room.
+5. **Negotiate the wage floor and the commission mechanic together**, not sequentially, so the commission doesn't erode a nominal increase in pay.
+6. **Rank concessions by which protect the client's downside** (termination rights, payment timing, credit/billing) over which protect the agent's convenience, and lead negotiation capital with the former.
+7. **Document the fee structure and any dual-payer arrangement in writing before signing**, since an undisclosed conflict discovered later is the fastest way to lose a client and, in several jurisdictions, a license.
+
+## Tools & methods
+
+- **Filed agency contract form** approved by the relevant state labor commissioner (required in CA before use; approval can be withheld only if the contract is "unfair, unjust and oppressive to the artist").
+- **Contract-clock tracker** for termination-for-inactivity windows, certification renewal dates (NBPA: July 1 plus a mid-year payment; NFLPA: annual), and registration expirations (state UAAA registrations commonly run on a fixed multi-year cycle).
+- **Deal memo** quoting gross deal value, commission mechanic, and any buyer-side payments before the client signs anything.
+- **Commission ledger** reconciling every payment against the applicable cap and the disclosed rate, per client, per deal.
+- **Background/licensing file**: fingerprint or background-check clearance, surety bond proof (CA requires $50,000), and current certification proof, kept current per governing body rather than assembled reactively when challenged.
+
+## Communication style
+
+With the client: plain about what the agency is paid and by whom, including any arrangement where a buyer pays the agency directly — the client should never learn about a packaging-style fee from someone else. Distinguishes a real offer from a courtesy call clearly and early, since false hope on a marginal opportunity costs trust. With buyers (studios, teams, publishers, promoters): opens on the client's value and availability, never the fee ask — commission structure is never the buyer's concern. In deal memos and renewal discussions: numbers first — gross value, commission rate against the applicable cap, net to client — the narrative around the deal comes after the arithmetic, not instead of it.
+
+## Common failure modes
+
+- **Personal managers unknowingly crossing into procurement** by treating "just relaying the studio's number" or "helping as a friend" as informal advice rather than negotiation — the illegal-agent doctrine (principle 1) doesn't care about the manager's intent, only whether a deal term was negotiated without a license.
+- **Overcorrecting into refusing any career-adjacent advice** for fear of "procuring," which guts the value the client is paying for; the actual line is procuring or negotiating *employment*, not giving general career guidance.
+- **Quoting the regulatory cap as the price** instead of applying the cap-vs-market heuristic above — a retention risk once the client compares notes and finds the agent priced at the ceiling.
+- **Missing a packaging-style or dual-payer conflict** because the payment arrives from the buyer's side and never crosses the client's own ledger, so it never gets modeled as a cost to the client.
+- **Letting a termination-for-inactivity clock lapse unnoticed**, handing the client (or a competing agent) a clean exit exactly when the relationship needs renewing instead of ending.
+- **Letting a certification or registration renewal slide past its deadline "for now"** on the assumption it's a paperwork catch-up, rather than tracking it as a live clock alongside termination windows (decision framework, step 4) — the risk is the same retroactive unwind described in principle 3, not a lesser, administrative-only version of it.
+
+## Worked example
+
+**Client:** a second-year professional basketball player signs a one-season contract at a **$5,000,000** salary; the league's rookie/minimum-scale threshold for this analysis is **$1,000,000** (illustrative, rounded figure consistent with NBPA's minimum-based cap structure, not a specific season's published minimum). The player also signs a regional endorsement deal worth **$500,000** for the season.
+
+**Naive read (junior agent):** "NBPA caps commission at 4%, so I'm entitled to 4% of the $5,000,000 contract: $200,000, plus 15% of the $500,000 endorsement: $75,000. Total: $275,000."
+
+**Expert correction:**
+1. The NBPA cap applies to **compensation above the minimum**, not the full contract — the commissionable base is $5,000,000 − $1,000,000 = **$4,000,000**, not $5,000,000.
+2. The cap (4%) is the ceiling, not the going rate; the commonly-charged market rate for an established agency is **3%**. Quoting the cap on a second-year player with market interest from competing agents overprices the service and invites a switch at renewal.
+3. Endorsement/marketing commission sits outside the on-contract cap entirely and is priced separately in the 10–20% range; 15% is a reasonable mid-range figure for a regional (non-national) deal, not a number that needs to justify itself against the playing-contract cap.
+4. Applying the 4% ceiling instead of the 3% market rate on the contract commission alone overstates the agent's take by $40,000 relative to competitive market pricing — the gap between "compliant" and "competitive" on this one deal.
+
+**Reconciled numbers:**
+- Contract commission base: $5,000,000 − $1,000,000 = $4,000,000
+- Contract commission at market rate: $4,000,000 × 3% = **$120,000** (cap ceiling would have been $4,000,000 × 4% = $160,000)
+- Endorsement commission: $500,000 × 15% = **$75,000**
+- **Total agent commission: $195,000**, against total client earnings of $5,500,000 — an effective blended rate of **3.5%**, below both individual caps and defensible against either regulator on request.
+
+**Deliverable — commission ledger line sent to the client's business manager:**
+
+> Player Contract (Season): Gross $5,000,000 | Minimum threshold $1,000,000 | Commissionable base $4,000,000 | Rate 3.0% (NBPA cap 4.0%, not applied) | Commission $120,000
+> Regional Endorsement: Gross $500,000 | Rate 15.0% | Commission $75,000
+> **Total commission $195,000 | Blended effective rate 3.5% of total earnings $5,500,000**
+
+## Going deeper
+
+- [references/playbook.md](references/playbook.md) — load when structuring a specific deal: commission mechanics by vertical, negotiation fallback ladders, and clock-tracking templates.
+- [references/red-flags.md](references/red-flags.md) — load when vetting a prospective agent, manager, or deal structure for conflict-of-interest or licensing exposure.
+- [references/vocabulary.md](references/vocabulary.md) — load when a term of art (packaging, franchise, procurement, scale-plus-10) needs a precise, misuse-aware definition.
+
+## Sources
+
+- California Labor Code §1700 et seq. (Talent Agencies Act) and DLSE, "Laws Relating to Talent Agencies" (2025 rev.) — licensing threshold, $250 fee, $50,000 bond, recording-contract carve-out, illegal-agent doctrine.
+- SAG-AFTRA Rule 16(g) agency regulations and franchise-agency FAQ — 10%/20% commission caps, "scale plus 10," 151-day/91-day/120-day inactivity-termination test.
+- WGA vs. major talent agencies packaging-fee campaign, 2019–2022 (Deadline, Hollywood Reporter, escholarship.org fiduciary-duty analysis) — 7,000+ member mass firing, packaging-fee mechanics, four fiduciary duties (loyalty, conflict avoidance, no adverse action, no commingling), TV writer pay decline 2014–2016, full sunset July 1, 2022.
+- NFLPA Regulations Governing Contract Advisors — $2,500 application fee, education/7-year-experience alternative path, tiered $1,500/$2,000 annual certification fee.
+- NBPA Regulations Governing Player Agents — 4%/2% commission caps, 10–20% endorsement commission, $2,500 + $2,500 certification fee structure.
+- Uniform Athlete Agents Act / Revised UAAA (state adoptions, e.g., Connecticut, Texas, Nevada) — registration requirement, 7-day athlete-initiated grace period, example state fee.
+- Sports Illustrated, "Confessions of an Agent" (George Dohrmann, Oct. 2010) — Josh Luchs improper-payment case; illustrative of the enforcement stakes around unlicensed/improper procurement, not a technical procedural source.
+- Publishing- and modeling-industry trade consensus (aggregate trade guides, not a single named text) — 15%/20% domestic vs. foreign-rights commission convention, no-upfront-fee norm, 15–20% modeling commission with >25% flagged as outside industry norms. [heuristic — needs practitioner check: exact commission percentages are trade-consensus figures, not confirmed against a single authoritative text]
+- Live-music booking-agent trade guides (rem.fan, pricinglink.com) — 10–20% touring commission, tiering by artist demand level. [heuristic — needs practitioner check]
+
+Not reviewed by a licensed talent agent or attorney — flag corrections via PR.

--- a/roles/talent-agent/references/playbook.md
+++ b/roles/talent-agent/references/playbook.md
@@ -1,0 +1,95 @@
+# Playbook
+
+Deal-structuring templates a working agent actually fills in, per vertical, with a clock-tracking system and negotiation fallback ladders. Adapt the numbers to the governing regime in play; the structures don't change.
+
+## 1. Commission mechanics by vertical
+
+| Vertical | Governing regime | Commission base | Cap | Market rate (typical) | Notes |
+|---|---|---|---|---|---|
+| Film/TV acting | SAG-AFTRA franchise agreement | Gross compensation | 10% | 10% (rarely discounted) | Commission taken *after* scale is cleared; see §3 "scale plus 10." |
+| TV writing (packaged) | WGA + studio | Episodic writer fee | N/A (packaging replaces commission) | 0% direct + up to 10% of show profits via packaging | Post-2022 WGA Code of Conduct restricts packaging; confirm current signatory status before assuming this model applies. |
+| Pro basketball (NBPA) | NBPA Regulations | Compensation above rookie/minimum scale | 4% | 3% | Endorsement/marketing commission priced separately, 10–20%. |
+| Pro football (NFLPA) | NFLPA Regulations | Full contract compensation | 3% | 2–3% | Certification fee $2,500 initial + tiered $1,500–$2,000 annual. |
+| Music touring (live booking) | Trade convention, no statutory cap | Gross performance fee | N/A | 15–20% emerging artist; 10–12% established/high-demand | Renegotiate down as an artist's draw grows — see §2 ladder. |
+| Publishing (literary) | Trade convention, no statutory cap | Advance + royalties | N/A | 15% domestic, 20% foreign/subsidiary rights | Never an upfront fee; commission only on money actually placed. |
+| Modeling | Trade convention, no statutory cap | Booking fee | N/A | 15–20% | >25% or any upfront "portfolio fee" is outside industry norms — treat as a red flag, not a negotiable term. |
+
+**Reading the table:** the cap and the market rate are two different numbers on purpose (Principle 5). Quote market rate by default; only move toward the cap when the client's leverage or deal complexity specifically justifies it, and say why in the deal memo.
+
+## 2. Negotiation fallback ladder
+
+Prepare every negotiation with a ranked concession order *before* the call, not improvised live. Template (filled for a touring deal):
+
+```
+DEAL: Regional tour support slot, 12 dates
+ANCHOR ASK: $8,000/night guarantee + 15% backend above $12,000 gate
+FALLBACK 1 (if guarantee resisted): $6,500/night guarantee + 20% backend above $10,000 gate
+FALLBACK 2 (if backend resisted): $6,500/night guarantee, no backend, but promoter covers
+  ground transport + 2 comp hotel rooms/night
+FALLBACK 3 (walk-away floor): $5,000/night guarantee flat — below this, dates cost the
+  artist money once crew payroll is netted out; walk.
+NEVER TRADE: backline/rider safety terms, billing position on the marquee, payment timing
+  (50% deposit at signing, balance day-of — not "net 30 after the show").
+```
+
+**Ranking rule (Decision framework step 6):** client-downside protections (payment timing, termination rights, billing/credit) rank above agent-convenience terms (marketing support, meet-and-greet logistics) in every ladder — the walk-away floor is set by the client's economics, never the agent's commission.
+
+## 3. "Scale plus 10" worked structure
+
+For a SAG-AFTRA principal role at scale of $1,100/day:
+
+1. Negotiate the base fee first, ignoring commission: target $1,500/day (36% above scale).
+2. Commission (10%) comes out of the $1,500, not added on top: agent take = $150/day, client net = $1,350/day.
+3. Compare client net ($1,350) against scale ($1,100): the client is still 23% ahead of bare scale after commission — the negotiation target has to clear scale by enough that the commission doesn't erase the gain.
+4. **Floor check:** if the best obtainable fee is $1,210/day, commission ($121) leaves the client at $1,089/day — *below* scale net of commission. At this floor, either push for a commission waiver on this booking or decline the booking; taking it as written costs the client money relative to working at scale with no agent.
+
+## 4. Contract-clock tracker (template, filled)
+
+One row per active client contract. Review weekly; anything inside 30 days of a threshold gets flagged in bold.
+
+| Client | Contract type | Start date | Clock | Threshold | Days elapsed / remaining | Status |
+|---|---|---|---|---|---|---|
+| A. Reyes | SAG-AFTRA TV holding deal | Jan 15 | 151-day inactivity test | 10 days worked in trailing 91 | Day 138 / 13 remaining | **Flag — offer needed by day 151** |
+| A. Reyes | Same | — | 120-day reset window | bona fide offer resets clock | Day 138 / 0 remaining if no offer lands | **Escalate to buyers this week** |
+| B. Chen | NBPA player contract | July 1 | Certification renewal | annual, due July 1 | Renewed | OK |
+| C. Okafor | UAAA state registration (TX) | — | Multi-year registration cycle | check state-specific expiry | 14 months remaining | OK |
+| D. Silva | Literary option | Mar 1 | 12-month option period | renew or lapse | Day 340 / 25 remaining | **Flag — confirm renewal or let lapse deliberately** |
+
+**Rule:** any row inside 30 days of its threshold gets a named next action in this table, not just a highlighted cell — "flagged" without an action is the same as untracked.
+
+## 5. Deal memo template (filled)
+
+```
+DEAL MEMO — [Client Name] / [Buyer/Studio/Promoter]
+Date: [date]                          Agent: [name]
+
+DEAL TYPE: [e.g., single-episode guest star, one-season endorsement]
+GROSS VALUE: $[amount]
+COMMISSIONABLE BASE: $[amount] (state any exclusion, e.g. "above scale," "above minimum")
+COMMISSION RATE: [x]% (cap for this regime: [y]% — quoting market rate, not cap, because [reason])
+COMMISSION AMOUNT: $[amount]
+BUYER-SIDE PAYMENTS TO AGENCY: [none / describe — packaging fee, referral fee, dual fee]
+  If any: modeled client outcome with this payment removed from agency incentive = [same/different
+  recommendation]. [If different, flag for disclosure conversation before signing.]
+PAYMENT TIMING: [e.g., 50% on signing, 50% on delivery]
+KEY NON-MONETARY TERMS: [billing/credit, exclusivity, options, morality clause]
+CONTRACT CLOCKS THIS DEAL STARTS: [e.g., 151-day inactivity clock begins on start date]
+CLIENT SIGN-OFF: [ ] pending  [ ] received [date]
+```
+
+## 6. Packaging / dual-payer conflict worksheet
+
+Run this before signing any deal where money could reach the agency from a source other than the client's own pay.
+
+1. List every payment in the deal and its source: client's pay, buyer's pay, both.
+2. For each buyer-side payment, ask: does it change size or trigger based on the client's own compensation? (E.g., a packaging fee tied to episodic budget headroom — yes; a flat referral fee unrelated to the client's rate — no, but still disclose.)
+3. Rebuild the recommendation with the buyer-side payment set to zero. If the recommended deal terms change, the conflict is real (Mental model, item 3).
+4. Disclose the arrangement to the client in writing before signing, regardless of the answer in step 3.
+5. Log the disclosure and the client's acknowledgment in the client's file alongside the deal memo.
+
+## 7. Registration/licensing pre-flight (before making or accepting any offer)
+
+1. Confirm current license/certification status (state talent-agency license, NBPA/NFLPA certification, UAAA state registration) against its expiry date — not "recently renewed," the actual date.
+2. If representing a student-athlete or amateur under UAAA and the athlete initiated contact: confirm registration will be filed within 7 days — this is the only window that permits acting before full registration.
+3. If any status is lapsed or unconfirmed, do not negotiate deal terms or make offers on the client's behalf; general career advice is still permitted (Common failure modes, overcorrection entry) but procurement is not.
+4. Note the confirmed status and date checked directly in the deal memo's clock section, not in a separate untracked file.

--- a/roles/talent-agent/references/red-flags.md
+++ b/roles/talent-agent/references/red-flags.md
@@ -1,0 +1,66 @@
+# Red Flags — Talent Agent / Business Manager
+
+### Any fee — "reading fee," "administrative fee," retainer — charged before a placement or booking exists
+- **Usually means:** an unlicensed operator running a pay-to-play scam targeting new or desperate talent, second most likely a legitimate manager mislabeling a flat monthly retainer without disclosing it clearly as non-contingent on work.
+- **First question:** "Show me the placement or booking this fee is tied to — if there isn't one yet, why is money moving?"
+- **Data to pull:** the fee schedule or invoice, the client's signed agreement's compensation clause, any correspondence describing what the fee covers.
+
+### Commission quoted at or above the regulatory cap (NBPA 4%, SAG-AFTRA 10%) with no case made for why this client sits above market
+- **Usually means:** the agent is defaulting to the legal ceiling instead of the competitive rate (NBPA market ≈3%), second most likely the client genuinely has below-average leverage (unproven rookie, thin competing interest) that justifies the higher end.
+- **First question:** "What specifically about this client's market position justifies charging above the going rate other agencies are quoting for comparable clients?"
+- **Data to pull:** the proposed commission schedule, comparable-client commission rates at competing agencies if known, the client's contract value and any competing offers on the table.
+
+### A payment tied to this deal arrives from the buyer's side (studio, team, promoter) rather than out of the client's own compensation
+- **Usually means:** a packaging fee, franchise fee, or dual-payer arrangement that misaligns the agency's incentive with the client's pay, second most likely a standard, disclosed referral or finder's fee that doesn't touch the client's deal terms at all.
+- **First question:** "If this side payment were removed from the model entirely, would the recommendation to the client change?"
+- **Data to pull:** the buyer-side payment agreement or packaging term sheet, the client's deal memo, a side-by-side model of the client's outcome with and without the agency's own payment included.
+
+### Personal manager is negotiating deal points, quoting rates, or preparing offer estimates in a state requiring talent-agency licensure
+- **Usually means:** the manager has crossed from career guidance into unlicensed procurement, exposing the resulting contract to being voided retroactively under the illegal-agent doctrine, second most likely the manager is relaying terms an actual licensed agent already negotiated and is not originating them.
+- **First question:** "Did a licensed agent set these specific terms, or is the manager the one who arrived at the number being quoted to the buyer?"
+- **Data to pull:** the manager's engagement letter and license status, correspondence with the buyer showing who proposed the terms, the state talent-agency statute's definition of procurement.
+
+### A termination-for-inactivity clock (e.g., SAG-AFTRA Rule 16(g): fewer than 10 workdays in the 91 days preceding day 151) is within 30 days of tripping with no bona fide offer in the file
+- **Usually means:** the client's activity has genuinely stalled and the agent is at real risk of losing the representation, second most likely an offer is in progress but hasn't been formalized in writing yet.
+- **First question:** "What bona fide offer, if any, is in motion right now that could reset this clock before it trips?"
+- **Data to pull:** the contract's effective date and the rolling 91-day workday log, any pending offer paperwork with a date, the guild's specific inactivity-termination rule text.
+
+### Certification or license renewal date (NBPA July 1, NFLPA annual, CA talent-agency license, state UAAA registration cycle) has passed with no renewed proof on file
+- **Usually means:** an administrative lapse rather than a substantive disqualification, second most likely a deliberate lapse because a disciplinary issue or fee dispute is unresolved.
+- **First question:** "Is there a renewal application pending, or has this certification actually expired with no action taken?"
+- **Data to pull:** the certifying body's renewal confirmation or receipt, the license/registration file, the applicable governing body's grace-period rules.
+
+### Athlete-agent contact was initiated by the athlete but registration under UAAA hasn't been filed within 7 days
+- **Usually means:** the agent is relying on the athlete-initiated exception past its window, putting any subsequent agency-contract signing at risk of being unenforceable, second most likely the registration is filed and simply not yet reflected in the file.
+- **First question:** "What date did the athlete first make contact, and where's the filed registration dated within 7 days of that?"
+- **Data to pull:** the initial-contact log or communication timestamp, the UAAA registration filing and its confirmation date, the state's specific registration statute.
+
+### Client's account is being told a fee percentage that doesn't match the number in the commission ledger
+- **Usually means:** an undisclosed rate increase or a side arrangement the client hasn't been shown, second most likely a bookkeeping error between two systems that never got reconciled.
+- **First question:** "Which number is correct — the rate in the client's signed agreement, or the rate actually being deducted — and when did they diverge?"
+- **Data to pull:** the client's signed representation agreement, the commission ledger for the trailing 12 months, any amendment or side letter changing the rate.
+
+### Modeling or literary commission quoted above 25% domestic with no foreign-rights or sub-agent split explaining the gap
+- **Usually means:** the agency is charging outside the 15–20% industry-norm band, either through an undisclosed sub-agent stack or simple overcharging, second most likely a legitimate foreign-rights or co-agency split that hasn't been itemized to the client.
+- **First question:** "Break this rate down — how much is the primary agency's cut, and how much is a sub-agent or foreign-rights split on top of it?"
+- **Data to pull:** the representation agreement's commission clause, any sub-agency or co-agency agreement, prior statements showing how past commissions were split.
+
+### Deal memo sent to the client omits the commission mechanic or any buyer-side payment entirely
+- **Usually means:** an oversight in a rushed memo, second most likely a deliberate omission because the fee structure wouldn't survive being written down next to the deal terms.
+- **First question:** "Why doesn't this memo state the commission rate and confirm whether the agency is being paid by anyone other than the client?"
+- **Data to pull:** the deal memo as sent, the client's signed representation agreement's fee clause, any buyer-side payment documentation.
+
+### Live-booking commission held at 15–20% for a client whose demand and asking fee have visibly increased over the last 2–3 booking cycles
+- **Usually means:** the agency hasn't revisited the rate as the client's leverage improved and is over-collecting relative to effort, second most likely the higher rate is still justified by a genuinely high-touch booking load (multi-market routing, complex riders) that hasn't eased.
+- **First question:** "Has booking effort per date actually stayed flat while the client's fee has climbed, or is there still a reason this client needs the higher-effort rate?"
+- **Data to pull:** the last 3 booking-fee and commission statements, the client's asking-fee history, agent time/effort notes per booking if tracked.
+
+### Background-check clearance, surety bond, or fingerprint file (CA requires a $50,000 bond) has no renewal date or is missing entirely
+- **Usually means:** the compliance file was assembled once at onboarding and never re-verified, second most likely the bond lapsed and hasn't been caught because no one reviews it until a complaint triggers a state audit.
+- **First question:** "When was this bond or clearance last verified as current, and who owns re-checking it on a schedule?"
+- **Data to pull:** the surety bond certificate and its expiration date, background-check clearance date, the state labor commissioner's specific bond-amount requirement.
+
+### Recording-contract procurement is being used as the sole basis for a personal manager's ongoing negotiation of non-recording deal terms
+- **Usually means:** the manager is stretching the recording-contract carve-out (which doesn't itself trigger talent-agency licensure) to cover activity — touring deals, sync licensing negotiation — that the carve-out doesn't reach, second most likely the manager's activity genuinely stays within the recording-contract exception.
+- **First question:** "Is every deal point being negotiated actually part of the recording contract itself, or has this drifted into other employment procurement?"
+- **Data to pull:** the specific deals the manager has negotiated in the last 12 months, each deal's category (recording vs. touring, sync, endorsement), the state's exact carve-out language.

--- a/roles/talent-agent/references/vocabulary.md
+++ b/roles/talent-agent/references/vocabulary.md
@@ -1,0 +1,59 @@
+# Talent agent working vocabulary
+
+Terms a talent agent uses precisely and a generalist often blurs together. Format: definition → how a practitioner says it → common misuse.
+
+**Procurement** — The legally licensable act of seeking, offering, promising, or negotiating employment for a client, as defined under statutes like California's Talent Agencies Act. Broader than "booking a gig" — includes negotiating deal terms on a client's behalf, even without a formal offer on the table.
+In use: "Drafting the counter on their deal points is procurement — that's the line a manager can't cross without a license."
+Misuse: assuming procurement means only closing signed deals. General career advice, introductions, and creative feedback aren't procurement; negotiating employment terms is, regardless of whether a contract results.
+
+**Packaging fee** — A fee paid by a buyer (studio, network) to an agency for assembling a project's talent (writer, director, cast) as a bundle, paid separately from and in addition to any individual client's compensation.
+In use: "The packaging fee comes out of the show's backend, not the writer's episodic rate — that's exactly why it's a conflict."
+Misuse: treating a packaging fee as just "another commission." It's paid by the buyer, not deducted from client pay, which is precisely what breaks the alignment between agent and client incentives.
+
+**Franchise (agency franchise)** — A guild's (e.g., SAG-AFTRA's) formal authorization for an agency to represent its members, conditioned on the agency operating under the guild's rules (commission caps, no packaging-for-cash arrangements, etc.).
+In use: "They lost their SAG-AFTRA franchise over the packaging dispute — that's not a fine, that's losing the right to rep union talent at all."
+Misuse: confusing "franchise" with a business franchise (like a retail chain). In this context it's a regulatory license from the guild, revocable for rule violations.
+
+**Scale (SAG-AFTRA)** — The union-negotiated minimum day rate or weekly rate a performer must be paid under the applicable collective bargaining agreement; the wage floor, not a target.
+In use: "This is a scale-plus-10 deal — we negotiated the base above scale specifically so commission doesn't eat into the guaranteed minimum."
+Misuse: treating "scale" as a fixed, low-status rate that signals a weak deal. Scale is a floor set by the guild; a deal can be "scale plus" 30–50% or more and still reference scale as its baseline.
+
+**Commission cap** — The maximum percentage a governing body (NBPA, SAG-AFTRA) permits an agent to charge, distinct from the rate an agent actually charges.
+In use: "NBPA caps at 4%, but we quote 3% — the cap is the ceiling, not the price."
+Misuse: quoting the cap itself as the going rate. The cap only bounds what's legal; the competitive market rate is typically well below it, and charging the ceiling by default overprices the service.
+
+**Termination-for-inactivity clock** — A contractual right (e.g., SAG-AFTRA Rule 16(g)) letting a client exit an agency agreement if the agency fails to secure a minimum amount of work within a defined trailing window.
+In use: "We're 20 days from the 151-day mark — if we don't land a bona fide offer, the client can terminate for inactivity."
+Misuse: treating this purely as a compliance date to log. It's a live leverage point — a bona fide offer inside the window resets the clock, so timing an offer is itself a negotiating move, not just paperwork.
+
+**Bona fide offer** — A genuine, specific offer of employment (not a general expression of interest or a courtesy call) sufficient to satisfy contractual activity requirements like an inactivity-termination clock.
+In use: "That was a courtesy call, not a bona fide offer — it doesn't reset anything."
+Misuse: reporting any inbound interest to the client as an "offer" to look productive. Conflating the two either falsely resets a termination clock in the agent's own recordkeeping or gives the client false hope.
+
+**Certification (players' association)** — The credential (e.g., NBPA, NFLPA agent certification) required to legally represent athletes in contract negotiations with a league, separate from any state licensing regime.
+In use: "He's not NFLPA-certified, so he can advise informally but can't negotiate the contract himself."
+Misuse: treating league certification and state talent-agency licensure as interchangeable or redundant. They're separate regimes with separate fees, exams, and renewal cycles; holding one doesn't satisfy the other.
+
+**Registration (UAAA/RUAAA)** — The state-level filing requirement under the Uniform Athlete Agents Act for anyone acting as an athlete agent, distinct from league certification and carrying its own grace periods and deadlines.
+In use: "He can respond to the athlete's own outreach without being registered yet, but only within the 7-day grace window before it has to be filed."
+Misuse: assuming certification with a players' association satisfies state registration requirements, or that the athlete-initiated exception is an open-ended pass rather than a narrow, time-boxed exception.
+
+**Illegal-agent doctrine** — The legal principle that a representation contract negotiated by an unlicensed agent can be voided retroactively, even years after signing, once the licensing violation is established.
+In use: "If this contract gets challenged, the whole thing could be void from day one — that's the illegal-agent doctrine, not just a fine."
+Misuse: treating an unlicensed procurement as a minor compliance gap to clean up later. The remedy isn't prospective correction — it can unwind past commissions and the agreement itself.
+
+**Dual-payer arrangement** — Any structure where the agency is paid, directly or indirectly, by both the client and the buyer on the same deal (as opposed to commission drawn solely from the client's earnings).
+In use: "Flag the endorsement override paid by the brand directly to the agency — that's a dual-payer arrangement and it needs disclosure."
+Misuse: assuming disclosure alone resolves the conflict. Disclosure tells the client the payment exists; it doesn't test whether the payment changed the agent's recommendation — that requires re-running the analysis with the buyer-side payment zeroed out and checking whether the advice still holds.
+
+**Fiduciary duty (agency context)** — The legal obligation an agent owes exclusively to the client's interests, encompassing loyalty, avoiding conflicts, taking no action adverse to the client, and not commingling funds.
+In use: "Recommending the lower-episodic-fee option because it preserves our packaging fee is a fiduciary breach, independent of whether it's disclosed."
+Misuse: treating disclosure of a conflict as satisfying fiduciary duty on its own. Fiduciary duty requires the underlying recommendation to still serve the client's interest, not just transparency about who else is getting paid.
+
+**Reading fee / upfront fee** — Any fee an agency charges a client before securing placement or sale (as opposed to commission drawn from the client's earnings after the fact).
+In use: "A 'reading fee' before they'll even consider the manuscript is the textbook scam pattern in literary representation."
+Misuse: treating upfront fees as an aggressive-but-legitimate business variant rather than a near-categorical red flag. Legitimate literary and modeling agencies are paid only from proceeds, never before them.
+
+**Endorsement override** — Commission an agency earns on a client's endorsement or sponsorship income, priced and negotiated separately from on-contract playing/performance commission and not subject to the same regulatory cap.
+In use: "The 15% is on the endorsement override, not the playing contract — those two caps don't stack or offset each other."
+Misuse: applying a playing-contract commission cap (e.g., NBPA's 4%) to endorsement income, or vice versa. They're separate revenue streams with separate, non-interchangeable pricing conventions.


### PR DESCRIPTION
## Rubric score: 18/18

## Resolution rationale

Checked all three candidates' full SKILL.md (purchasing-agent, project-management-specialist, wind-energy-operations-manager) plus scanned roles/ for any closer neighbor (entertainment-recreation-manager, gambling-manager, etc.). None share the decision framework, tools, or failure modes needed for 13-1011.00: none address contract negotiation on behalf of a client, commission/fee structures, endorsement/sponsorship deal evaluation, booking and scheduling around a career, image-rights and appearance management, or conflicts between agent and client interests. A practitioner doing exactly this job would get actively wrong guidance from procurement thresholds, EVM schedule math, or turbine O&M frameworks — these fail the granularity test outright, not just a detail-depth test. entertainment-recreation-manager is the nearest thematically-adjacent existing role but it governs venues/facilities operations, not personal representation of talent, so it is not a reasonable parent either. This is a new top-level domain requiring its own first-principles core, decision framework, and worked example.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `talent-agent` role (O*NET 13-1011.00) at spec‑2 to handle contract negotiation, commission structures, licensing/registration boundaries, and contract-clock tracking. Updates project counts and O*NET coverage in `README.md` and `ROADMAP.md`.

- **New Features**
  - Added `roles/talent-agent/SKILL.md` with core principles, decision framework, tools, and a worked commission example.
  - Added references: `references/playbook.md` (commission mechanics, negotiation ladders, clock tracker, deal memo), `references/red-flags.md`, `references/vocabulary.md`.
  - Registered role in `data/roles.json` (category `other`, spec 2, O*NET `13-1011.00`).
  - Updated stats: 119 roles total; 115 mapped to O*NET; coverage 11.3%; `other` category increases to 7.

<sup>Written for commit 11f9f6135bd12b2c2c2414f85132a65a6e41d826. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

