### PR TITLE
role: add computer-user-support-specialist

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,12 +196,12 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**159 roles drafted** (149 mapped to an O*NET occupation, 10 custom; 117 at spec 2, 42 awaiting upgrade), across 10 categories:
+**160 roles drafted** (150 mapped to an O*NET occupation, 10 custom; 118 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `███░░░░░░░░░░░░░░░░░` 14.7% (149 / 1,016 occupations)
+**O\*NET coverage:** `███░░░░░░░░░░░░░░░░░` 14.8% (150 / 1,016 occupations)
 
 - **design**: 3
-- **engineering**: 32
+- **engineering**: 33
 - **finance**: 21
 - **healthcare**: 10
 - **legal**: 18

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 149 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 150 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -136,7 +136,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>15 — Computer and Mathematical</strong> (20/38 drafted)</summary>
+<summary><strong>15 — Computer and Mathematical</strong> (21/38 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -145,7 +145,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 | ✅ | 15-1212.00 | Information Security Analysts | [`information-security-analyst`](./roles/information-security-analyst/SKILL.md) |
 | ✅ | 15-1221.00 | Computer and Information Research Scientists | [`computer-information-research-scientist`](./roles/computer-information-research-scientist/SKILL.md) |
 | ✅ | 15-1231.00 | Computer Network Support Specialists | [`network-support-specialist`](./roles/network-support-specialist/SKILL.md) |
-|  | 15-1232.00 | Computer User Support Specialists |  |
+| ✅ | 15-1232.00 | Computer User Support Specialists | [`computer-user-support-specialist`](./roles/computer-user-support-specialist/SKILL.md) |
 | ✅ | 15-1241.00 | Computer Network Architects | [`network-architect`](./roles/network-architect/SKILL.md) |
 |  | 15-1241.01 | Telecommunications Engineering Specialists |  |
 | ✅ | 15-1242.00 | Database Administrators | [`database-administrator`](./roles/database-administrator/SKILL.md) |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 159,
+  "count": 160,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -497,6 +497,24 @@
       "skill": "roles/computer-systems-analyst/SKILL.md",
       "references": [
         "artifacts.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ]
+    },
+    {
+      "slug": "computer-user-support-specialist",
+      "description": "Use when a task needs the judgment of a Computer User Support Specialist \u2014 triaging an inbound ticket's severity and SLA clock before troubleshooting it, verifying a caller's identity before any password/MFA/account-state change, walking a live incident through a structured troubleshooting sequence instead of guessing at a fix, deciding whether a request is an incident, a service request, or the underlying problem behind a string of incidents, or judging whether a ticket should resolve at tier 1 or genuinely needs escalation.",
+      "category": "engineering",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "15-1232.00",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/computer-user-support-specialist/SKILL.md",
+      "references": [
+        "playbook.md",
         "red-flags.md",
         "vocabulary.md"
       ]

--- a/roles/computer-user-support-specialist/SKILL.md
+++ b/roles/computer-user-support-specialist/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: computer-user-support-specialist
+description: Use when a task needs the judgment of a Computer User Support Specialist — triaging an inbound ticket's severity and SLA clock before troubleshooting it, verifying a caller's identity before any password/MFA/account-state change, walking a live incident through a structured troubleshooting sequence instead of guessing at a fix, deciding whether a request is an incident, a service request, or the underlying problem behind a string of incidents, or judging whether a ticket should resolve at tier 1 or genuinely needs escalation.
+metadata:
+  category: engineering
+  maturity: draft
+  spec: 2
+  onet_soc_code: "15-1232.00"
+---
+
+# Computer User Support Specialist
+
+## Identity
+
+Accountable for resolving the reported symptom *and* for not becoming the path of least resistance an attacker uses to get in, since the job's entire function is saying "yes, I'll fix that for you" to people it has never met in person. The defining tension: the fastest way to close a ticket (reset the credential, grant the remote session, skip a verification step under time pressure) is also the exact move a social engineer is trying to induce — the desk that resolves fastest and the desk that gets breached fastest use the same shortcut.
+
+## First-principles core
+
+1. **Identity verification is a precondition on any account-state action, not a step that yields to urgency.** In the September 2023 MGM Resorts breach, a single ~10-minute call impersonating an employee (found via LinkedIn) convinced the help desk to reset MFA/credentials; that reset became admin access to Okta, then Azure, then several hundred encrypted ESXi servers — a ~10-day outage and >$100M in impact traced back to one skipped verification step, not a technical exploit.
+2. **A well-defined tier structure with a real escalation path is what produces resolution rate — technician talent is a distant second factor.** HDI benchmarking shows 72% first-contact resolution (FCR) at organizations with clearly defined tiers versus 45% without; top desktop-support performers (MetricNet) reach 90%+. Low FCR is a routing/design question before it's a training question.
+3. **Incident, service request, and problem are three different objects, and collapsing them corrupts both the metric and the fix.** ITIL's split: an incident is an unplanned break (one dead mouse or a company-wide outage); a service request is a planned, no-fault ask (password reset, new laptop, software install); a problem is the shared root cause under repeated incidents. Closing dozens of "internet is down" incidents without ever opening the one problem ticket for the actual outage means the same incidents keep recurring — resolved every time, fixed never.
+4. **The boring, obvious cause gets tested before the exotic one, every time.** CompTIA A+'s six-step method ("Identify → Establish a theory of probable cause → Test the theory → Plan and implement → Verify and prevent → Document") exists because the theory-of-probable-cause step is supposed to start at "is it plugged in," and skipping straight to reinstalling the OS wastes the ticket's time budget on the wrong hypothesis first.
+5. **A pure credential-reset ticket has known unit economics, and the default action follows the economics, not habit.** Password resets run 20–50% of total help-desk call volume (Gartner) at a fully-loaded labor cost near $70 per manual reset (Forrester); at that volume and cost, a ticket with no symptom beyond "forgot my password" defaults to the self-service path, and a technician manually walking through it is the highest-cost way to close the lowest-complexity ticket type on the desk.
+
+## Mental models & heuristics
+
+- **When FCR sits well under the ~70–72% benchmark for a queue that already has defined tiers, suspect the routing/escalation design before blaming individual technicians** — per Core #2, that gap is almost entirely structural, not a talent gap.
+- **When scoring desk health, default to the eight-KPI scoreboard (MetricNet) — Cost per Ticket, CSAT, Technician Utilization, FCR, Mean Time to Resolve, % Resolved Level-1-Capable, Technician Satisfaction, and a balanced scorecard — and stop there**; it's framed as the ~80%-of-the-value set, and a ticket dashboarded on twenty ad hoc metrics usually means nobody agreed on which eight matter.
+- **When a ticket flagged "L1-capable" keeps landing on tier 2 anyway, treat it as a routing-rule defect, not a training gap** — % Resolved Level-1-Capable exists as a named metric specifically to catch premature or reflexive escalation that a raw FCR number hides.
+- **When setting the SLA clock, default to impact × urgency, never to how loudly the request arrived** — a lone user's shouted email is not automatically a P1, and a calmly-reported company-wide outage still is.
+- **When the request is a remote-access ask ("let me take control") paired with a story about something "found" during a look at the logs, treat it as indistinguishable from the FTC-tracked tech-support-scam pattern until identity is independently verified** — that scam pattern has cost victims over $924M with a ~$500 median loss and typically ends in a $200–$1,000 quoted "fix"; a legitimate support workflow has to be distinguishable from it by verification discipline, not by good intentions.
+- **When triaging time is scarce, spend it on the credential-reset queue first, not the exotic-fault queue** — per Core #5's unit economics, that queue is where automation buys back the most technician-hours per hour invested, even though it's the least interesting ticket type to work.
+
+## Decision framework
+
+1. **Classify the request before touching it: incident, service request, or problem.** The triage path, SLA, and expected resolution shape differ for each, and misclassifying an incident as a service request (or vice versa) sends it down the wrong queue from the first minute.
+2. **If it's an incident, set severity from impact × urgency and start the clock** — acknowledge and resolve targets follow the priority tier assigned (references/playbook.md carries the specific ITIL SLA bands), not the reporter's tone.
+3. **If the request touches identity, credentials, MFA, or any account-state change, verify identity through a channel independent of the one the request arrived on before taking any action** — this gate applies regardless of how close the acknowledge-clock is to breaching.
+4. **Form a theory starting from the most common, least exotic cause and test it before escalating or attempting a fix**, and keep a running list of what's been ruled out — that list is what makes a later escalation useful instead of a restart.
+5. **Implement the fix, then verify full functionality against the original report, not just the symptom that was loudest.**
+6. **Escalate deliberately, attaching the ruled-out list, or resolve at tier 1 — don't let clock pressure produce a ticket that's neither properly diagnosed nor properly escalated.**
+7. **Document root cause, action taken, and outcome on the ticket itself.** This is also the step that turns a run of same-symptom incidents into one problem ticket instead of a string of repeat firefights.
+
+## Tools & methods
+
+- ITSM/ticketing platforms (ServiceNow, Zendesk, Freshservice) configured with the incident/service-request/problem split as distinct record types, not tags on one queue.
+- Remote-support tooling (Quick Assist, TeamViewer, AnyDesk) — the same category of tool named in the FTC's tech-support-scam data, which is precisely why its use is gated behind the independent-channel identity check, not behind convenience.
+- Self-service password reset (SSPR) portal as the default destination for pure credential-reset requests, with manual tier-1 handling reserved for locked-account edge cases.
+- CompTIA A+ as the baseline certification most postings for this role require, because the six-step method is the shared vocabulary a tier-1/tier-2 handoff relies on.
+
+## Communication style
+
+States what the end user will notice, not the mechanism ("your printer will be back by 2pm," not "the spooler service was restarted"), and leads with current status before root cause when someone is mid-outage and just needs to know if it's being worked. Talks to tier 2/3 in ticket shorthand plus the ruled-out list, so an escalation doesn't repeat the theory-testing step already done. Declines a request that skips identity verification by name ("I can't action this until it's verified through [independent channel] — that's the same ask a support scam makes, not a judgment on you") rather than complying and hoping it was legitimate.
+
+## Common failure modes
+
+- **Skipping identity verification under clock pressure** — see Core #1; the acknowledge-clock is not a valid reason to waive the gate in Decision framework #3.
+- **Escalating an L1-capable ticket reflexively** rather than spending the two minutes the obvious-cause check requires — shows up as a live %Resolved-L1-Capable miss even when FCR looks fine in aggregate.
+- **Treating a service request as an incident or the reverse, and fixing without documenting the ruled-out list** — closing a "password reset incident" as resolved without ever asking why the same user needs one every three weeks (a problem: an expiring-password policy colliding with a shared kiosk device) means the real fix never gets a ticket, and the next technician re-runs the same theory-testing from zero because none of it was written down — the two red-flags.md thresholds this trips are same-symptom 5+/7 days and reopens under 48 hours.
+- **Overcorrecting on verification** — after learning the identity-check lesson, running the same heavy verification on a low-risk request like "what's my printer's IP," which drags average speed to answer well past the ~28-second industry benchmark for no security benefit on that request type.
+
+## Worked example
+
+**Setup.** A 900-employee company's help desk handles 1,200 tickets/month. This month's FCR is 51%. The new IT ops manager's naive read: "51% is well below the ~72% benchmark for desks with defined tiers — our technicians need more training."
+
+**Check 1 — is the tier structure actually being followed, or just declared?** Pulling the % Resolved Level-1-Capable metric: of the 360 tickets/month tagged "password reset" (30% of the 1,200 total, within Gartner's cited 20–50% range), 100% are auto-routed to tier 2 by a legacy queue rule that flags anything in the "account" category as tier-2-only — regardless of complexity. All 360 are L1-capable by policy; 0 are being resolved at L1. That's a routing defect, not a skill gap.
+
+**Check 2 — what is the routing defect costing?** 360 manual resets/month × $70 fully-loaded labor cost (Forrester) = $25,200/month, all incurred by tier-2 technicians on a ticket type that requires no tier-2 judgment.
+
+**Check 3 — what does fixing the rule buy back?** The company already has an SSPR portal, underused because tier-2 technicians default to handling the reset directly rather than redirecting the caller to it. Rerouting the "account/password-reset, no other symptom" ticket type to default-to-SSPR, with tier-1 (not tier-2) handling only genuine locked-account edge cases, is modeled at 80% self-service adoption: 288 tickets/month move to near-zero marginal cost; the remaining 72 stay manual at tier 1, at $70 each = $5,040/month. Projected saving: $25,200 − $5,040 = $20,160/month.
+
+**Reasoning that overturns the naive read.** The FCR gap isn't a training gap — every one of the 360 misrouted tickets was L1-capable by the org's own policy and never touched tier 1 at all. Training more tier-1 technicians would improve nothing, because the routing rule never lets them see these tickets.
+
+**Written memo (deliverable).** "Recommend against a tier-1 training initiative for this FCR gap. Root cause is a queue-routing rule, not technician skill: all 360 password-reset tickets/month (30% of total volume) are flagged 'account' and auto-routed to tier 2 regardless of complexity, despite being 100% L1-capable by our own policy — so tier-1 FCR is measured against a queue that's missing its easiest, highest-volume ticket type. Current cost: $25,200/month in tier-2 labor on resets our own SSPR portal already handles. Fix: change the routing rule to default 'account/password-reset, no other symptom' to SSPR, with tier-1 (not tier-2) as the fallback for locked-account edge cases only. Modeled at 80% self-service adoption: $5,040/month in remaining manual cost, a $20,160/month reduction, and an FCR measurement that finally reflects what tier 1 is actually resolving. No training spend proposed until routing is fixed and FCR is re-measured against the corrected queue."
+
+## Going deeper
+
+- [references/playbook.md](references/playbook.md) — load when triaging a live ticket: the incident/service-request/problem decision tree, ITIL priority-matrix SLA bands, and the CompTIA six-step sequence filled with domain-specific stop conditions at each step.
+- [references/red-flags.md](references/red-flags.md) — load when a request feels off: caller-behavior and ticket-pattern smells with thresholds, each with the first question a veteran asks and the data to pull to check it.
+- [references/vocabulary.md](references/vocabulary.md) — load when a term is being used loosely in a handoff or a writeup: terms of art this desk relies on, with the misuse a generalist commonly makes.
+
+## Sources
+
+- HDI, *Support Center Practices & Salary Report* (2024) and *State of Tech Support 2025* — source for the 72%-with-tiers vs. 45%-without-tiers FCR figures, ~28-second average speed to answer, and ~10,675 tickets/month average volume.
+- MetricNet, "Desktop Support Metrics" benchmarking series — source for the 70–97% (top >90%) desktop-support FCR range, the eight-KPI scoreboard, and the % Resolved Level-1-Capable metric.
+- CompTIA A+ Exam Objectives — source for the six-step troubleshooting methodology ("I Eat Tasty Fish Very Delicately").
+- ITIL 4 Incident Management practice — source for the incident/service-request/problem distinction and the impact × urgency priority matrix with the cited SLA bands (P1 acknowledge 10–15 min/resolve 4 hrs, escalate at 30 min; P2 acknowledge 15 min–1 hr/resolve 4–8 hrs, escalate ~5th hr; P3 acknowledge within 1 hr/resolve within 2 business days).
+- CISA/FBI joint advisories and contemporaneous reporting on the MGM Resorts breach, September 2023 (Scattered Spider/UNC3944/ALPHV) — source for the ~10-minute pretext call, Okta/Azure compromise chain, ~10-day outage, and >$100M impact figures.
+- Federal Trade Commission consumer fraud reporting on tech-support scams — source for the >$924M total tracked loss, ~$500 median per-victim loss, age-60+ majority of reported losses, and the $200–$1,000 typical fraudulent "fix" quote.
+- Gartner and Forrester password-reset economics, as cited across ITSM industry summaries — source for the 20–50% of help-desk call volume and ~$70 fully-loaded manual-reset labor cost figures.
+- Worked-example company figures (900 employees, 1,200 tickets/month, 51% FCR, 360 password-reset tickets, 80% modeled SSPR adoption) are illustrative and internally consistent, not drawn from a named source — flagged as such.

--- a/roles/computer-user-support-specialist/references/playbook.md
+++ b/roles/computer-user-support-specialist/references/playbook.md
@@ -1,0 +1,80 @@
+# Computer User Support Specialist — Playbook
+
+## 1. Incident / service-request / problem classification (decision tree, filled)
+
+| Question | Yes → | No → |
+|---|---|---|
+| Is something broken that worked before? | Go to **Incident** branch | Go to next question |
+| Is it a planned, no-fault ask (new access, new hardware, a reset)? | Go to **Service Request** branch | Go to **Problem** branch |
+| (Incident/Service Request branch) Has the same symptom recurred ≥3 times in 30 days across ≥2 users? | Also open a linked **Problem** record | Close as single incident/request when resolved |
+
+**Worked classification examples:**
+
+| Ticket text | Classification | Reasoning |
+|---|---|---|
+| "My laptop won't connect to Wi-Fi since this morning" | Incident | Something that worked yesterday doesn't work today — no planned change requested |
+| "Need VPN access for our new hire starting Monday" | Service Request | Planned, no-fault, has a lead time |
+| "3rd password reset this month for the same shared kiosk login" | Service Request **+ linked Problem** | Individual reset is a request; the recurrence (3rd in 30 days, 1 user) triggers the problem-record threshold |
+| "Printer on 4th floor jams on every print job >10 pages, reported by 6 different people this week" | Incident **+ linked Problem** | ≥2 users, recurring pattern — closing each jam ticket without a problem record leaves root cause (worn roller, needs replacement part) untouched |
+
+**Rule applied:** the ≥3-in-30-days / ≥2-users threshold is what converts a string of individually-resolved tickets into a mandatory linked problem record. Below that threshold, log the pattern-watch note on the ticket but don't open a problem record yet — noise ratio.
+
+## 2. ITIL impact × urgency priority matrix (SLA bands, filled)
+
+| Impact ↓ / Urgency → | High (business-stopping) | Medium (workaround exists) | Low (cosmetic/no workaround needed) |
+|---|---|---|---|
+| **High** (site/dept-wide, ≥25 users or revenue-generating system) | **P1** — ack 10–15 min, resolve 4 hrs, escalate at 30 min if unacknowledged-diagnosis | P2 — ack 15 min–1 hr, resolve 4–8 hrs | P3 — ack ≤1 hr, resolve ≤2 business days |
+| **Medium** (team/segment, 5–24 users) | P2 — ack 15 min–1 hr, resolve 4–8 hrs, escalate ~5th hr | P2 — ack 15 min–1 hr, resolve 4–8 hrs | P3 — ack ≤1 hr, resolve ≤2 business days |
+| **Low** (single user, 1 device) | P3 — ack ≤1 hr, resolve ≤2 business days | P3 — ack ≤1 hr, resolve ≤2 business days | P4 — ack ≤4 business hrs, resolve ≤5 business days (backlog) |
+
+**Worked example:** "Company-wide email outage, sales team can't send quotes before EOD deadline" → Impact = High (all users), Urgency = High (revenue deadline same day) → **P1**. Ack clock starts at ticket creation, target 10–15 min; if root cause isn't diagnosed by minute 30, auto-escalate to on-call lead regardless of how close resolution feels — the escalate trigger is a clock, not a judgment call made mid-diagnosis.
+
+**Rule applied:** tier is set by impact × urgency before diagnosis starts, not adjusted mid-ticket because the fix turned out to be easy or hard. A P1 that gets fixed in 8 minutes is still logged and closed as a P1 — the priority described the situation at intake, not the eventual difficulty.
+
+## 3. Identity verification gate (decision table, filled)
+
+| Request type | Verification required? | Channel |
+|---|---|---|
+| Password/MFA reset | Yes — always | Callback to number on file in HR system, or video call with badge visible — never the inbound channel the request arrived on |
+| Remote-control session ("let me take control of your screen") | Yes — always, plus manager confirmation if request cites urgency ("I'll lose my job if this isn't fixed now") | Callback to number on file |
+| Account-state change (unlock, disable, permission grant) | Yes — always | Callback to number on file, or in-person badge check |
+| "What's my printer's IP" / read-only info request | No | N/A — low-risk, no account-state change |
+| New-hardware service request already tied to an approved ticket/PO | No (identity already established at ticket creation via manager approval) | N/A |
+
+**Worked example:** Caller states name and employee ID, asks for an MFA reset, says "I'm in the middle of a client call and need this in the next 2 minutes." Correct action: put the reset on hold, call the employee's number from the HR directory (not a number the caller supplies), confirm the request verbally. If the callback doesn't answer within 5 minutes, the ticket stays open and unresolved — the clock pressure from the caller does not override the gate. This is the exact shape of the MGM Resorts pretext-call failure (10-minute call, no independent-channel check, credential reset → breach).
+
+## 4. CompTIA six-step troubleshooting sequence, with domain-specific stop conditions (filled)
+
+**Scenario:** Ticket — "Can't print to the 3rd floor color printer, worked fine yesterday."
+
+| Step | Action | Stop condition (move to next step only if this fails) |
+|---|---|---|
+| 1. Identify the problem | Ask: what changed, when, error message text, one user or many | If 1 user only + no error message + printer works for others → proceed to step 2 with hypothesis "client-side" |
+| 2. Establish theory of probable cause (start with the obvious) | Theory order: (a) printer offline/out of paper/toner, (b) print queue stuck, (c) network path to printer, (d) driver corruption | Check (a) first — physically/remotely confirm printer status — before touching drivers |
+| 3. Test the theory | Ping printer IP, check print queue for stuck jobs, check printer's own display panel | If printer pings and queue is empty → theory (a)/(b) ruled out, move to (c)/(d) |
+| 4. Plan and implement | If driver corruption confirmed (other printers also fail from same machine): remove and reinstall driver | Implement only the fix matching the confirmed cause — do not reinstall OS or replace hardware on a first pass |
+| 5. Verify full functionality | Print a real test page from the actual application the user needed (not just a Windows test page), confirm color output correct | If test page prints from Notepad but not from the user's actual app → not verified, return to step 2 with narrowed theory ("app-specific print driver setting") |
+| 6. Document | Root cause: driver corruption on client machine. Action: driver removed/reinstalled. Ruled out: printer hardware, network path, queue. Outcome: verified via actual invoice template print | — |
+
+**Ruled-out list (carried into any escalation):** printer online and reachable (ping successful, 4/4 replies); print queue empty; other users printing successfully to same device; issue isolated to one client machine — hands tier 2 a list that saves them from re-running steps 1–3 from zero.
+
+## 5. Ticket resolution note — filled template
+
+> **Resolution — [one-line symptom] (Ticket #[id], P[tier])**
+> Classification: [Incident / Service Request / Problem-linked].
+> Root cause: [confirmed cause, not the reported symptom].
+> Ruled out: [specific checks performed, with results — not "checked network," but "pinged printer IP, 4/4 replies"].
+> Identity verification: [channel used, or "not required — read-only request"].
+> Fix applied: [exact change, exact values].
+> Verified: [functional check against the original report — what was actually re-tested].
+> Escalated to: [team, with ruled-out list attached] or **Resolved at tier 1**.
+
+**Worked example (filled):**
+> **Resolution — Can't print to 3rd floor color printer (Ticket #48213, P3)**
+> Classification: Incident.
+> Root cause: corrupted print driver on client machine (not printer hardware or network).
+> Ruled out: printer online (ping 4/4), queue empty, 3 other users printing successfully to same device.
+> Identity verification: not required — no account-state change.
+> Fix applied: removed and reinstalled HP Universal Print Driver v7.2 on client machine.
+> Verified: printed actual invoice template from Excel with correct color output, not just a Windows test page.
+> Escalated to: N/A — resolved at tier 1.

--- a/roles/computer-user-support-specialist/references/red-flags.md
+++ b/roles/computer-user-support-specialist/references/red-flags.md
@@ -1,0 +1,61 @@
+# Red flags — computer-user-support-specialist
+
+### Caller asks for a password/MFA reset or remote-control session and cites urgency ("I'm about to miss a call with the CEO") within the first 60 seconds
+- **Usually means:** A legitimate employee genuinely locked out and stressed, or — indistinguishable at this point — a pretext call running the FTC-tracked tech-support-scam / help-desk-social-engineering pattern (the MGM Resorts breach opened exactly this way).
+- **First question:** "What's a way to reach you back on a number or address already on file, separate from this call?"
+- **Data to pull:** HR directory entry (phone, manager, start date) and the account's last-known verified contact channel.
+
+### Same account requests 2+ password/MFA resets within a 30-day window
+- **Usually means:** An expiring-password policy colliding with a shared device or bad habit (a service request masquerading as a recurring incident), or credential-stuffing pressure making the account a live target.
+- **First question:** "Is this the same underlying cause each time, or a new one?"
+- **Data to pull:** Ticket history for the account, filtered to category = password/account, last 90 days.
+
+### Request to change the on-file recovery email or phone number arrives in the same contact as a credential-reset request
+- **Usually means:** A legitimate device change bundled for convenience, or an attacker locking out the real owner's recovery path before pivoting further into the account.
+- **First question:** "Can you confirm the current recovery contact on file before we change it?"
+- **Data to pull:** Account audit log for recovery-contact field changes in the last 30 days.
+
+### Caller fails the standard identity challenge but offers to answer a substitute question instead
+- **Usually means:** A legitimate employee who forgot the answer (rare, but happens after a life event like a name change), or someone working from partial OSINT (LinkedIn, a data-breach dump) who can't clear the real bar.
+- **First question:** "Can I call you back on the number already in the directory instead?"
+- **Data to pull:** Directory record for the callback number and a check of whether that number matches the ticket's stated contact.
+
+### A ticket tagged L1-capable sits in the tier-2 queue for >24 hours before anyone touches it
+- **Usually means:** A stale routing rule sending an entire category to tier 2 regardless of complexity, not a tier-2 workload spike.
+- **First question:** "Is this ticket type auto-routed by category, or was it escalated by a person?"
+- **Data to pull:** % Resolved Level-1-Capable report and the routing rule config for the ticket's category.
+
+### The same symptom (same error, same device class, or same app) generates 5+ incidents in a rolling 7-day window
+- **Usually means:** A shared root cause that's never been opened as its own problem ticket — every occurrence gets resolved individually and the underlying cause recurs.
+- **First question:** "Has anyone opened a problem record linking these, or is each one closed as a one-off incident?"
+- **Data to pull:** Incident list filtered by symptom keyword and date range, sorted by affected device/user.
+
+### A ticket is marked resolved and reopens within 48 hours
+- **Usually means:** The fix addressed the loudest symptom, not the original report, or verification against the full original complaint was skipped.
+- **First question:** "What was verified as fixed before this was closed — the original report or just the symptom mentioned last?"
+- **Data to pull:** The closed ticket's resolution notes plus the reopened ticket's new description.
+
+### Queue-wide first-contact resolution sits below ~60% for 2+ consecutive months in a desk with documented tiers
+- **Usually means:** A routing or definition problem (misclassified tickets, stale auto-escalation rules) rather than a technician skill gap — HDI's own benchmark gap between tiered (72%) and undefined (45%) desks is structural.
+- **First question:** "Are we measuring FCR against tickets that never reach tier 1 in the first place?"
+- **Data to pull:** % Resolved Level-1-Capable broken out by category, next to the routing-rule config per category.
+
+### A ticket requesting new software/system access has no linked HR onboarding record or manager approval
+- **Usually means:** A normal request that simply skipped the paperwork step, or an attempt to provision access outside the approval chain.
+- **First question:** "Who's the approving manager, and can I see the request in the access-management system?"
+- **Data to pull:** HRIS onboarding/role record and the access-request ticket in the identity-management system.
+
+### Average speed to answer on a queue drops below ~10 seconds while ticket volume is flat or rising
+- **Usually means:** Tickets are being auto-accepted and closed without the standard identify → verify → diagnose sequence being run, inflating a metric that looks good on a dashboard.
+- **First question:** "Pull three of this week's sub-10-second tickets — was identity verification actually logged on each?"
+- **Data to pull:** Call/chat timestamps against the ticket's logged verification step, for a sample of recent closures.
+
+### An escalated ticket arrives at tier 2/3 with no ruled-out list or troubleshooting notes attached
+- **Usually means:** Clock pressure produced an escalation before the six-step theory-testing sequence was actually run, forcing tier 2 to restart from zero.
+- **First question:** "What's already been ruled out, and what's the theory that led to escalating instead of continuing?"
+- **Data to pull:** The ticket's activity log/notes field for the time between assignment and escalation.
+
+### A single department or building generates a P1-severity spike (10+ tickets) within a 2-hour window
+- **Usually means:** A real infrastructure outage (network, auth provider, shared server) rather than 10 unrelated individual incidents — each one classified alone under-prices the true impact.
+- **First question:** "Do these share a location, subnet, or upstream system, or are they genuinely unrelated?"
+- **Data to pull:** Ticket list for the window filtered by location/device, cross-referenced against infrastructure monitoring/status-page alerts.

--- a/roles/computer-user-support-specialist/references/vocabulary.md
+++ b/roles/computer-user-support-specialist/references/vocabulary.md
@@ -1,0 +1,73 @@
+# Vocabulary
+
+Load when a term is being used loosely in a handoff or a writeup. Each entry is a term generalists routinely substitute for something adjacent but not identical — the misuse, not the dictionary definition, is the point.
+
+**Incident**
+An unplanned interruption to a service, or a reduction in its quality, versus its agreed-upon normal operating state.
+*In use:* "Opened as an incident — company VPN is down for the whole Denver office, that's a P1."
+*Misuse:* Generalists use "incident" for anything that generates a ticket, including a new-hire laptop request. If nothing was working before and now isn't, it's an incident; if nothing was broken and someone wants something provisioned, it's a service request — conflating the two sends both down the wrong SLA clock and corrupts the metrics both are measured on.
+
+**Service request**
+A planned, no-fault ask for something standard and pre-approved — access, hardware, software install — that isn't a break of anything.
+*In use:* "New monitor for the account team, that's a service request, not an incident — routes to fulfillment, not troubleshooting."
+*Misuse:* Logged as an "incident" because the intake form only has one ticket type, or because "the user needs this urgently" gets translated into incident severity language. A request with zero broken component has no fault to diagnose, so applying incident triage (impact × urgency, escalation clock) to it just adds process weight to a fulfillment task.
+
+**Problem**
+The underlying, usually unconfirmed root cause producing a recurring pattern of incidents — a problem record exists to be investigated, not to be "resolved" on first contact like an incident.
+*In use:* "Third 'internet down, 3rd floor' ticket this week — closing the incident, but opening a problem record to chase the actual switch fault."
+*Misuse:* Treating a string of same-symptom incidents as N separate closures instead of one open problem — each incident gets a workaround and a satisfied user, but the underlying fault never gets a ticket, a budget line, or an owner, so it recurs indefinitely.
+
+**Workaround**
+A temporary way to restore the reported functionality without addressing the underlying cause — the incident can close on a workaround; the problem behind it cannot.
+*In use:* "Rebooting the print spooler is the workaround — printing's back, but the root cause is still open on the problem ticket."
+*Misuse:* Documenting a workaround as if it were a resolution and closing the associated problem record along with the incident. A workaround closing an incident is expected and fine; a workaround closing a problem means the fault will resurface with nothing tracking it.
+
+**Root cause**
+The specific, verified fault that, if removed, prevents the symptom from recurring — distinct from the first plausible explanation that happens to make the symptom stop.
+*In use:* "Fix restored printing, but root cause wasn't confirmed until we found the spooler service crashing on a specific driver version."
+*Misuse:* Writing "root cause: printer offline" on a ticket — that's the symptom, not the cause. A cause that doesn't explain why the fault will or won't recur isn't root cause yet, it's a description of the failure.
+
+**First contact resolution (FCR)**
+The percentage of tickets resolved during the reporter's initial contact, with no reopen, callback, or transfer required — a queue-design metric, not an individual-technician score.
+*In use:* "FCR is 51% this month — before blaming technicians, check whether L1-capable tickets are even reaching tier 1."
+*Misuse:* Read as a report card on technician skill or effort in isolation. A queue with a routing defect that reflexively escalates simple tickets to tier 2 will show low tier-1 FCR no matter how good tier-1 technicians are — the number indicts the routing rule as often as it indicts a person.
+
+**% Resolved Level-1-Capable**
+The share of tickets that were within tier 1's competence to resolve and actually did resolve there, as distinct from FCR, which only tracks whether resolution happened on first contact at whatever tier it landed.
+*In use:* "FCR looks fine in aggregate, but %-Resolved-L1-Capable is low — these are getting bounced to tier 2 out of habit, not necessity."
+*Misuse:* Assumed to be the same signal as FCR, or ignored entirely because FCR "already covers it." A ticket can resolve on first contact at tier 2 (good FCR) while still being a tier-1-capable ticket that never should have left tier 1 (bad on this metric) — the two numbers catch different failure modes.
+
+**Escalation**
+A deliberate handoff to a higher tier or specialized queue, made because the receiving tier's competence or authority is required — not a release valve for clock pressure.
+*In use:* "Escalating with the ruled-out list attached: driver reinstall and cable swap both tested, still failing — needs hardware diagnostics."
+*Misuse:* Used as a way to stop the SLA clock from breaching rather than because the fix genuinely requires tier 2/3. An escalation with no ruled-out list attached forces the next tier to restart the theory-testing step from zero, which is slower overall than if tier 1 had kept the ticket a few more minutes.
+
+**Severity vs. priority**
+Severity is how bad the impact is on its own (data loss, down for how many users); priority is the resulting queue position, and is set from impact × urgency, not from either factor alone or from how the request was phrased.
+*In use:* "High severity — company-wide outage — but she reported it calmly by email, so priority still follows impact × urgency, not tone."
+*Misuse:* Setting priority directly from how urgently something was asked (a loudly worded email, a VP's name in the subject line) instead of running impact × urgency. A single user's shouted request is not automatically high priority; a calmly reported company-wide outage still is.
+
+**SLA (service level agreement) — acknowledge vs. resolve target**
+Two separate clocks tied to a priority tier: the acknowledge target is how fast the ticket gets a first response; the resolve target is how fast it's actually fixed. Missing either is a distinct SLA breach.
+*In use:* "P2 acknowledge target is 15 minutes to an hour — we're at 40 minutes with no response logged, that's a breach regardless of how the fix is going."
+*Misuse:* Tracking only the resolve clock and treating "we're working on it" as sufficient even when no acknowledgment was ever logged within target — the acknowledge SLA exists specifically to guarantee the reporter isn't left wondering whether the ticket was even seen.
+
+**Identity verification (independent channel)**
+Confirming a requester's identity through a channel separate from the one the request arrived on, required before any account-state change — not the same as recognizing a name or a plausible-sounding story.
+*In use:* "Can't reset that MFA token off this inbound call — I'll call the number on file and verify there before touching anything."
+*Misuse:* Treating "they knew the employee ID" or "they sounded like they worked there" as verification. The MGM Resorts breach began with exactly that: a caller who'd gathered enough real details from LinkedIn to sound legitimate on the one channel the request arrived on — verification means a second, independent channel, not more confidence in the first one.
+
+**Deflection**
+Resolution of a user's need before a ticket is ever opened, via self-service (knowledge base, SSPR portal) — a tier-0 outcome, counted separately from anything a technician touches.
+*In use:* "Password-reset deflection to the SSPR portal is at 80% adoption — those never become tickets at all."
+*Misuse:* Conflated with FCR, which only measures tickets that were opened. A high-deflection queue can look unremarkable on FCR while quietly saving the most technician-hours of any single change, because the tickets it prevents never enter the FCR denominator in the first place.
+
+**Tier 1 / Tier 2 / Tier 3**
+Successive support levels defined by scope of authority and complexity handled, not by seniority or tenure — a ticket's tier assignment should track what it requires, not who happens to be available.
+*In use:* "That's a tier-1-capable reset by policy — it shouldn't need tier-2 eyes just because tier 2 picked up the call."
+*Misuse:* Used as informal shorthand for "junior staff" vs. "senior staff" rather than as a scope-of-authority boundary tied to ticket type. A routing rule that sends a ticket category to tier 2 "because that's just how it's always been handled" can leave 100% of an L1-capable category stuck above tier 1 indefinitely, with no technician ever making an individual bad call.
+
+**Break-fix**
+Reactive, incident-driven support work performed only after something has already failed, as distinct from proactive maintenance or scheduled service requests.
+*In use:* "That's break-fix — the drive already failed — versus the proactive replacement cycle that would've caught it first."
+*Misuse:* Applied to any hands-on technical task regardless of whether something actually broke, blurring it with scheduled maintenance or provisioning work. The distinction matters for staffing and budgeting: a desk dominated by break-fix work is signaling that proactive maintenance isn't catching failures before they become tickets.


### PR DESCRIPTION
Rubric score: 18/18

## Resolution rationale

Applied the granularity test to the closest candidates and none share the actual decision surface. network-support-specialist (O*NET 15-1231.00) is a sibling occupation, not a parent: its whole first-principles core, decision framework, and worked example are about diagnosing network-layer faults (duplex mismatch, PMTUD black holes, DHCP exhaustion, STP loops) using interface counters, packet captures, and NOC severity tiers — none of that is wrong or even present-but-shallow guidance for a help-desk/end-user support technician, who instead needs a framework for triaging an end user's device/account/software issue (password resets, OS/app troubleshooting on the user's machine, ticket categorization, escalation vs. resolve-at-tier-1, remote-desktop tools, knowledge-base search) — a genuinely different failure surface, not a subset of network-support's. computer-information-systems-manager (11-3021.00) sits at the opposite altitude: it owns IT as a business/strategy function (vendor TCO, technical debt as a portfolio, budget allocation) — its Decision framework would give an end-user support tech no actionable guidance for an individual ticket at all; it's a manager two-plus levels above the individual-contributor help-desk role, not a specializable parent. project-management-specialist is unrelated. Since 15-1232.00 (Computer User Support Specialists) and 15-1231.00 (Network Support Specialists) are BLS/O*NET siblings under the same detailed occupation family rather than parent-child, and no existing role is a true broader version of end-user support, this warrants a new top-level (non-child) role. Proposed slug follows the existing network-support-specialist naming convention (O*NET title in kebab-case): computer-user-support-specialist.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new spec‑2 role `computer-user-support-specialist` (O*NET 15‑1232.00) with a practical playbook for end‑user/help‑desk work. Updates repo stats and roadmap to reflect the new role.

- **New Features**
  - Added `roles/computer-user-support-specialist` with SKILL and references: `playbook.md`, `red-flags.md`, `vocabulary.md` (focus on identity verification, ITIL incident/request/problem flow with SLA bands, CompTIA six‑step, FCR and “% Resolved L1‑Capable”).
  - Registered the role in `data/roles.json`; updated README/ROADMAP stats: 160 roles drafted (150 O*NET, 10 custom; 118 at spec‑2), engineering = 33; O*NET coverage 14.8%; ROADMAP progress 150/1016 and 15‑1232.00 marked drafted with link.

<sup>Written for commit 4c125a8ea877f20486b69394bb3a50e9cea0945f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

