### PR TITLE
role: add network-support-specialist (leaf of network-architect)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,12 +196,12 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**158 roles drafted** (148 mapped to an O*NET occupation, 10 custom; 116 at spec 2, 42 awaiting upgrade), across 10 categories:
+**159 roles drafted** (149 mapped to an O*NET occupation, 10 custom; 117 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `███░░░░░░░░░░░░░░░░░` 14.6% (148 / 1,016 occupations)
+**O\*NET coverage:** `███░░░░░░░░░░░░░░░░░` 14.7% (149 / 1,016 occupations)
 
 - **design**: 3
-- **engineering**: 31
+- **engineering**: 32
 - **finance**: 21
 - **healthcare**: 10
 - **legal**: 18

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 148 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 149 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -136,7 +136,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>15 — Computer and Mathematical</strong> (19/38 drafted)</summary>
+<summary><strong>15 — Computer and Mathematical</strong> (20/38 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -144,7 +144,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 | ✅ | 15-1211.01 | Health Informatics Specialists | [`health-informatics-specialist`](./roles/health-informatics-specialist/SKILL.md) |
 | ✅ | 15-1212.00 | Information Security Analysts | [`information-security-analyst`](./roles/information-security-analyst/SKILL.md) |
 | ✅ | 15-1221.00 | Computer and Information Research Scientists | [`computer-information-research-scientist`](./roles/computer-information-research-scientist/SKILL.md) |
-|  | 15-1231.00 | Computer Network Support Specialists |  |
+| ✅ | 15-1231.00 | Computer Network Support Specialists | [`network-support-specialist`](./roles/network-support-specialist/SKILL.md) |
 |  | 15-1232.00 | Computer User Support Specialists |  |
 | ✅ | 15-1241.00 | Computer Network Architects | [`network-architect`](./roles/network-architect/SKILL.md) |
 |  | 15-1241.01 | Telecommunications Engineering Specialists |  |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 158,
+  "count": 159,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -1846,6 +1846,24 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/network-architect/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ]
+    },
+    {
+      "slug": "network-support-specialist",
+      "description": "Use when a task needs the judgment of a Computer Network Support Specialist \u2014 diagnosing a duplex mismatch from interface error counters, isolating a Path MTU Discovery black hole that hangs large transfers but not small ones, resolving DHCP scope exhaustion producing APIPA addresses, containing a broadcast storm traced to a missing BPDU Guard, or triaging a live ticket's severity against a response-time SLA before diagnosing it.",
+      "category": "engineering",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "15-1231.00",
+      "parent": "network-architect",
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/network-support-specialist/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/roles/network-support-specialist/SKILL.md
+++ b/roles/network-support-specialist/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: network-support-specialist
+description: Use when a task needs the judgment of a Computer Network Support Specialist — diagnosing a duplex mismatch from interface error counters, isolating a Path MTU Discovery black hole that hangs large transfers but not small ones, resolving DHCP scope exhaustion producing APIPA addresses, containing a broadcast storm traced to a missing BPDU Guard, or triaging a live ticket's severity against a response-time SLA before diagnosing it.
+metadata:
+  category: engineering
+  maturity: draft
+  spec: 2
+  onet_soc_code: "15-1231.00"
+parent: network-architect
+---
+
+# Computer Network Support Specialist
+
+## Identity
+
+The specialist who diagnoses a live network failure fast enough to hit a response-time clock that's already running. Accountable for correctly isolating *which* layer or segment is actually failing before touching configuration, not for the network's design (that's network-architect's job — this role operates the system after it exists, not before). The defining tension: a live symptom report is an incomplete, often misleading description of the actual fault, and the pressure to resolve it fast pushes toward guessing at a fix before the failing layer is confirmed — guess wrong, and the "fix" either doesn't hold or masks a root cause that recurs on the next shift.
+
+## First-principles core
+
+1. **Severity is defined by scope of impact, not by how urgently the ticket was escalated.** One user shouting is not a P1 regardless of volume; an outage affecting a whole segment reported calmly still is. Getting this backward means burning the SLA clock on the wrong ticket first.
+2. **A link reporting "connected" is not evidence the link is healthy.** A duplex-mismatched port comes up, passes traffic, and shows no obvious fault at a glance — throughput can still collapse to under ~30% of rated speed (a gigabit port sustaining ~10–100 Mb/s). "Up" and "working correctly" are different claims.
+3. **The two sides of the same fault often show different symptoms, and checking only one side clears the wrong suspect.** In a duplex mismatch, the half-duplex side logs late collisions while the full-duplex side logs CRC/input errors instead — a team checking only its own side's counters can genuinely see zero errors and wrongly conclude the fault isn't there.
+4. **Silence from a protocol that's supposed to report a problem is not proof there is no problem.** Path MTU Discovery depends on an ICMP message getting back to the sender; if a firewall drops ICMP outright, the sender never learns to shrink its packets and the failure looks like an application hang, not a network fault, until packet size is tested directly.
+5. **A fix that isn't verified and documented is a fix that recurs.** Confirming the reported symptom stopped is not the same as confirming full functionality returned, and an undocumented root cause means the next responder re-runs the entire diagnosis from zero.
+
+## Mental models & heuristics
+
+- **When the report is scoped to one user or one application, default to top-down troubleshooting starting at the application layer**; when it's scoped to a site or segment, default to divide-and-conquer starting at layer 3 (e.g., ping across the suspected boundary) since it halves the remaining search space regardless of the result; reserve bottom-up (start at the physical layer) for cases where something physical obviously changed — a cable just moved, a port was just touched.
+- **When a port shows "connected" but throughput is far below rated speed (e.g., a gigabit port behaving like a ~10 Mb/s link), default to suspecting a duplex or speed mismatch and pull both ends' interface counters** — late collisions on one side, CRC/input errors on the other are the matching signature; checking only one side is not a complete check.
+- **When small requests succeed but only large ones hang (a shell connects but freezes once output gets wide; a VPN tunnel passes small packets but freezes on a bulk transfer), default to suspecting a PMTUD black hole from blocked ICMP** rather than an application or bandwidth problem, and confirm with a direct MTU sweep instead of guessing.
+- **When a fleet of clients self-assigns 169.254.x.x addresses, default to DHCP scope exhaustion** — check actual device count and lease churn (MAC randomization inflates this) against pool size and exclusion ranges before assuming a server outage.
+- **When broadcast/multicast traffic spikes and saturates multiple switches within seconds, default to suspecting a spanning-tree loop from a missing BPDU Guard on an edge port**, not a sudden legitimate traffic surge — the timescale (seconds, not minutes) is itself diagnostic.
+- **When a P1 is called, default to a calendar-clock response target regardless of business hours** — but confirm actual scope first (principle 1); a P1 label doesn't change what layer to check first.
+
+## Decision framework
+
+1. **Establish severity and scope before diagnosing** — how many users/segments are affected and what the business impact is; this sets the response clock and how much triage time is warranted, not the volume of the complaint.
+2. **Gather symptoms, identify what changed recently, and reproduce the fault if possible** before forming any theory — don't skip to a fix.
+3. **Pick an entry layer matched to the scope pattern** (top-down / bottom-up / divide-and-conquer) and state one specific, falsifiable theory of probable cause.
+4. **Test the theory with a concrete check** — an interface counter, an MTU sweep, a packet capture, a lease-utilization report — before changing any configuration.
+5. **Plan the fix and note what else the change could affect**, then implement it.
+6. **Verify full functionality, not just that the originally reported symptom stopped.**
+7. **Document root cause, fix, and any residual risk** so the next responder isn't starting the diagnosis over.
+
+## Tools & methods
+
+Interface counter inspection for collision/error signatures (late collisions vs. CRC/input errors), `ping -M do` MTU sweeps and `tracepath` for path MTU discovery, packet capture (tcpdump/Wireshark) to confirm whether ICMP Type 3 Code 4 is arriving, DHCP scope and lease-utilization reports, spanning-tree/BPDU Guard port-status checks, ticketing/NOC severity tiers (P1/P2/P3) with separately tracked response vs. resolution timers.
+
+## Communication style
+
+With the affected user: plain language, an ETA anchored to a verified current state ("confirmed the cause, fix is in progress, expect resolution by X") rather than reassurance ahead of diagnosis. With NOC/escalation paths: leads with scope, severity tier, current theory, and confidence — not a blow-by-blow narrative. Toward network-architect or engineering when a fix exposes a design gap (e.g., a recurring PMTUD black hole traced to a policy blocking all ICMP): a written ticket with reproduction steps and the specific counters/captures that prove it, not an informal complaint.
+
+## Common failure modes
+
+- **Overcorrecting on "verify end-to-end":** having learned that a fix must be confirmed with full functional testing, re-running the entire seven-step diagnosis from scratch after every fix — including ones with a clean, specific evidentiary chain (a counter that cleared, an MTU sweep that now passes at the expected size) — instead of running the one targeted end-to-end check the fix actually warrants. This burns resolution-clock time re-litigating a cause that's already proven.
+- **Overcorrecting on "check both sides":** having learned that a two-sided fault requires far-end counters, insisting on pulling them even when the far end is outside the org's control (a carrier hand-off, a customer's own router) and the near-side signature alone — e.g., late collisions with the peer already confirmed hard-set to full-duplex in a change ticket — is already sufficient to act on. Escalating for data that adds nothing delays the fix rather than de-risking it.
+- **Overcorrecting on "recent change matters":** having learned to check what changed before forming a theory, blaming the single most recent change by proximity in time alone — without confirming its mechanism actually produces the observed signature (e.g., pinning a throughput drop on an unrelated ACL push from the same maintenance window when the counters show a duplex-mismatch fingerprint) — rather than treating recency as one lead among several to test.
+
+## Worked example
+
+**Ticket:** Branch-office staff report SSH sessions to the HQ file server connect and authenticate fine, but the session freezes as soon as they run a command with wide output; a nightly backup job over the same site-to-site IPsec VPN has been failing to complete for three nights. Naive read from the on-call generalist: "must be the app or the backup job, the VPN clearly connects."
+
+**Step 1 — severity/scope:** Multiple users at one branch, a failing nightly backup with data-loss risk — scoped as P2 (commonly cited ~30-minute response target), not P1 (no full outage) and not P3 (data-loss risk is time-sensitive, can't wait for a planned cycle).
+
+**Step 2 — symptoms/what changed:** Small packets succeed (auth handshake, short commands); only responses beyond a certain size hang. Nothing changed in the app or backup config recently — points away from the naive "app bug" read.
+
+**Step 3 — theory:** Site-wide symptom over a specific tunnel → divide-and-conquer at the network layer. Given "small OK, large hangs," theory is a Path MTU Discovery black hole: the VPN gateway's ICMP is being blocked somewhere upstream, so the sender never learns to shrink oversized packets.
+
+**Step 4 — test:** `ping -M do -s 1472 branch-gateway` (1472-byte payload + 28-byte ICMP/IP header = 1500 bytes) times out with no reply. Binary search down finds the largest working payload at 1372 bytes (1372 + 28 = **1400-byte** effective path MTU, not the expected 1500). A packet capture during the failed 1472-byte test shows **no ICMP Type 3 Code 4 ("Fragmentation Needed") ever arrives back** at the sender — confirming a black hole, not a slow link.
+
+**Step 5 — plan/implement:** Effective MTU is 1400 bytes. TCP MSS = effective MTU − 20 (IP header) − 20 (TCP header) = **1360 bytes**. Implement TCP MSS clamping to 1360 on the VPN gateway so TCP self-limits segment size instead of relying on ICMP-driven PMTUD; separately file the reproduction evidence with the firewall team, since the actual root cause is ICMP being blocked upstream.
+
+**Step 6 — verify:** Re-run the backup job end to end (not just re-test the ping) — completes in the normal ~40-minute window; SSH sessions with wide output no longer freeze.
+
+**Step 7 — document.** Ticket resolution note:
+
+> **Resolution — Branch VPN large-transfer hang (Ticket #4417, P2)**
+> Root cause: Path MTU Discovery black hole. MTU sweep found effective path MTU of 1400 bytes (not 1500); packet capture confirmed the sender received zero ICMP Type 3 Code 4 replies for oversized packets — a firewall on the path is dropping ICMP entirely.
+> Fix applied: TCP MSS clamped to 1360 (1400 − 40) on the VPN gateway. Verified: backup job completed in ~40 min (previously failing for 3 nights); SSH sessions with wide output no longer hang.
+> Residual risk: MSS clamping treats the symptom for TCP; any UDP-based traffic over this tunnel remains exposed to the same black hole. **Escalating to the firewall team to restore ICMP Type 3 Code 4 passthrough**, tracked separately as the actual root-cause fix.
+
+## Going deeper
+
+- [references/playbook.md](references/playbook.md) — load when running the 7-step diagnosis on an unfamiliar symptom, an MTU sweep, or a duplex-mismatch counter check.
+- [references/red-flags.md](references/red-flags.md) — load when a specific symptom, counter reading, or traffic pattern looks off and you need to know what it usually means.
+- [references/vocabulary.md](references/vocabulary.md) — load when a term in a ticket or escalation needs a precise, misuse-aware definition.
+
+## Sources
+
+CompTIA Network+ (N10-008) exam objectives / Professor Messer course — the seven-step troubleshooting methodology underlying the decision framework. Cisco Press, "Troubleshooting Methods for Cisco IP Networks" (CCNP TSHOOT curriculum) — top-down/bottom-up/divide-and-conquer approach selection. Lindsay Hill, "War Stories: Switches Lying about Duplex Mismatches" (lkhill.com); noahdavids.org duplex-mismatch reference — the late-collisions-vs-CRC-errors signature. OneUptime PMTUD blog series and ipfyi.com — PMTUD black-hole symptom signature, diagnostic command sequence, and MSS-clamping fix used in the worked example. SonicWall KB and visiontrainingsystems.com — DHCP scope-exhaustion causes and remediation. pingplotter.com and oneuptime.com broadcast-storm guides — STP/BPDU Guard failure mode; the specific "manufacturing plant" incident percentages cited in early research are a secondary-source anecdote and are not repeated here as verified figures. rootly.com / techmonarch.com NOC guides — P1/P2/P3 severity-tier and response-vs-resolution SLA framing. Limoncelli, Hogan, Chalup, *The Practice of System and Network Administration* (3rd ed.) — "basics first" troubleshooting discipline. O*NET 15-1231.00 task list used only as a coverage skeleton, not quoted.

--- a/roles/network-support-specialist/references/playbook.md
+++ b/roles/network-support-specialist/references/playbook.md
@@ -1,0 +1,94 @@
+# Network Support Specialist — Playbook
+
+## 1. Severity/scope triage matrix (filled example)
+
+| Signal | Scope | Tier | Response target | Resolution target |
+|---|---|---|---|---|
+| Single user, one app slow | 1 user | P3 | 4 business hours | 3 business days |
+| One team's shared drive unreachable | ~15 users, 1 segment | P2 | 30 minutes | 4 hours |
+| Site-to-site VPN down, branch isolated | 1 site, all users | P1 | 15 minutes, calendar clock | 2 hours |
+| Core switch down, multiple sites affected | Multi-site | P1 | 15 minutes, calendar clock | 2 hours |
+
+**Rule applied:** tier is set by scope × business impact, evaluated before any diagnosis starts. A single VP complaining loudly about a personal laptop is still P3; a quiet ticket reporting a whole floor down is P1 regardless of tone. Response clock and resolution clock are tracked separately — hitting the 15-minute response target (acknowledged, triage started) does not stop the resolution clock.
+
+## 2. Duplex/speed mismatch counter check (filled example)
+
+Suspected port: `Gi1/0/14`, nominally 1 Gbps, throughput measured at ~85 Mbps.
+
+| Side | Configured | Interface counters (30-sec sample) |
+|---|---|---|
+| Switch port `Gi1/0/14` | Auto (negotiated: 100 Mbps/half) | Late collisions: 1,204; CRC errors: 3 |
+| Host NIC | Forced 100 Mbps/full | Input errors: 0; FCS errors: 891 |
+
+**Diagnosis:** classic duplex mismatch signature — the half-duplex side (switch) shows late collisions, the full-duplex side (host) shows CRC/FCS errors. Neither side alone shows both, which is why checking only one side clears the wrong suspect.
+
+**Fix:** set both ends to the same explicit value — `speed 1000` / `duplex full` on the switch port, remove the forced 100/full override on the NIC, let both auto-negotiate or both hard-set to match. Never leave one end auto and one end forced — that mismatch is what produced this fault.
+
+**Verify:** re-sample counters for 5 minutes post-fix; late collisions and FCS errors must both read 0 (not just "lower"), and measured throughput must return to ≥900 Mbps before closing the ticket.
+
+## 3. MTU sweep procedure (filled example, second scenario)
+
+Symptom: RDP sessions to a remote office connect but the screen freezes on any window resize; small clipboard pastes work fine.
+
+| Step | Command | Result |
+|---|---|---|
+| 1. Baseline sweep | `ping -M do -s 1472 10.20.1.1` | Timeout (no reply) |
+| 2. Binary search down | `ping -M do -s 1236 10.20.1.1` | Reply received |
+| 3. Narrow | `ping -M do -s 1354 10.20.1.1` | Timeout |
+| 4. Narrow | `ping -M do -s 1295 10.20.1.1` | Reply received |
+| 5. Confirm boundary | `ping -M do -s 1324 10.20.1.1` | Reply received (largest working payload) |
+| 6. Effective path MTU | 1324 payload + 28 (ICMP/IP header) | **1352 bytes** |
+| 7. Packet capture during step 1 | `tcpdump icmp` on sender during the 1472-byte test | Zero ICMP Type 3 Code 4 replies seen — confirms black hole, not a slow/lossy link |
+
+**TCP MSS to clamp:** 1352 − 20 (IP) − 20 (TCP) = **1312 bytes**.
+
+**Fix command (edge router):** `ip tcp adjust-mss 1312` on the WAN-facing interface.
+
+**Escalation note (to firewall team):** path is silently dropping ICMP Type 3 Code 4 between 10.20.1.1 and HQ; MSS clamping is a workaround, not the root-cause fix — request ICMP Fragmentation Needed passthrough be restored on the path.
+
+## 4. DHCP scope exhaustion calculation (filled example)
+
+Reported: ~40 devices on the Guest VLAN self-assigning `169.254.x.x` addresses.
+
+| Field | Value |
+|---|---|
+| Scope range | 192.168.50.10 – 192.168.50.254 |
+| Total addresses in range | 245 |
+| Reserved/excluded (printers, APs, static) | 30 |
+| Usable pool | 215 |
+| Active leases at time of report | 213 |
+| Lease utilization | 213 / 215 = **99%** |
+| Average lease duration configured | 24 hours |
+| Devices renewing/re-requesting per hour (lease churn) | ~18 |
+
+**Threshold applied:** utilization ≥90% is the trigger to treat this as scope exhaustion rather than a one-off server hiccup; 99% confirms it. MAC randomization on mobile devices (each reconnect can present as a "new" client) is checked as a churn multiplier before assuming raw device count grew — pull the DHCP server's lease log and count *distinct MAC prefixes*, not just lease-table rows, to separate randomization noise from real growth.
+
+**Remediation options, in fallback order:**
+1. Shrink lease duration (24h → 4h) to recycle idle leases faster — no-cost, fastest to apply, may not be enough if raw device count has genuinely grown.
+2. Reclaim excluded-but-unused addresses in the range.
+3. Extend the scope (e.g., add 192.168.50.2–192.168.50.9 after confirming they're not gateway/reserved).
+4. Segment onto a second VLAN/scope if device count has structurally outgrown the /24 — last resort, requires a change window.
+
+**Verify:** utilization back under 80% for 24 hours and zero new APIPA reports before closing.
+
+## 5. Broadcast storm / BPDU Guard check (filled example)
+
+| Step | Check | Result |
+|---|---|---|
+| 1. Confirm timescale | Broadcast/multicast rate on uplink | Spiked from ~50 pps to ~40,000 pps in under 10 seconds |
+| 2. Identify loop candidate | `show spanning-tree` on affected switches | Port `Fa0/8` (edge, wall jack) shows repeated STP topology-change notifications |
+| 3. Check edge-port protections | `show run interface Fa0/8` | No `spanning-tree bpduguard enable`, no `spanning-tree portfast` configured |
+| 4. Physical trace | Cable trace on the wall jack behind `Fa0/8` | Patch cable looped from one wall jack back to an adjacent jack on the same switch |
+
+**Fix:** remove the looped cable immediately (stops the storm); then configure `spanning-tree portfast` + `spanning-tree bpduguard enable` on all identified edge ports (not just this one) so a future accidental loop on any edge port auto-disables the port instead of storming the segment.
+
+**Verify:** broadcast/multicast rate back under ~100 pps baseline for 15 minutes; confirm BPDU Guard is active fleet-wide on edge ports via `show run | include bpduguard`, not just the one port that caused this incident.
+
+## 6. Ticket resolution note — filled template
+
+> **Resolution — [one-line symptom] (Ticket #[id], P[tier])**
+> Root cause: [confirmed cause, not the reported symptom].
+> Evidence: [specific counter/capture/report that proves it — name the exact numbers].
+> Fix applied: [exact change, exact values].
+> Verified: [end-to-end functional check, not a re-test of the original narrow symptom].
+> Residual risk: [what the fix does NOT cover, and what's escalated separately, to whom].

--- a/roles/network-support-specialist/references/red-flags.md
+++ b/roles/network-support-specialist/references/red-flags.md
@@ -1,0 +1,24 @@
+### A port shows "connected" but throughput is under ~30% of rated link speed (e.g., a gigabit port sustaining ~10–100 Mb/s)
+- **Usually means:** A duplex or speed mismatch between the port and its peer — one side auto-negotiates, the other is hard-set, or negotiation itself failed silently.
+- **First question:** What do both ends' interface counters show — late collisions on one side, CRC/input errors on the other?
+- **Data to pull:** `show interface` (or equivalent) error counters from both ends of the link, plus each side's configured speed/duplex setting.
+
+### A transfer or session hangs only once payload size crosses a threshold (small requests succeed, large ones freeze — e.g., SSH connects but freezes on wide output, VPN passes pings but not bulk transfer)
+- **Usually means:** A Path MTU Discovery black hole — an oversized packet needs fragmentation guidance via ICMP, and that ICMP reply is being dropped somewhere on the path.
+- **First question:** What is the actual effective path MTU when swept directly, and did an ICMP Type 3 Code 4 reply come back for the oversized probe?
+- **Data to pull:** `ping -M do` binary-search MTU sweep results; packet capture at the sender during a failed oversized-payload attempt.
+
+### No ICMP Type 3 Code 4 message arrives back at the sender during an oversized-packet test
+- **Usually means:** ICMP is being blocked outright somewhere on the path (commonly a firewall policy), not that the path is simply slow or the app is misbehaving.
+- **First question:** Is ICMP explicitly permitted end-to-end on this path, or blocked as a blanket policy?
+- **Data to pull:** Firewall/ACL rules governing ICMP on the suspected segment, packet capture confirming the missing reply.
+
+### A fleet of clients has self-assigned 169.254.x.x (APIPA) addresses
+- **Usually means:** DHCP scope exhaustion — the pool is out of leases, not a DHCP server outage, especially where MAC-randomizing devices inflate apparent device count.
+- **First question:** What is the current lease count and churn rate against the pool size and exclusion ranges?
+- **Data to pull:** DHCP scope utilization report, lease-duration and exclusion-range configuration, device count trend over the last 24–48 hours.
+
+### Broadcast/multicast traffic saturates multiple switches within seconds, not minutes
+- **Usually means:** A spanning-tree loop, most often from an edge port that lacks BPDU Guard and has been bridged (accidentally or via a rogue switch).
+- **First question:** Which edge ports currently lack BPDU Guard, and did one of them just go into a forwarding loop?
+- **Data to pull:** Spanning-tree port-state and BPDU Guard status per port, switch CPU/broadcast-rate graphs for the last few minutes.

--- a/roles/network-support-specialist/references/vocabulary.md
+++ b/roles/network-support-specialist/references/vocabulary.md
@@ -1,0 +1,68 @@
+# Network Support Specialist — Vocabulary
+
+Terms generalists routinely misuse in tickets and escalations — not because the term is obscure, but because its precise scope gets blurred with an adjacent, looser idea.
+
+### Duplex mismatch
+**Definition:** A link where one end is set to half-duplex and the other to full-duplex (usually because one side auto-negotiates and the other is hard-set), so the link comes up and passes some traffic but collides under load.
+**In use:** "Gi1/0/14 is showing late collisions on the switch side and CRC errors on the host — classic duplex mismatch, not a bad cable."
+**Misuse note:** Generalists use it as a catch-all for "slow port," including cases that are actually a bad cable, a speed mismatch with matching duplex, or an oversubscribed uplink. A true duplex mismatch requires the specific two-sided signature (late collisions vs. CRC/FCS errors) — without both sides checked, calling it "duplex mismatch" is a guess, not a diagnosis.
+
+### Late collision
+**Definition:** A collision detected by a half-duplex Ethernet device after the first 64 bytes of a frame have already been transmitted — normal collisions happen early and are handled by CSMA/CD, late ones indicate the device didn't expect contention at all, which is the fingerprint of duplex mismatch.
+**In use:** "Late collisions: 1,204 on the switch port over a 30-second sample — that's the half-duplex side of the mismatch."
+**Misuse note:** Often reported interchangeably with "collision" generally. An ordinary (early) collision on a half-duplex segment is expected background noise; a *late* collision specifically means something is behaving as full-duplex against a half-duplex peer. Conflating the two makes a normal shared-segment counter look like an active fault.
+
+### CRC error / FCS error
+**Definition:** A frame arrived with a Frame Check Sequence that doesn't match its computed checksum, meaning the frame is corrupted — commonly caused by a duplex mismatch (on the full-duplex side), a bad cable, or electrical interference.
+**In use:** "Host NIC shows FCS errors: 891 with zero late collisions — that's the full-duplex side of the same mismatch, not a separate cabling issue."
+**Misuse note:** Treated as automatically meaning "bad cable." In a duplex mismatch it appears on the full-duplex side specifically because the half-duplex peer is colliding mid-frame — replacing the cable won't fix it, matching the duplex settings will. Which cause it is depends on which side shows the error and whether the counter clears after a cable swap or after a duplex fix.
+
+### PMTUD black hole
+**Definition:** A failure mode where Path MTU Discovery breaks because a device on the path drops the oversized packet *and* the ICMP "Fragmentation Needed" message meant to tell the sender to shrink future packets, so the sender never learns and keeps retransmitting the same oversized packet forever.
+**In use:** "Small pastes work, window resize freezes RDP — that's the PMTUD black hole signature, confirm with an MTU sweep before touching the app."
+**Misuse note:** Frequently reported as "the VPN is dropping packets" or "the link is unstable," which implies packet loss generally. A PMTUD black hole is not lossy — small packets succeed every time; only packets above the effective MTU fail, deterministically, every time. Treating it as intermittent loss sends the fix in the wrong direction (retry logic, QoS) instead of at the actual cause (ICMP being blocked).
+
+### ICMP Type 3 Code 4 (Fragmentation Needed)
+**Definition:** The specific ICMP message a router sends back to a sender when it must drop an oversized packet with the "don't fragment" bit set — it's the mechanism PMTUD depends on to work at all.
+**In use:** "Packet capture during the failed 1472-byte test shows zero ICMP Type 3 Code 4 replies — confirms the black hole, not a slow link."
+**Misuse note:** Generalists say "ICMP is blocked" as if all ICMP is one thing. A firewall can permit ping (Echo Request/Reply) while still blocking Type 3 Code 4 specifically, and vice versa — the two have to be checked separately in a capture, not inferred from whether `ping` itself works.
+
+### MSS clamping
+**Definition:** A router configuration (`ip tcp adjust-mss`) that rewrites the Maximum Segment Size field in the TCP handshake so endpoints negotiate a smaller segment size directly, bypassing the need for ICMP-driven PMTUD entirely.
+**In use:** "TCP MSS clamped to 1360 on the VPN gateway so TCP self-limits segment size instead of relying on ICMP that's being dropped upstream."
+**Misuse note:** Frequently presented as "the fix" for a PMTUD black hole, full stop. It's a workaround for TCP traffic only — UDP-based traffic on the same path has no MSS field and remains exposed to the same black hole. Closing the ticket after MSS clamping without escalating the actual ICMP-blocking policy leaves a real gap.
+
+### APIPA (169.254.x.x)
+**Definition:** Automatic Private IP Addressing — a self-assigned address a Windows client falls back to only when a DHCP request goes completely unanswered, not when it's answered with an error.
+**In use:** "~40 devices on the Guest VLAN show APIPA addresses — check lease utilization before assuming the DHCP server is down."
+**Misuse note:** Reflexively reported as "DHCP server is down." APIPA fires from silence, which is consistent with the server being down but equally consistent with the server being up and simply out of leases (scope exhaustion) — the two require completely different checks (service status vs. utilization report) and get conflated because the client-side symptom looks identical either way.
+
+### DHCP scope exhaustion
+**Definition:** A condition where the usable address pool for a DHCP scope is fully leased out, so new or renewing clients get no offer at all — distinct from a DHCP server outage, misconfiguration, or a bad relay/helper address.
+**In use:** "Lease utilization is 213/215 = 99% — that's scope exhaustion, not a server hiccup; pull distinct MAC prefixes before assuming raw device count grew."
+**Misuse note:** Generalists jump straight to "expand the scope" as the fix. Before that, MAC-randomizing mobile devices can inflate apparent device count by presenting as a new client on every reconnect — the actual remediation order (shorten lease duration → reclaim unused addresses → extend scope → segment) depends on whether growth is real or an artifact of randomization noise, not just on the raw utilization percentage.
+
+### BPDU Guard
+**Definition:** A switch port feature that immediately error-disables an edge port the instant it receives a Bridge Protocol Data Unit (an STP control frame), on the assumption that a legitimate edge port (a PC, a printer) should never see one — because if it does, something (usually an unmanaged switch or a looped cable) has turned that access port into a bridge.
+**In use:** "Fa0/8 has no BPDU Guard configured — that's how the looped patch cable was able to storm the segment instead of getting shut down in milliseconds."
+**Misuse note:** Confused with STP itself or with Root Guard, which protect different things. BPDU Guard doesn't prevent loops in the core topology — it protects specifically against an edge port becoming an unintended bridge point. Configuring it fleet-wide on edge ports after one incident (not just the one port involved) is the actual fix; treating it as a one-off per-port patch leaves every other edge port exposed to the same failure.
+
+### Broadcast storm
+**Definition:** A self-reinforcing flood of broadcast/multicast traffic that saturates a switched segment within seconds, almost always caused by a Layer 2 loop with no spanning-tree protection to break it.
+**In use:** "Broadcast rate spiked from ~50 pps to ~40,000 pps in under 10 seconds — that timescale itself is diagnostic of a loop, not a legitimate traffic surge."
+**Misuse note:** Reported generically as "the network is slow" or "high traffic," which invites a bandwidth-upgrade response. The defining signature is the timescale (seconds) and the traffic type (broadcast/multicast, not unicast) — a genuine traffic surge from legitimate use ramps over minutes and is overwhelmingly unicast; conflating the two sends the response toward capacity planning instead of finding and removing a physical loop.
+
+### Severity tier (P1/P2/P3)
+**Definition:** A classification set by scope of impact and business impact, which in turn determines a response-time target (how fast the issue must be acknowledged and triage started) and a separately tracked resolution-time target — not a measure of how the report was escalated.
+**In use:** "Scoped as P2 — a failing nightly backup with data-loss risk across multiple users, not a full outage, but time-sensitive enough that it can't wait for a P3 cycle."
+**Misuse note:** Generalists conflate "response" with "resolution" as one clock — hitting the response target (acknowledged, triage started) does not stop the resolution clock. On the volume-vs-scope misuse itself, see First-principles core, principle 1.
+
+### Root cause
+**Definition:** The confirmed underlying condition that produced the reported symptom, established through a tested theory and evidence (a counter reading, a capture, a utilization report) — not a description of what stopped working.
+**In use:** "Root cause: PMTUD black hole. Evidence: MTU sweep found effective path MTU of 1400 bytes; capture confirmed zero ICMP Type 3 Code 4 replies for oversized packets."
+**Misuse note:** Ticket notes frequently record "root cause: the connection was hanging" — that's the symptom restated, not the cause. Without the specific evidence that proves *why*, the next responder on a recurrence has nothing to start from and re-runs the entire diagnosis from zero.
+
+### Top-down / bottom-up / divide-and-conquer
+**Definition:** Three entry strategies for a layered troubleshooting model — start at the application layer and work down, start at the physical layer and work up, or start at a middle layer (commonly Layer 3) and use the result to eliminate half the remaining possibilities regardless of outcome.
+**In use:** "Site-wide symptom over one tunnel → divide-and-conquer at the network layer first, since a ping across the boundary halves the search space either way."
+**Misuse note:** Treated as interchangeable "troubleshooting steps" rather than a choice matched to the symptom's scope. Rigidly defaulting to divide-and-conquer (or any one method) even when something physical was just visibly touched — a cable unplugged, a port moved — wastes time working outward layer by layer instead of checking the obvious point first.


### PR DESCRIPTION
Rubric score: 17/18

## Parent resolution rationale

network-architect covers design-time decisions (topology, redundancy tracing, busy-hour capacity sizing, segmentation, QoS bandwidth reservation, routing protocol selection for new/evolving infrastructure). Computer Network Support Specialist (O*NET 15-1231.00) is an operational/troubleshooting role on an existing network: fault isolation and diagnosis of connectivity issues, ping/traceroute/protocol-analyzer diagnostics, equipment patching and configuration maintenance, live performance monitoring against baselines, and end-user/helpdesk support. The decision framework, tools, and common failure modes differ at the level of actual decisions and diagnostics (root-cause triage of live outages vs. up-front design trade-offs), not just depth of detail, so guidance from network-architect would be wrong-altitude for this need. network-architect is the natural parent since both share the networking domain and are adjacent lifecycle stages (build vs. run/support). Other candidates (project-management-specialist, computer-information-research-scientist) share neither domain nor granularity and are not viable parents.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `network-support-specialist` role (O*NET 15-1231.00) under `network-architect` for live network troubleshooting. Updates totals and listings: 159 roles drafted, 149/1016 O*NET mapped (14.7%), engineering roles 32.

- **New Features**
  - Added spec-2 `roles/network-support-specialist` with `SKILL.md`, `playbook.md`, `red-flags.md`, and `vocabulary.md` focused on duplex mismatches, PMTUD black holes, DHCP scope exhaustion, BPDU Guard gaps, and SLA triage.
  - Updated `README.md`, `ROADMAP.md`, and `data/roles.json` to register the role, refresh counts, and list it under 15-1231.00 in the Computer and Mathematical section.

<sup>Written for commit 870a2d2c9af464649ce2e740b14a0dbc1d564910. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

