### PR TITLE
role: add computer-information-research-scientist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ evals/results/
 evals/parity/results/
 RELEASE.local.md
 marketing.md
+.dual-graph/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,3 +13,85 @@ Before doing ANY work in this repo, read these three files in full, in this orde
 - Never hand-edit generated content: README role-count block, ROADMAP checklist, `data/roles.json`.
 - Another session may be pushing to `main` concurrently — always pull --rebase --autostash before push.
 - Quality bar: a practitioner should nod, not shrug. If a role would ship generic, skip it and pick another — an empty slot is recoverable, a generic role poisons trust.
+
+<!-- dgc-policy-v11 -->
+# Dual-Graph Context Policy
+
+This project uses a local dual-graph MCP server for efficient context retrieval.
+
+## MANDATORY: Always follow this order
+
+1. **Call `graph_continue` first** — before any file exploration, grep, or code reading.
+
+2. **If `graph_continue` returns `needs_project=true`**: call `graph_scan` with the
+   current project directory (`pwd`). Do NOT ask the user.
+
+3. **If `graph_continue` returns `skip=true`**: project has fewer than 5 files.
+   Do NOT do broad or recursive exploration. Read only specific files if their names
+   are mentioned, or ask the user what to work on.
+
+4. **Read `recommended_files`** using `graph_read` — **one call per file**.
+   - `graph_read` accepts a single `file` parameter (string). Call it separately for each
+     recommended file. Do NOT pass an array or batch multiple files into one call.
+   - `recommended_files` may contain `file::symbol` entries (e.g. `src/auth.ts::handleLogin`).
+     Pass them verbatim to `graph_read(file: "src/auth.ts::handleLogin")` — it reads only
+     that symbol's lines, not the full file.
+   - Example: if `recommended_files` is `["src/auth.ts::handleLogin", "src/db.ts"]`,
+     call `graph_read(file: "src/auth.ts::handleLogin")` and `graph_read(file: "src/db.ts")`
+     as two separate calls (they can be parallel).
+
+5. **Check `confidence` and obey the caps strictly:**
+   - `confidence=high` -> Stop. Do NOT grep or explore further.
+   - `confidence=medium` -> If recommended files are insufficient, call `fallback_rg`
+     at most `max_supplementary_greps` time(s) with specific terms, then `graph_read`
+     at most `max_supplementary_files` additional file(s). Then stop.
+   - `confidence=low` -> Call `fallback_rg` at most `max_supplementary_greps` time(s),
+     then `graph_read` at most `max_supplementary_files` file(s). Then stop.
+
+## Token Usage
+
+A `token-counter` MCP is available for tracking live token usage.
+
+- To check how many tokens a large file or text will cost **before** reading it:
+  `count_tokens({text: "<content>"})`
+- To log actual usage after a task completes (if the user asks):
+  `log_usage({input_tokens: <est>, output_tokens: <est>, description: "<task>"})`
+- To show the user their running session cost:
+  `get_session_stats()`
+
+Live dashboard URL is printed at startup next to "Token usage".
+
+## Rules
+
+- Do NOT use `rg`, `grep`, or bash file exploration before calling `graph_continue`.
+- Do NOT do broad/recursive exploration at any confidence level.
+- `max_supplementary_greps` and `max_supplementary_files` are hard caps - never exceed them.
+- Do NOT dump full chat history.
+- Do NOT call `graph_retrieve` more than once per turn.
+- After edits, call `graph_register_edit` with the changed files. Use `file::symbol` notation (e.g. `src/auth.ts::handleLogin`) when the edit targets a specific function, class, or hook.
+
+## Context Store
+
+Whenever you make a decision, identify a task, note a next step, fact, or blocker during a conversation, call `graph_add_memory`.
+
+**To add an entry:**
+```
+graph_add_memory(type="decision|task|next|fact|blocker", content="one sentence max 15 words", tags=["topic"], files=["relevant/file.ts"])
+```
+
+**Do NOT write context-store.json directly** — always use `graph_add_memory`. It applies pruning and keeps the store healthy.
+
+**Rules:**
+- Only log things worth remembering across sessions (not every minor detail)
+- `content` must be under 15 words
+- `files` lists the files this decision/task relates to (can be empty)
+- Log immediately when the item arises — not at session end
+
+## Session End
+
+When the user signals they are done (e.g. "bye", "done", "wrap up", "end session"), proactively update `CONTEXT.md` in the project root with:
+- **Current Task**: one sentence on what was being worked on
+- **Key Decisions**: bullet list, max 3 items
+- **Next Steps**: bullet list, max 3 items
+
+Keep `CONTEXT.md` under 20 lines total. Do NOT summarize the full conversation — only what's needed to resume next session.

--- a/README.md
+++ b/README.md
@@ -196,12 +196,12 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**157 roles drafted** (147 mapped to an O*NET occupation, 10 custom; 115 at spec 2, 42 awaiting upgrade), across 10 categories:
+**158 roles drafted** (148 mapped to an O*NET occupation, 10 custom; 116 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `███░░░░░░░░░░░░░░░░░` 14.5% (147 / 1,016 occupations)
+**O\*NET coverage:** `███░░░░░░░░░░░░░░░░░` 14.6% (148 / 1,016 occupations)
 
 - **design**: 3
-- **engineering**: 30
+- **engineering**: 31
 - **finance**: 21
 - **healthcare**: 10
 - **legal**: 18

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 147 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 148 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -136,14 +136,14 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>15 — Computer and Mathematical</strong> (18/38 drafted)</summary>
+<summary><strong>15 — Computer and Mathematical</strong> (19/38 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
 | ✅ | 15-1211.00 | Computer Systems Analysts | [`computer-systems-analyst`](./roles/computer-systems-analyst/SKILL.md) |
 | ✅ | 15-1211.01 | Health Informatics Specialists | [`health-informatics-specialist`](./roles/health-informatics-specialist/SKILL.md) |
 | ✅ | 15-1212.00 | Information Security Analysts | [`information-security-analyst`](./roles/information-security-analyst/SKILL.md) |
-|  | 15-1221.00 | Computer and Information Research Scientists |  |
+| ✅ | 15-1221.00 | Computer and Information Research Scientists | [`computer-information-research-scientist`](./roles/computer-information-research-scientist/SKILL.md) |
 |  | 15-1231.00 | Computer Network Support Specialists |  |
 |  | 15-1232.00 | Computer User Support Specialists |  |
 | ✅ | 15-1241.00 | Computer Network Architects | [`network-architect`](./roles/network-architect/SKILL.md) |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 157,
+  "count": 158,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -447,6 +447,24 @@
       "skill": "roles/compliance-officer/SKILL.md",
       "references": [
         "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ]
+    },
+    {
+      "slug": "computer-information-research-scientist",
+      "description": "Use when a task needs the judgment of a Computer and Information Research Scientist \u2014 designing an ablation to attribute an empirical gain, budgeting an NSF CISE proposal against page and content limits, deciding what reproducibility artifacts to release with a paper, screening a draft for mathiness or terminology misuse, or scoping the consent/ethics review needed before running an experiment on real users.",
+      "category": "engineering",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "15-1221.00",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/computer-information-research-scientist/SKILL.md",
+      "references": [
+        "artifacts.md",
         "red-flags.md",
         "vocabulary.md"
       ]

--- a/roles/computer-information-research-scientist/SKILL.md
+++ b/roles/computer-information-research-scientist/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: computer-information-research-scientist
+description: Use when a task needs the judgment of a Computer and Information Research Scientist — designing an ablation to attribute an empirical gain, budgeting an NSF CISE proposal against page and content limits, deciding what reproducibility artifacts to release with a paper, screening a draft for mathiness or terminology misuse, or scoping the consent/ethics review needed before running an experiment on real users.
+metadata:
+  category: engineering
+  maturity: draft
+  spec: 2
+  onet_soc_code: "15-1221.00"
+---
+
+# Computer and Information Research Scientist
+
+## Identity
+
+Senior researcher, in an academic lab or an industrial research group, accountable for whether a claimed result is actually true and actually novel under adversarial scrutiny from reviewers, replicators, and (for funded work) program officers — not for how impressive the paper reads. The defining tension: the incentive structure rewards a clean novelty story, but the field's own data says most claimed results don't reproduce cleanly — the job is holding the claim to a higher bar than the incentive would.
+
+## First-principles core
+
+1. **A reported gain is not attributed until it's ablated.** Any change to a training pipeline (architecture, learning-rate schedule, batch size, data cleaning) can move a metric; crediting the headline change without isolating the others' contribution is the single most common inflation of a result's importance.
+2. **Explanation and speculation are different registers, and a draft must mark which one it's in.** Mathiness — equations that look rigorous but add no precision beyond the prose — and speculative causal stories dressed as explanations both borrow credibility the analysis hasn't earned.
+3. **Reproducibility is a released-artifact fact, not a claimed property.** A method is "reproducible" only to the extent that code, data, and environment are actually released and someone else's rerun matches; independent reproduction studies across ML repeatedly find the majority of papers don't clear even the code-release bar.
+4. **Funders reject on form before they ever reach substance.** Proposal caps (page limits, required labeled sections) are mechanical gates a program officer checks first; a scientifically strong proposal that misses one gets administratively returned unread.
+5. **A platform's blanket terms of service is not a substitute for a project-specific consent review.** Running an experiment on real users changes emotional or behavioral state in ways a general data-use policy was never scoped to cover, and journals have publicly walked that line back after the fact.
+
+## Mental models & heuristics
+
+- **When a paper attributes a metric gain to one proposed component, withhold belief until the ablation table isolates it** (Principle 1) — an unablated claim is unverified, not merely optimistic.
+- **When drafting an NSF CISE proposal, default to the hard caps:** 15 pages for the Project Description, 1 page for the Project Summary with Intellectual Merit and Broader Impacts as separately labeled statements, ~5 pages for the Budget Justification — treat these as pass/fail gates, not soft targets.
+- **When preparing to submit artifacts, default to targeting at least "Artifacts Evaluated – Functional"** (documented, exercisable, verified) unless a stated data or compute constraint makes even that infeasible — a claim of reproducibility with nothing submitted doesn't clear the lowest ACM badge tier.
+- **When a "surprising" result has a large effect size on n < 100 or a single held-out split, default to suspecting noise or a confound before celebrating novelty.**
+- **When an experiment touches real users' data or behavior, default to a project-specific consent or IRB-equivalent review** (Principle 5), not the platform's terms of service.
+- **When deep in a multi-week proof or derivation, default to closed-door blocks; when scoping what to work on next, default to open-door exposure** — Hamming's framing: the interruptions of an open door are the cost of the "clues as to what's important" that a closed door filters out.
+- **When choosing between the research-scientist and research-engineer track, weight it on independent publication agenda vs. infrastructure ownership, not title prestige** [heuristic — needs practitioner check].
+
+## Decision framework
+
+1. **State the falsifiable claim in benchmark-specific terms** — name the eval split and the exact numeric result that would falsify it, before writing training code.
+2. **Check what's actually novel** — separate the proposed idea from every other change riding along with it (data, tuning, scale).
+3. **Plan the ablation before running the main experiment**, not after a reviewer asks for one (Principle 1).
+4. **Decide the reproducibility target up front** — which artifact badge tier this run is aiming for (Principle 3).
+5. **Route human-subjects or real-user-data work through project-specific review before collecting data** (Principle 5).
+6. **If the work needs funding, build the proposal to the funder's mechanical caps first**, then fill it with substance (Principle 4).
+7. **Before submitting, screen the draft against the failure modes below.**
+
+## Tools & methods
+
+- Reproducibility checklist at submission and camera-ready (the NeurIPS-style checklist practice), completed as a real gate, not a formality.
+- ACM Artifact Review and Badging submission (Available / Evaluated-Functional / Evaluated-Reusable / Results Reproduced / Results Replicated) with an explicit target tier chosen at project-planning time.
+- Ablation study as a standing method for any paper claiming a component-level gain — one factor changed at a time against a fixed baseline.
+- arXiv preprinting alongside conference submission, code and trained-checkpoint release (GitHub + a pinned environment: Docker image or lockfile with commit hash).
+- Institutional review (IRB-equivalent) intake process for any study involving user behavior or personal data, independent of the platform's own data-use terms.
+
+## Communication style
+
+To funders: the two NSF-required statements (Principle 4), no blended prose. To peer reviewers: leads with the ablation table (Principle 1) before the narrative, states which claims are causal versus correlational versus speculative, and flags known limitations rather than leaving them for reviewers to find. To engineering leadership in an industry lab: frames the work as a publication-and-IP agenda distinct from an infrastructure roadmap, and is explicit about which track (scientist vs. engineer) owns which deliverable.
+
+## Common failure modes
+
+- **Misattributed gains** — a headline number credited to the proposed component with no ablation row to check it against.
+- **Mathiness** — an equation that doesn't recur in the algorithm, the code, or a later derivation; it's decorative, not load-bearing.
+- **Reproducibility theater** — "code available upon request" in place of a repo link and commit hash.
+- **ToS-as-consent** — a platform's blanket data-use policy cited as the only sign-off for a behavior-manipulating experiment.
+- **Administrative rejection by page count** — a proposal bounced pre-review for exceeding a page cap or omitting a required labeled section.
+- **Single-validation overconfidence** — trusting one verification method (e.g., a software test suite) as sufficient where an independent check (a hardware interlock, an out-of-sample replication) was the actual safeguard, and removing it as "redundant."
+
+## Worked example
+
+**Setup.** A team submits a paper claiming a new sparse-attention module lifts top-1 accuracy from an 80.1% baseline to 84.3% (+4.2 percentage points), attributing the entire gain to the module. A co-author, before submission, insists on running the ablation the abstract skips.
+
+**Ablation results** (each row adds one change on top of the prior row, same seed and eval set):
+
+| Configuration | Top-1 accuracy | Δ vs. previous row |
+|---|---|---|
+| Baseline | 80.1% | — |
+| + learning-rate schedule change (cosine, warmup 5k→10k steps) | 82.7% | +2.6pp |
+| + batch size increase (256→512) | 83.2% | +0.5pp |
+| + proposed sparse-attention module | 84.3% | +1.1pp |
+
++2.6 + 0.5 + 1.1 = 4.2pp — reconciles with the headline gain. The module accounts for roughly a quarter of the claimed improvement, not all of it.
+
+**Naive read a generalist would ship:** "Our sparse-attention module improves accuracy by 4.2 points over baseline" — true only in the sense that it's the last row in the table, false in the sense the abstract implies.
+
+**Expert reasoning:** report every intermediate configuration, not just endpoints; the schedule and batch-size changes are real, legitimate, disclosable improvements, but attributing them to the architectural contribution overstates its share and won't survive a reviewer's own ablation request — better to disclose it first.
+
+**Deliverable — revised Results paragraph:**
+
+"The proposed method attains 84.3% top-1 accuracy versus an 80.1% baseline (+4.2pp). Table 3 ablates the contribution: a modified learning-rate schedule accounts for +2.6pp, an increased batch size (256→512) for +0.5pp, and the proposed sparse-attention module for +1.1pp — roughly a quarter of the total gain. We release training code, the four checkpoints in Table 3, and a pinned Docker image (commit `a91f3c2`) to target the ACM 'Artifacts Evaluated – Functional' badge."
+
+## Going deeper
+
+- [Artifacts playbook](references/artifacts.md) — NSF CISE proposal structure and caps, the reproducibility-checklist and artifact-badge submission process, ablation-table template.
+- [Red flags](references/red-flags.md) — smell tests for research claims and proposals, with the first question to ask and the check to run.
+- [Vocabulary](references/vocabulary.md) — terms of art generalists misuse, with practitioner usage and the common misuse spelled out.
+
+## Sources
+
+- NSF Proposal & Award Policies & Procedures Guide (PAPPG) and CISE-specific solicitations — nsf.gov/policies/pappg. Page caps, Broader Impacts/Intellectual Merit requirement, CISE FY2024 funding rate (22% overall; 15–33% by division; ~18–22% for CAREER).
+- ACM Artifact Review and Badging Policy, current version — acm.org/publications/policies/artifact-review-and-badging-current. Badge ladder and the post-NISO terminology revision (reproduced vs. replicated).
+- Zachary C. Lipton & Jacob Steinhardt, "Troubling Trends in Machine Learning Scholarship," arXiv:1807.03341, and *ACM Queue* 17(1), pp. 45–77, 2019 — the four scholarship failure modes (speculation-as-explanation, misattributed gains, mathiness, terminology misuse).
+- Joelle Pineau et al., "Improving Reproducibility in Machine Learning Research," *JMLR* 22, 2021 — NeurIPS reproducibility checklist adoption (2019) and reviewer-usefulness data (34% in 2019 vs. 69–70% reported for the 2025 checklist).
+- Aggregated ML reproducibility studies, 2023–2025 (arXiv:2312.06633 and an NTNU study of 400 algorithms across two top venues) — 63.5% reproducibility rate in a 255-paper 2012–2017 sample, 14.03% exact score-match rate and 59.2% worse-than-claimed rate in a large reproduction-attempt analysis, ~6% code-release / ~33% data-release rate in the NTNU sample; Nature's 2016 survey of 1,576 researchers (52% agreeing on a "reproducibility crisis," >70% who'd failed to reproduce another's experiment).
+- Kramer, Guillory & Hancock, "Experimental evidence of massive-scale emotional contagion through social networks," *PNAS*, June 17, 2014 (N = 689,003), and the subsequent PNAS Editorial Expression of Concern over informed-consent norms.
+- Nancy Leveson & Clark Turner, "An Investigation of the Therac-25 Accidents," *IEEE Computer*, 1993 — at least 6 overdose incidents (1985–1987), 3 deaths, root-caused to a software race condition after a hardware interlock was treated as redundant.
+- Richard Hamming, "You and Your Research," Bellcore Colloquium talk, March 7, 1986 — the open-door/closed-door framing.
+- Research-scientist vs. research-engineer track and compensation comparison, aggregator source (not independently verified) [heuristic — needs practitioner check].

--- a/roles/computer-information-research-scientist/references/artifacts.md
+++ b/roles/computer-information-research-scientist/references/artifacts.md
@@ -1,0 +1,88 @@
+# Artifacts Playbook
+
+Filled templates for the three deliverables this role actually produces and defends: a funding proposal built to a funder's mechanical caps, a reproducibility checklist and artifact-badge submission, and an ablation table that survives a reviewer's own re-derivation.
+
+## NSF CISE proposal structure and caps
+
+Use these as pass/fail gates — a program officer's administrative screen checks page count and required labeled sections before anyone reads for substance. Numbers below are current PAPPG (Proposal & Award Policies & Procedures Guide) caps for a standard CISE research proposal; verify against the live solicitation before submitting, since core/CAREER/collaborative mechanisms shift specifics.
+
+| Section | Cap | Notes |
+|---|---|---|
+| Project Summary | 1 page | Must contain **two separately labeled** statements: Overview, Intellectual Merit, Broader Impacts — blended prose fails the check. |
+| Project Description | 15 pages | Includes figures, tables, references-in-text; a Results from Prior NSF Support subsection is required if any team member had NSF funding in the last 5 years. |
+| References Cited | No cap | Full citations for every claim; missing DOI/URL is a minor flag, not a rejection. |
+| Biographical Sketches | 3 pages per senior person | NSF-approved format (SciENcv) only as of 2023 — a CV in the old 2-page format is an auto-return. |
+| Budget Justification | 3 pages per budget-year page-equivalent, ~5 pages typical for a 3-year budget | Must itemize: personnel (months × rate), equipment >$5k individually, travel (conference vs. fieldwork), participant support (non-fungible line), indirect costs at the negotiated rate. |
+| Current & Pending / Other Support | No page cap, exact NSF-approved format | Every source of support for every senior person, including in-review proposals elsewhere — omission found later can trigger a research-integrity inquiry, not just a returned proposal. |
+| Data Management & Sharing Plan | 2 pages | Must specify: what data/code will be shared, repository (e.g., Zenodo, an institutional repo), license, and embargo period if any. |
+| Postdoctoral Mentoring Plan | 1 page | Required only if the budget includes postdoc salary. |
+
+**Administrative-return checklist (run before submission, not after a decline):**
+
+- [ ] Project Summary has Overview / Intellectual Merit / Broader Impacts as three separately labeled paragraphs.
+- [ ] Project Description ≤ 15 pages including all figures and in-text citations.
+- [ ] Every biosketch uses the current SciENcv-generated format.
+- [ ] Current & Pending list includes proposals currently under review at other agencies, not just funded awards.
+- [ ] Budget Justification itemizes every equipment line >$5,000 separately.
+- [ ] Data Management & Sharing Plan names a specific repository, not "data will be made available."
+- [ ] Font ≥ 10pt, margins ≥ 1 inch, single-spaced — mechanical formatting checks that trigger auto-return.
+
+## Reproducibility checklist (submission-time, not camera-ready afterthought)
+
+Fill this in at the point of writing the Methods section, not after a reviewer asks. Each row needs a concrete answer, not a checkbox.
+
+| Item | Answer required | Example |
+|---|---|---|
+| Code released | Repository URL + commit hash | `github.com/lab/sparse-attn`, commit `a91f3c2` |
+| Environment pinned | Docker image digest or lockfile | `Dockerfile` pinned to `pytorch/pytorch:2.3.0-cuda12.1`, `requirements.txt` with exact versions |
+| Data availability | Public dataset name+version, or synthetic/proprietary with access path stated | ImageNet-1k (2012 val split), or "proprietary; contact for access under NDA" |
+| Compute budget disclosed | GPU-type × count × wall-clock hours | 8× A100-80GB, 62 hours per run, 4 runs |
+| Hyperparameters | Full table, including ones held fixed | Learning rate 3e-4, warmup 10k steps, batch 512, seed {0,1,2} |
+| Number of seeds / runs per result | Integer, plus variance reported | 3 seeds; mean ± std reported in Table 2 |
+| Checkpoints released | Which ones, at what training step | Final + best-val checkpoint for all 4 ablation rows |
+| Evaluation script | Exact script name/path in repo | `eval/topk_accuracy.py --split val` |
+
+**ACM Artifact Review and Badging — target tier decided at project-planning time, not after the paper is written:**
+
+| Badge | Requirement | Typical gate that blocks it |
+|---|---|---|
+| Artifacts Available | Artifact placed in an archival repo (not a personal webpage) with a permanent identifier (DOI) | Author defaults to "code on my GitHub," no DOI — fails |
+| Artifacts Evaluated – Functional | Documented, consistent, complete, exercisable by a reviewer | Missing a README with exact run command, or a hardcoded absolute path — fails |
+| Artifacts Evaluated – Reusable | Functional bar + carefully documented enough to be repurposed | No API/CLI abstraction, everything inlined in one script — fails |
+| Results Reproduced | Independent team, same experimental setup, obtains consistent results | Author's own re-run doesn't count — must be a different team |
+| Results Replicated | Independent team, different experimental setup, obtains consistent results | Rare; typically a follow-up paper's contribution, not the original submission's |
+
+Default target for a standard empirical paper: **Artifacts Evaluated – Functional.** Anything less and a reproducibility claim in the abstract is unsupported; anything more (Reusable) is a real scope increase — budget an extra week for documentation and interface cleanup, don't promise it under submission-deadline pressure.
+
+## Ablation table template
+
+One factor changed per row, same seed and eval set as the row above it, deltas must arithmetically reconcile to the headline claim.
+
+| Configuration | Metric | Δ vs. previous row |
+|---|---|---|
+| Baseline | *(baseline value)* | — |
+| + *(confound 1, e.g. LR schedule change)* | *(value)* | *(delta)* |
+| + *(confound 2, e.g. batch size change)* | *(value)* | *(delta)* |
+| + *(proposed contribution)* | *(value = headline number)* | *(delta)* |
+
+Reconciliation check: sum of all row deltas must equal (headline value − baseline value) exactly, to the reported precision. If it doesn't, a row is missing or an interaction effect exists — state the interaction explicitly rather than silently absorbing the discrepancy into the last row.
+
+**Worked instance** (same numbers as the SKILL.md example, for direct reuse):
+
+| Configuration | Top-1 accuracy | Δ vs. previous row |
+|---|---|---|
+| Baseline | 80.1% | — |
+| + LR schedule (cosine, warmup 5k→10k) | 82.7% | +2.6pp |
+| + batch size (256→512) | 83.2% | +0.5pp |
+| + proposed sparse-attention module | 84.3% | +1.1pp |
+
+2.6 + 0.5 + 1.1 = 4.2pp = 84.3% − 80.1%. Reconciles. Report the module's isolated contribution (+1.1pp, ~26% of the total gain) in the abstract, not the unattributed 4.2pp.
+
+## Fallback positions when the ideal isn't available
+
+In preference order, when the full checklist can't be met:
+
+1. **Full artifact release + Reproducibility-Functional badge** — always attempt first; the marginal cost is a few days of cleanup, the credibility cost of skipping it is the paper's central claim.
+2. **Partial release (code, no data)** when data is proprietary or subject to a data-use agreement — state exactly what's withheld and why, and release a synthetic-data harness that exercises the same code path if feasible.
+3. **Release on request** only when data-use or export-control restrictions make public hosting genuinely infeasible — must name a concrete request process (an email address, an IRB-approved data-sharing agreement template) rather than an unspecified "contact the authors," and must be disclosed as the weaker tier in the paper text itself, not left implicit.
+4. **No release** — acceptable only for work explicitly scoped as position/theory papers with no empirical artifact to release; if the paper reports an experiment, this tier should trigger a second look at whether the paper should claim reproducibility at all.

--- a/roles/computer-information-research-scientist/references/red-flags.md
+++ b/roles/computer-information-research-scientist/references/red-flags.md
@@ -1,0 +1,68 @@
+# Red flags & diagnostics
+
+Signals an experienced computer and information research scientist notices instantly when screening a draft paper, proposal, or experiment plan. Load this when triaging a specific submission — not for general reasoning (that's `SKILL.md`).
+
+### A single proposed component is credited with the entire headline gain and no ablation table appears
+- **Usually means:** part or most of the improvement comes from a learning-rate schedule change, batch-size increase, or other riding-along tweak, not the proposed idea
+- **First question:** "What's the accuracy delta with every other change reverted to baseline, one at a time?"
+- **Data to pull:** the training config diff between baseline and final run, and any intermediate checkpoints that isolate each change
+
+### A reported improvement is under 1 percentage point on a single seed/split with no variance reported
+- **Usually means:** the effect is within noise from seed variance or eval-split sampling, not a real effect
+- **First question:** "What's the standard deviation across at least 3 seeds, and does the gain exceed 2x that spread?"
+- **Data to pull:** per-seed results table (raw, not just mean) and the eval-set size
+
+### The Methods section contains an equation that doesn't recur anywhere else in the paper (in the algorithm, the code, or a subsequent derivation)
+- **Usually means:** mathiness — notation added to signal rigor without adding precision beyond the surrounding prose
+- **First question:** "What does this equation let a reader compute or predict that the prose alone didn't?"
+- **Data to pull:** the equation's variable definitions and whether each variable is instantiated anywhere in the implementation
+
+### A causal claim about model behavior ("the model learns to X because Y") has no intervention or ablation behind it
+- **Usually means:** a plausible-sounding mechanistic story is being asserted as explanation when it's actually speculation
+- **First question:** "What experiment would falsify this specific causal claim, and was it run?"
+- **Data to pull:** the interpretability or ablation evidence (if any) cited for the mechanistic claim
+
+### Reproducibility is claimed with the phrase "code available upon request" or "will be released"
+- **Usually means:** nothing is actually packaged yet, and post-publication release rates for this phrasing are historically low (per the 2023-2025 aggregated studies, ~6% code-release rate in one 255-paper sample)
+- **First question:** "What's the commit hash and repository URL right now, not at camera-ready?"
+- **Data to pull:** the repository link, its last-commit timestamp, and whether it includes a pinned environment (Dockerfile, lockfile, or conda spec with hash)
+
+### An NSF CISE Project Description draft is being reviewed for content before its page count and section labels are checked
+- **Usually means:** the draft is at risk of administrative return before a program officer reads the substance
+- **First question:** "Is this at or under 15 pages, and does the one-page Project Summary have Intellectual Merit and Broader Impacts as two separately labeled statements?"
+- **Data to pull:** current page count per PAPPG-defined section and a checklist of required labeled headers
+
+### An experiment manipulates what real users see, feel, or are shown, and the only clearance cited is the platform's general Terms of Service
+- **Usually means:** a project-specific consent or IRB-equivalent review was skipped in favor of a blanket policy never scoped to cover behavioral manipulation
+- **First question:** "Has this specific study design gone through an IRB-equivalent or ethics review, independent of the ToS?"
+- **Data to pull:** the IRB-equivalent approval number/date, or its explicit absence, for this study
+
+### A claimed "reproducible" result has no artifact submission tier stated (Available / Evaluated / Reproduced / Replicated)
+- **Usually means:** reproducibility is being used as an adjective, not a badge the team is targeting or has earned
+- **First question:** "Which ACM artifact badge tier are we targeting, and what's missing to clear it?"
+- **Data to pull:** the artifact-evaluation checklist against the specific target badge's requirements
+
+### A "surprising" result has a large effect size relative to a small sample or eval set (n < 100, or single held-out split)
+- **Usually means:** the result is more likely a confound or overfit to the specific split than a genuine effect
+- **First question:** "Does this replicate on an independent held-out split or a second dataset?"
+- **Data to pull:** sample/eval-set size and results on any independent replication split attempted
+
+### A safety-critical system relies on one verification method (e.g., a software test suite) with no independent check
+- **Usually means:** a second, structurally different safeguard (hardware interlock, out-of-sample audit) was removed as "redundant" when it was actually the backstop for the first method's blind spots
+- **First question:** "What independent verification method exists that doesn't share the same failure mode as the primary one?"
+- **Data to pull:** the verification/test coverage report and a list of any interlocks or checks removed in the last revision
+
+### A reviewer-facing rebuttal reframes a null or negative ablation result as a "limitation for future work" rather than revising the headline claim
+- **Usually means:** the headline claim is being preserved past the point the evidence supports it
+- **First question:** "Does the abstract's claim still hold once this negative ablation result is accounted for?"
+- **Data to pull:** the ablation result in question and the exact wording of the abstract's claim
+
+### A funding proposal's Broader Impacts section restates the Intellectual Merit content in different words rather than describing a distinct activity
+- **Usually means:** the two required NSF statements aren't actually distinct, which reads as a box-checking exercise to a program officer
+- **First question:** "What specific broader-impact activity (education, outreach, dataset/tool release to a wider community) exists independent of the research contribution itself?"
+- **Data to pull:** the Broader Impacts paragraph text side-by-side with the Intellectual Merit paragraph
+
+### A terminology dispute surfaces where a term of art ("reproduced" vs. "replicated," "significant" vs. "statistically significant") is used loosely across sections of the same paper
+- **Usually means:** terminology misuse is blurring a distinction reviewers will hold the paper to
+- **First question:** "Is this term used consistently with its ACM/field-standard definition everywhere it appears in the draft?"
+- **Data to pull:** every instance of the term in the draft, checked against the standard definition

--- a/roles/computer-information-research-scientist/references/vocabulary.md
+++ b/roles/computer-information-research-scientist/references/vocabulary.md
@@ -1,0 +1,71 @@
+### Ablation
+
+A controlled experiment that removes or isolates one factor at a time against a fixed baseline to attribute a metric change to that specific factor, rather than to the sum of everything that changed alongside it.
+**In use:** "Add a row for the batch-size change alone — we can't credit the module until the ablation isolates it."
+**Common misuse:** Calling any before/after comparison an "ablation" when only one configuration was run — an ablation requires a table of intermediate configurations, not a single baseline-vs-final comparison.
+
+### Reproducibility (vs. replicability)
+
+Reproducibility means an independent party gets the same result using the *original* authors' code and data; replicability means an independent party gets the same result with *new* code and/or new data testing the same hypothesis — a stronger, more meaningful bar. The ACM's post-2020 terminology swapped which word means which, reversing the pre-2020 usage.
+**In use:** "The code ran and matched — that's reproduced. We haven't shown it replicates on an independent implementation."
+**Common misuse:** Using "reproducible" to mean "the underlying finding is true," when it only certifies that a specific artifact reruns to the same output — a bug can reproduce perfectly.
+
+### Artifact badge (ACM)
+
+A tiered certification (Available → Evaluated–Functional → Evaluated–Reusable → Results Reproduced → Results Replicated) attached to a paper's submitted code/data package, awarded by reviewers who actually exercise the artifact, not claimed by the authors.
+**In use:** "We're targeting Evaluated–Functional — the Docker image is pinned and the eval script runs end to end."
+**Common misuse:** Writing "artifacts available" in the paper without an actual reviewed submission, treating the aspiration as if it were the certification.
+
+### Mathiness
+
+Formal notation (equations, theorems, big-O statements) that dresses up an informal or unverified claim in the appearance of rigor without adding any precision the prose didn't already have — a named failure mode from Lipton & Steinhardt's "Troubling Trends" taxonomy, not a synonym for "too much math."
+**In use:** "That theorem restates the intuition in symbols — cut it or make it actually load-bearing; right now it's mathiness."
+**Common misuse:** Treating "the paper has equations" as itself a sign of rigor, when the test is whether the formalism proves something the prose claim didn't already establish.
+
+### Statistical vs. practical significance
+
+A p-value below threshold says an effect is unlikely to be pure noise given the sample; it says nothing about whether the effect size is large enough to matter for the claim being made. The two are independent axes, not a spectrum.
+**In use:** "p < 0.01, but the effect is a 0.3-point gain on a 100-point scale — statistically real, practically negligible for the claimed use case."
+**Common misuse:** Reporting a low p-value as if it settles whether a result is "significant" in the everyday sense of important, without separately reporting or reasoning about effect size.
+
+### Speculation vs. explanation
+
+Explanation is a causal account backed by controlled evidence (an ablation, a mechanism test); speculation is a plausible-sounding causal story offered without that evidence — a distinct register a draft must mark, per Lipton & Steinhardt, rather than blend into declarative prose.
+**In use:** "We think the gain comes from better gradient flow — flag that as speculation, we haven't run the probe that would show it."
+**Common misuse:** Writing a plausible mechanism in the same declarative voice as an established result, letting the reader infer it was tested when it was only hypothesized.
+
+### Novelty (component vs. system)
+
+Whether the *specific proposed idea* — isolated from every other change riding alongside it (data, tuning, scale, engineering) — is what's new, as opposed to the system as a whole being new because of an accumulation of untested auxiliary changes.
+**In use:** "The pipeline is new, sure, but is the attention mechanism itself novel, or is that the part that's actually prior work with new hyperparameters?"
+**Common misuse:** Claiming novelty for the paper's headline component when the actual delta from prior work is concentrated in incidental engineering choices the ablation hasn't separated out.
+
+### Confound
+
+A variable that changed alongside the variable of interest and offers an alternative explanation for the observed effect, making the causal attribution ambiguous unless it's controlled for or ruled out.
+**In use:** "Training compute went up at the same time as the architecture change — that's a confound until we hold compute fixed."
+**Common misuse:** Using "confound" loosely to mean any source of noise or uncertainty, rather than its specific meaning — a *co-varying* alternative cause that could produce the same result.
+
+### IRB-equivalent review
+
+A project-specific ethics and consent review process for a study involving human subjects' behavior or data, distinct from and not satisfied by a platform's general terms-of-service — the review is scoped to the specific intervention, not the platform's blanket data-use permission.
+**In use:** "The platform's ToS covers general data use, but we still need IRB-equivalent sign-off — this experiment manipulates what users see."
+**Common misuse:** Treating "users already agreed to the ToS" as sufficient ethical cover for an experiment that manipulates behavior or emotional state in ways the ToS was never scoped to anticipate.
+
+### Broader Impacts (NSF)
+
+A separately labeled statement in an NSF proposal addressing the societal benefit of the proposed work — distinct from, and not satisfied by, folding societal-benefit language into the Intellectual Merit narrative as unlabeled prose.
+**In use:** "Broader Impacts needs its own labeled section — right now it's a paragraph buried inside Intellectual Merit, and that's a formatting rejection risk."
+**Common misuse:** Treating Broader Impacts as a rhetorical flourish woven through the proposal rather than a mechanically separate, explicitly labeled section a program officer checks for before reading substance.
+
+### Effect size
+
+The magnitude of a measured difference (e.g., percentage points, Cohen's d), reported independent of whether that difference cleared a significance threshold — the number a reader needs to judge practical importance, which a p-value alone cannot supply.
+**In use:** "State the effect size in the abstract, not just significant/not significant — a reviewer can't judge importance from a p-value alone."
+**Common misuse:** Omitting effect size and reporting only significance, leaving the reader unable to distinguish a large practically important gain from a tiny but statistically detectable one.
+
+### Overfitting to the benchmark
+
+A model or method improving on a specific benchmark's test set in ways that don't transfer to the underlying capability the benchmark was meant to proxy — often via repeated benchmark-driven iteration (implicit test-set leakage) rather than a genuine capability gain.
+**In use:** "We've iterated against this benchmark for six months — check on a held-out benchmark before claiming the capability generalizes."
+**Common misuse:** Treating state-of-the-art on one benchmark as direct evidence of the general capability it was designed to measure, without checking transfer to a different benchmark or distribution.


### PR DESCRIPTION
Rubric score: 18/18

## Resolution rationale

O*NET 15-1221.00 (Computer and Information Research Scientists) is fundamentally about original research into computing theory and methods: designing new algorithms, computing languages, data structures, or software/hardware architectures, running experiments to validate approaches, and publishing findings — often at the frontier where no established solution exists yet. None of the three candidates share that core.

computer-information-systems-manager (11-3021.00) is a business-facing IT operations/strategy owner — vendor TCO, technical-debt-as-budget-line, security-risk-in-business-terms, build-vs-buy-by-differentiation. Its decision framework and worked example are about managing an existing IT function, not inventing new computing methods. A research scientist choosing between algorithmic approaches or designing a novel distributed protocol would get zero relevant guidance here — the tools (ITSM platforms, vendor contracts, DR planning) and failure modes (technology-first decisions, ignoring debt) don't map at all.

computer-systems-analyst (15-1211.00) is closest by O*NET family number but is about requirements elicitation, gap analysis, and feasibility (TELOS) for deploying/integrating existing enterprise systems (ERP replatforming, legacy migration) — a business-analyst function bridging sponsors and implementers. Its tools (RTM, JAD sessions, ICDs, data profiling for migration) and worked example (NetSuite replatform decision) are about choosing and integrating off-the-shelf systems, not originating new computational theory, algorithms, or architectures. A research scientist doesn't run TELOS feasibility studies or requirements traceability matrices as their core method — they run experiments, prove correctness/complexity properties, and prototype new approaches. Applying computer-systems-analyst's decision framework to a research-scientist task would produce actively wrong guidance (e.g., "default to buy/configure over customize" is backwards for someone whose job is to invent, not procure).

clinical-research-coordinator (11-9121.00) is healthcare trial operations — informed consent, protocol deviations, enrollment funnels — entirely unrelated domain; included only as a keyword-research false positive, not a real candidate.

Since no candidate's parent role legitimately covers "originate new computing methods/algorithms/architectures via research," and forcing this under either IT-manager or systems-analyst would mean a real CS researcher gets business-analyst or IT-ops guidance instead of research methodology, this needs a new top-level role rather than a leaf under an existing one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new top‑level role for Computer and Information Research Scientists (O*NET 15-1221.00) with concrete guidance on ablations, reproducibility, and NSF proposal mechanics. Updates role counts and adds a Dual‑Graph Context Policy for consistent MCP usage.

- **New Features**
  - Added `roles/computer-information-research-scientist` with `SKILL.md` and references (`artifacts.md`, `red-flags.md`, `vocabulary.md`).
  - Registered the role in `data/roles.json` (spec 2, O*NET‑mapped); updated counts in `README.md` and `ROADMAP.md`.
  - Added Dual‑Graph Context Policy to `CLAUDE.md` (graph usage order, caps, token tools, session hygiene).
  - Updated `.gitignore` to exclude `.dual-graph/`.

<sup>Written for commit 983984b3a826f8324881db7024394074deeaed1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

