### PR TITLE
role: add network-systems-administrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**160 roles drafted** (150 mapped to an O*NET occupation, 10 custom; 118 at spec 2, 42 awaiting upgrade), across 10 categories:
+**161 roles drafted** (151 mapped to an O*NET occupation, 10 custom; 119 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `███░░░░░░░░░░░░░░░░░` 14.8% (150 / 1,016 occupations)
+**O\*NET coverage:** `███░░░░░░░░░░░░░░░░░` 14.9% (151 / 1,016 occupations)
 
 - **design**: 3
 - **engineering**: 33
@@ -206,7 +206,7 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 - **healthcare**: 10
 - **legal**: 18
 - **marketing**: 5
-- **operations**: 57
+- **operations**: 58
 - **other**: 7
 - **product**: 1
 - **sales**: 5

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 150 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 151 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -136,7 +136,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>15 — Computer and Mathematical</strong> (21/38 drafted)</summary>
+<summary><strong>15 — Computer and Mathematical</strong> (22/38 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -151,7 +151,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 | ✅ | 15-1242.00 | Database Administrators | [`database-administrator`](./roles/database-administrator/SKILL.md) |
 | ✅ | 15-1243.00 | Database Architects | [`database-architect`](./roles/database-architect/SKILL.md) |
 |  | 15-1243.01 | Data Warehousing Specialists |  |
-|  | 15-1244.00 | Network and Computer Systems Administrators |  |
+| ✅ | 15-1244.00 | Network and Computer Systems Administrators | [`network-systems-administrator`](./roles/network-systems-administrator/SKILL.md) |
 |  | 15-1251.00 | Computer Programmers |  |
 | ♻️ | 15-1252.00 | Software Developers | [`software-engineer`](./roles/software-engineer/SKILL.md) |
 | ✅ | 15-1253.00 | Software Quality Assurance Analysts and Testers | [`software-qa-analyst`](./roles/software-qa-analyst/SKILL.md) |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 160,
+  "count": 161,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -1882,6 +1882,24 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/network-support-specialist/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ]
+    },
+    {
+      "slug": "network-systems-administrator",
+      "description": "Use when a task needs the judgment of a network/systems administrator \u2014 triaging a connectivity or outage incident, sequencing an emergency patch or firmware rollout across a device fleet, reviewing backup-job and monitoring coverage, setting account-access and password policy, or planning a WAN circuit order or data-center/office move.",
+      "category": "operations",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "15-1244.00",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/network-systems-administrator/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/roles/network-systems-administrator/SKILL.md
+++ b/roles/network-systems-administrator/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: network-systems-administrator
+description: Use when a task needs the judgment of a network/systems administrator — triaging a connectivity or outage incident, sequencing an emergency patch or firmware rollout across a device fleet, reviewing backup-job and monitoring coverage, setting account-access and password policy, or planning a WAN circuit order or data-center/office move.
+metadata:
+  category: operations
+  maturity: draft
+  spec: 2
+  onet_soc_code: "15-1244.00"
+---
+
+# Network/Systems Administrator
+
+## Identity
+
+The harder job isn't running the LAN/WAN, servers, and access control — it's the tradeoff baked into every change on them: the safest change is also the one most likely to break something at 2am, and the fastest fix is also the one most likely to take down every site at once.
+
+## First-principles core
+
+1. **The alert's location is rarely the fault's location.** A DNS-resolution failure looks like "the internet is down"; a BGP route withdrawal three hops away looks like a single server outage. Meta's October 2021 global outage started as a backbone-capacity audit command, not a DNS problem, but it presented as "DNS is broken everywhere" because the withdrawal took the DNS server prefixes offline with it.
+2. **A synchronized global change is the single riskiest action available, regardless of how good the change is.** Cloudflare's July 2019 global outage came from one WAF rule, pushed everywhere at once with no canary; at their scale that meant roughly 10 million requests/second hitting the same pathological regex simultaneously, and the emergency kill switch was itself delayed because it rode the same congested path. The size of the blast radius is a choice made at rollout time, not at write-the-fix time.
+3. **The path back into the network must not depend on the part of the network that's down.** During the same Meta outage, the backbone failure also locked the employee badge system, so responders had a physical access problem on top of the network problem. Out-of-band management — console servers, cellular failover, a badge system on its own circuit — is the thing you provision before the incident, not during it.
+4. **Patch timelines are set by exploitation risk and compliance deadlines, not by vendor release cadence.** A monthly patch cycle is a convenience baseline; once a CVE lands in CISA's Known Exploited Vulnerabilities catalog, the clock is 14 calendar days for internet-facing systems and 45 for everything else (BOD 22-01), and that deadline overrides waiting for the next scheduled maintenance window.
+
+## Mental models & heuristics
+
+- **When pushing any fix to more than one device, default to a canary group plus a defined bake window before the full fleet** — unless an active-exploitation deadline (14-day KEV) forces same-day action, in which case canary on the lowest-impact site first and compress the bake window rather than skip it.
+- **When a ticket says "the network is down," default to checking routing and name resolution before touching physical hardware** — WAN circuits take 2-3 months to reorder and rarely fail without warning, so a sudden total outage is almost always a config or protocol event, not the circuit itself.
+- **When setting password policy, default to NIST 800-63B: rotate only on suspected or confirmed compromise, favor length (64+ characters permitted) over composition rules** — this runs against the inherited 90-day-rotation GPO most enterprises still ship, and the older policy trains users into predictable increment patterns without stopping a credential-stuffing attack.
+- **When a major incident is underway, default to an Incident Command structure** — a named commander, a 15-30 minute goal-setting meeting to open, hourly updates to leadership, and fixes applied in blocks of two or three capped at an hour of work each, so debugging doesn't turn into an unstructured all-nighter.
+- **When planning a data-center or office move, default to fixed lead times, not negotiated ones**: run cooling 48-72 hours before occupying a new space and replace filters after, and treat WAN/ISP circuit ordering as a 2-3 month lead item communicated to the business up front.
+- **When two networks are being merged, default to auditing for overlapping RFC 1918 address space before any tunnel or peering goes up** — overlapping private ranges break routing silently and show up as intermittent, hard-to-reproduce connectivity loss weeks later.
+- **When the ticket backlog's opened-to-closed ratio grows month over month, default to reading it as a staffing or process signal** — not as an individual admin needing to work faster.
+- **When a manual task recurs on every on-call rotation, default to treating it as toil to eliminate**, not a permanent part of the job — Google SRE's guideline caps operational toil at roughly half of an engineer's time so the other half stays available for the automation that removes the toil.
+
+## Decision framework
+
+1. **Confirm the recovery path is independent of the failure** — verify out-of-band/console access before touching production config, so a bad change doesn't lock out the person fixing it.
+2. **Localize the fault by layer** — physical, routing/protocol, DNS/naming, application — from monitoring and logs, before assuming the layer the alert pointed at.
+3. **Identify the actual remediation deadline**: active-exploitation/compliance SLA (KEV 14/45-day, quarterly PCI ASV scan) versus a standard change window, and target the earliest one that's actually binding.
+4. **Stage the rollout** — canary group, a defined bake/monitoring window, and a rollback trigger decided before the push starts, never during it.
+5. **Run a fixed communication cadence for the duration of the incident** — hourly updates, work in capped blocks — and keep a timeline as it happens rather than reconstructing it afterward.
+6. **Close the loop on the tool or process that caused or missed the failure** — the audit script, the missing canary step, the alert that didn't fire — so the same failure mode can't repeat undetected.
+7. **Feed the incident into monthly ticket and backlog metrics** so a pattern of recurring incidents shows up as a staffing or automation gap, not twelve unrelated one-offs.
+
+## Tools & methods
+
+- Monitoring/NOC stack: SNMP polling, NetFlow/sFlow, a platform like LibreNMS/PRTG/SolarWinds for hardware, link, and server integrity; BGP/route monitors for peering-session state.
+- Network automation and config management (Ansible, NAPALM) for staged, auditable pushes instead of hand-typed changes on individual devices.
+- IPAM/documentation of record (NetBox or equivalent) kept current, not reconstructed after an incident.
+- Vulnerability scanning: an ASV-accredited scanner for the quarterly PCI-scope scan (internal-only or unaccredited tools do not satisfy the control); Tenable/Qualys-class tooling for the rest of the fleet.
+- Secrets/credential management (Vault or equivalent) instead of shared static passwords on network gear.
+- Change management/CAB ticket as the artifact of record for any fleet-wide push, with the canary/bake/rollback plan written into it before approval.
+
+## Communication style
+
+To peers and other admins: precise and log-referenced — cites the specific interface, session, or log line rather than describing symptoms in general terms. To leadership during an incident: states current impact, next update time, and the single next action, on the hourly cadence, not a technical narrative. To other functions requesting a change (security, app teams): states the deadline that's actually driving the timeline (compliance SLA vs. convenience) so the request doesn't get compressed by an assumed urgency that isn't real, and states what the canary/bake plan costs in elapsed time up front rather than promising the fastest possible number.
+
+## Common failure modes
+
+- **Trusting automation's own success signal instead of an independent health check** — Ansible/NAPALM reports "changed" or exits 0 across the fleet, but a subset of devices never actually came back up with the service running; the tool ran, it just didn't verify the outcome it was supposed to produce.
+- **Watching the bake window only for the metrics named in the rollback trigger** — BGP/OSPF reconvergence and VPN reconnect rate both hold clean, but the firmware push regressed something the two named signals don't cover (e.g., a split-tunnel routing behavior), so a clean bake gets read as a clean change outside the metrics actually being watched.
+- **Hand-patching one device during an emergency without updating the config-management source of truth** — the live device and the Ansible/NetBox record of it diverge, so the next fleet-wide push either reverts the emergency fix or fails against a device that no longer matches its recorded state.
+- **Rolling back a bad stage correctly, then letting the deferred remediation quietly drop off the backlog** — instead of re-scheduling the fixed version with an owner and a date, so the underlying vulnerability or deadline reopens with no one visibly on the hook for it.
+- **Confusing a passing quarterly scan with current safety** — treating the last ASV scan as sufficient coverage for a CVE that landed in the KEV catalog the following week.
+
+## Worked example
+
+**Setup.** The quarterly PCI ASV scan flags CVE-2025-1974 (illustrative CVE ID) on the DMZ-facing VPN concentrator firmware, CVSS 9.8. Three days later the CVE is added to the CISA KEV catalog, which sets a 14-calendar-day remediation deadline because the device is internet-facing. The vendor's next scheduled firmware release is 5 weeks out. 40 regional-office VPN concentrators run the same vulnerable firmware version.
+
+**Naive read.** CVSS 9.8, on the KEV list, deadline running — patch all 40 concentrators in one maintenance window tonight to close the exposure as fast as possible.
+
+**Expert reasoning.** A synchronous fleet-wide firmware push has no canary and no rollback signal before commitment; if the new image has a routing or VPN-negotiation defect, every regional office loses its WAN/VPN path at the same time, and the admin VPN used to reach the concentrators for remote recovery runs over the same devices being flashed — the same out-of-band dependency problem that trapped Meta's responders behind their own badge system. 14 days is enough runway to stage this instead of rushing it:
+
+- Day 1: flash the 2 lowest-business-impact regional offices (canary). Confirm a separate console-server path into those two sites that doesn't depend on the concentrator's VPN service.
+- Day 1-2: 4-hour bake window checking BGP/OSPF neighbor stability and VPN client reconnect success rate on the canary pair. Clean.
+- Day 3: batch 2 — 19 concentrators. 24-hour bake window. Clean.
+- Day 5: batch 3 — the remaining 19 concentrators (2 + 19 + 19 = 40).
+
+Total elapsed time: 5 days, leaving 9 days of margin inside the 14-day KEV deadline for a reschedule if any batch shows a problem, instead of zero margin from a single all-at-once push.
+
+**Deliverable — change ticket, filed before batch 1:**
+
+> **CHG-4471: VPN concentrator firmware remediation — CVE-2025-1974 (KEV, deadline day 14)**
+> Scope: 40 DMZ VPN concentrators, firmware X.Y.Z → X.Y.Z+1.
+> Rollout: Day 1 canary (2 lowest-impact sites, console-server access confirmed independent of VPN path) → 4hr bake → Day 3 batch of 19 → 24hr bake → Day 5 batch of remaining 19.
+> Rollback trigger: any canary or batch site failing BGP/OSPF reconvergence within the bake window, or VPN reconnect success rate dropping below 98% of the pre-change baseline.
+> Deadline: Day 14 (CISA BOD 22-01, internet-facing). Current plan completes Day 5, 9 days of margin retained.
+
+## Going deeper
+
+- [Playbook](references/playbook.md) — staged-rollout and incident-response sequencing, backup/monitoring review checklist, and circuit/capacity planning lead times.
+- [Red flags](references/red-flags.md) — smell tests for network and access-control incidents: what each usually means, the first question to ask, the data to pull.
+- [Vocabulary](references/vocabulary.md) — terms generalists misuse, with practitioner usage and the common misuse spelled out.
+
+## Sources
+
+- Thomas A. Limoncelli, Christina J. Hogan, Strata R. Chalup, *The Practice of System and Network Administration*, 2nd ed. (Addison-Wesley, 2007) — data-center move cooling/lead-time practice, Incident Command-style outage response, ticket opened:closed ratio as a staffing signal, RFC 1918 overlap check during mergers.
+- Meta Engineering, "More details about the October 4 outage" (engineering.fb.com, Oct 5, 2021), and Cloudflare, "Understanding how Facebook disappeared from the Internet" (blog.cloudflare.com, Oct 2021) — backbone-audit-tool root cause, BGP withdrawal timeline, badge-system lockout.
+- Cloudflare, "Details of the Cloudflare outage on July 2, 2019" (blog.cloudflare.com) — global synchronous WAF rollout, catastrophic-backtracking regex, 27-minute outage, delayed kill switch.
+- Google, *Site Reliability Engineering* and *The Site Reliability Workbook* (sre.google) — toil cap, error-budget mechanic.
+- NIST Special Publication 800-63B, Digital Identity Guidelines (Rev. 4, pages.nist.gov/800-63-4) — password rotation on compromise only, 64-character minimum, no composition rules.
+- PCI Security Standards Council, PCI DSS Requirement 11.3.2 — quarterly ASV-scan requirement for internet-facing cardholder-data-environment systems.
+- CISA Binding Operational Directive 22-01 (Known Exploited Vulnerabilities Catalog) — 14-day (internet-facing) / 45-day remediation deadlines.
+- O*NET-SOC 15-1244.00 task list used only as a coverage skeleton, not as source text.
+- Pass 0 research complete as of 2026; no direct practitioner sign-off yet — flag via PR if you can confirm, correct, or add a citation. The CVE ID in the worked example is illustrative, not a claim about a real vulnerability.

--- a/roles/network-systems-administrator/references/playbook.md
+++ b/roles/network-systems-administrator/references/playbook.md
@@ -1,0 +1,90 @@
+# Network/Systems Administrator — Playbook
+
+## Staged rollout sequencing (canary → bake → batch), filled example
+
+**Scope:** 40-device fleet, firmware/config push.
+
+| Stage | Devices | Bake window | Go/no-go gate |
+|---|---|---|---|
+| Canary | 2 lowest-business-impact sites | 4 hours | BGP/OSPF neighbor count stable, VPN/session reconnect rate ≥98% of pre-change baseline |
+| Batch 1 | 19 (50% of the 38 remaining) | 24 hours | Same gate as canary, plus zero new P2+ tickets tagged to the change |
+| Batch 2 | 19 (remainder) | 24 hours post-push, formal close at 72 hours | Same gate; if clean, change ticket closes |
+
+**Rollback trigger (define before push, not during):** any stage showing routing reconvergence failure, session/reconnect rate below 98% of baseline, or a P1 ticket tagged to the change within the bake window — revert that stage only, hold subsequent stages, do not advance the fleet.
+
+**Sizing rule of thumb:** canary = smallest group that still exercises every device model/OS version in the fleet, never fewer than 2 (a single canary can't distinguish a device-specific fault from a change-wide one). Batch size for the remaining stages isn't a fixed multiplier — it's set by working backward from the deadline: split what's left into as few equal batches as the deadline's margin allows, so each stage still gets a full bake window. In the 40-device/14-day example, that's two 19-device batches at a 24-hour bake each, completing day 5 with 9 days of margin instead of one all-at-once push with none.
+
+## Emergency same-day exception (KEV/active-exploitation deadline)
+
+When a 14-day KEV clock or active-exploitation evidence forces same-day movement, canary stays but bake compresses:
+
+| Stage | Devices | Bake window |
+|---|---|---|
+| Canary | 2 lowest-impact sites | 4 hours (compressed from 24) |
+| Full remaining fleet | rest | rolled in one pass after canary bake clears |
+
+Never skip the canary stage itself — compress the bake window, not the step count.
+
+## Incident Command response sequence, filled example (P1 — total outage)
+
+| T+ | Action |
+|---|---|
+| 0 min | Declare incident, name Incident Commander (IC). IC role ≠ person doing the fix. |
+| 0–15 min | IC runs goal-setting meeting: current known state, hypothesis, who owns which layer (physical / routing / DNS / app), first fix-block owner assigned. |
+| 15 min | First leadership update: impact statement, next update time (T+75), single next action. No technical narrative to leadership. |
+| 15–75 min | Fix-block 1 (capped 60 min). Change applied only through confirmed-independent out-of-band path. |
+| 75 min | Leadership update #2. If fix-block 1 didn't resolve: fix-block 2 begins, capped 60 min, different hypothesis or escalation to vendor/next-tier. |
+| Every 60 min thereafter | Leadership update on the same cadence until resolved. |
+| Resolution | IC declares incident closed, starts postmortem timeline from the incident log kept live during the event (not reconstructed after). |
+
+**Fix-block discipline:** if a capped block doesn't resolve it, stop, reassess, don't silently extend into a second uncapped hour — that's how a 20-minute outage becomes an all-nighter.
+
+## Out-of-band access independence check (run before any fleet-wide change)
+
+1. Identify the primary path used to reach the device being changed (SSH over production VPN, web GUI over LAN, etc.).
+2. Identify the recovery path if the primary change breaks routing/VPN/DNS.
+3. Confirm the recovery path shares **zero** physical or logical dependency with what's being changed — different circuit, different power feed, console server or cellular OOB, not "the same VPN concentrator on a different port."
+4. If step 3 fails, provision the independent path *before* the change ticket is approved, not during the incident it would have prevented.
+
+## Backup job and monitoring coverage review checklist
+
+- [ ] Every production server has a scheduled backup job — cross-reference asset inventory (IPAM/CMDB) against backup-tool job list; flag any host in inventory with no matching job.
+- [ ] Last successful **restore test** per backup tier is ≤90 days old — a green "backup completed" status without a restore test only confirms bytes were written, not that they're usable.
+- [ ] Backup job failure alerting routes to a monitored channel, not email-only — email-only alerts have a documented median time-to-notice of >24 hours in most shops.
+- [ ] RPO/RTO stated per system tier (e.g., Tier 1: RPO 1 hr / RTO 4 hr; Tier 3: RPO 24 hr / RTO 24 hr) and actual last-backup timestamp checked against RPO, not just job-success status.
+- [ ] Monitoring coverage: every device in IPAM has an active SNMP/agent poll — cross-reference monitoring-tool inventory count against IPAM device count; a gap here is dark infrastructure with no alerting.
+- [ ] Alert thresholds reviewed against **busy-hour**, not 24-hour average utilization (see capacity table below) — an alert set at 90% of the 24-hour average will never fire before saturation during the actual peak window.
+- [ ] Escalation path per alert severity documented and tested (paged the right person, at the right hour, within the last quarter) — an untested escalation path is the same as no escalation path during a 2 a.m. page.
+
+## Circuit and capacity planning lead-time table
+
+| Item | Typical lead time | Planning trigger |
+|---|---|---|
+| New WAN/ISP circuit order | 2–3 months | Start ordering at 4 months before needed, not when current circuit is already saturated |
+| Data-center/office move — HVAC/cooling run-in | 48–72 hours before occupancy | Cooling must run and stabilize before equipment is powered on; filters replaced after move-in dust settles |
+| Firmware/patch vendor release cadence (non-emergency) | Monthly maintenance window | Baseline cadence — overridden by KEV/compliance deadlines when one is active |
+| Quarterly PCI ASV scan | Every 90 days | Must use an ASV-accredited scanner for internet-facing CDE systems; internal-only tooling doesn't satisfy the control |
+
+## Busy-hour vs. average utilization comparison, filled example
+
+| Metric | Value |
+|---|---|
+| 24-hour average utilization | 34% |
+| Busy-hour utilization (8–10 AM) | **86%** |
+| Capacity planning basis | Busy-hour figure (86%), not the average |
+| Trigger for upgrade order | Busy-hour utilization crossing 80% sustained over 2 consecutive weeks — start the 2–3 month circuit-order lead time at that point, not at 95% |
+
+## RFC 1918 overlap audit (network merger / acquisition)
+
+1. Pull the full subnet list from both networks' IPAM/documentation of record.
+2. Diff the two lists for any overlapping RFC 1918 range (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), not just exact-match subnets — a /16 on one side can silently contain a /24 on the other.
+3. For every overlap found, document it as a blocker for tunnel/peering standup — do not bring up the interconnect until renumbering or NAT is in place for the overlapping range.
+4. Where renumbering isn't feasible before a deadline, use static NAT/1:1 translation as the fallback, documented in the change ticket with the overlapping ranges named explicitly.
+
+## Password/access policy audit checklist (NIST 800-63B alignment)
+
+- [ ] Rotation policy: confirm no blanket 90-day forced rotation remains on any GPO/IdP policy — rotation should trigger only on suspected/confirmed compromise.
+- [ ] Minimum length ≥8 enforced, 64+ characters permitted (not blocked by an upper-bound policy relic).
+- [ ] No composition-rule requirement (mandatory special character/number) still active — these correlate with predictable increment patterns, not stronger passwords.
+- [ ] Breached-password screening enabled against a known-compromised-credential list at set time and at login.
+- [ ] MFA required on all remote-access and privileged-account paths — check this before checking password policy detail, since MFA absence outweighs any password-policy fix.

--- a/roles/network-systems-administrator/references/red-flags.md
+++ b/roles/network-systems-administrator/references/red-flags.md
@@ -1,0 +1,61 @@
+# Red flags
+
+### "The internet is down" ticket volume spikes org-wide within a 5-minute window
+- **Usually means:** DNS resolution failure or a routing/BGP event upstream, not a true internet outage — a single naming or routing fault reads as total loss because every app depends on it.
+- **First question:** Can any affected host resolve a name via a different resolver (8.8.8.8, a secondary internal DNS server) right now?
+- **Data to pull:** Resolver query logs for SERVFAIL/NXDOMAIN spikes, and the BGP/route table diff for the last 30 minutes.
+
+### A single fleet-wide push is scheduled for more than 20% of devices in one maintenance window
+- **Usually means:** No canary or bake window was built into the change plan — the rollout risk was priced on the fix being correct, not on the blast radius if it isn't.
+- **First question:** What is the canary group, and what is the rollback trigger if the bake window shows a regression?
+- **Data to pull:** The CAB/change ticket's rollout section — canary size, bake duration, and named rollback threshold.
+
+### Admin/recovery access (console server, out-of-band VPN, badge system) shares a network path or power circuit with the systems it's meant to recover
+- **Usually means:** The recovery path will go down in the same incident it's needed for — this is the exact failure that locked Meta's own responders out during the Oct 2021 backbone outage.
+- **First question:** If this device/circuit fails right now, can an admin still reach the console out-of-band?
+- **Data to pull:** Out-of-band topology diagram or IPAM record showing the physical/logical path independence of console/cellular failover from production.
+
+### A CVE lands in the CISA KEV catalog on an internet-facing system
+- **Usually means:** The 14-calendar-day remediation clock has started and overrides the normal patch cycle — waiting for the next scheduled maintenance window will miss the deadline.
+- **First question:** Is this asset internet-facing (14-day clock) or internal-only (45-day clock), and how many days of margin does the current staged-rollout plan leave?
+- **Data to pull:** KEV catalog entry date, asset exposure classification, and the canary/batch schedule with elapsed-time total.
+
+### Password policy still enforces rotation on a fixed calendar (e.g., every 90 days) with no compromise indicator
+- **Usually means:** The policy is inherited from an old GPO baseline, not a current security control — NIST 800-63B (Rev. 4) recommends rotation only on suspected/confirmed compromise, and calendar rotation trains users into predictable increment patterns.
+- **First question:** Has this policy been reviewed against 800-63B, or is it running because "it's always been 90 days"?
+- **Data to pull:** Current password policy GPO/config and the date of its last security review.
+
+### Two networks are being merged or peered without an RFC 1918 overlap audit
+- **Usually means:** Overlapping private address ranges are present and will cause silent, intermittent routing failures weeks after the merge, not an immediate visible break.
+- **First question:** Has every subnet on both sides been diffed for overlap before the tunnel or peering session goes up?
+- **Data to pull:** IPAM export from both networks, sorted by CIDR, for an overlap diff.
+
+### VPN reconnect success rate drops below 98% of pre-change baseline during a bake window
+- **Usually means:** The firmware or config change just pushed has a negotiation or routing defect — this is a rollback trigger, not a metric to watch and wait on.
+- **First question:** Does this cross the rollback threshold written into the change ticket, and has the next batch been held?
+- **Data to pull:** VPN concentrator reconnect success-rate dashboard for the canary/batch group versus the pre-change 7-day baseline.
+
+### A quarterly PCI ASV scan was run by an internal or unaccredited tool
+- **Usually means:** The scan does not satisfy PCI DSS 11.3.2 regardless of whether it passed — the requirement is specifically an ASV-accredited external scan for internet-facing cardholder-data-environment systems.
+- **First question:** Is the scanning vendor on the current PCI SSC ASV list for this quarter?
+- **Data to pull:** ASV accreditation status and the scan report's vendor attestation.
+
+### Backup job success-rate dashboard hasn't been checked in over 30 days
+- **Usually means:** A silently failing backup job is indistinguishable from a healthy one until a restore is needed — job completion notifications get filtered or ignored long before anyone notices.
+- **First question:** When was the last test restore actually performed, not just the last "job succeeded" notification?
+- **Data to pull:** Backup job success/failure log for the last 30 days and the date of the last verified test restore.
+
+### Monthly ticket backlog's opened-to-closed ratio has grown for 3+ consecutive months
+- **Usually means:** A staffing or process gap, not an individual admin working too slowly — reading it as an individual performance issue misses the systemic signal.
+- **First question:** Is the growth concentrated in one ticket category (pointing at a process fix) or spread evenly (pointing at headcount)?
+- **Data to pull:** Ticket system's monthly opened-vs-closed count, broken out by category, for the last 6 months.
+
+### The same manual step appears in every on-call rotation's runbook
+- **Usually means:** Toil that should be automated, not a permanent fixture of the job — left unaddressed it consumes the time budget meant for the automation that would remove it.
+- **First question:** How many on-call hours per rotation does this step currently cost, and is that pushing total toil over roughly half of available engineering time?
+- **Data to pull:** On-call runbook step frequency log and cumulative toil-hours estimate per rotation.
+
+### A WAN circuit order is placed less than 6 weeks before a planned office or data-center move date
+- **Usually means:** The 2-3 month carrier lead time won't be met — the move date will slip or the site will open without connectivity, not a scheduling inconvenience that can be expedited.
+- **First question:** What is the carrier's confirmed install date, and does it fall before or after the planned occupancy date?
+- **Data to pull:** Circuit order confirmation with committed install date versus the project's occupancy timeline.

--- a/roles/network-systems-administrator/references/vocabulary.md
+++ b/roles/network-systems-administrator/references/vocabulary.md
@@ -1,0 +1,59 @@
+# Network/systems administrator working vocabulary
+
+Terms a network/systems admin uses precisely and a generalist blurs together. Format: definition → how a practitioner says it → common misuse.
+
+**Blast radius** — The set of systems, users, or sites actually affected if a given change goes wrong, as distinct from the set it was intended to touch. A property of how the rollout is staged, not of how good the change is.
+In use: "The WAF rule itself is fine — the blast radius is the problem, it's going to every edge node in one push with no canary."
+Misuse: treating blast radius as a fixed property of the change ("it's just a config tweak, low risk") instead of a variable set by the rollout plan — a trivial-looking change pushed everywhere at once has the same blast radius as a risky one.
+
+**Canary** — A small, deliberately low-impact subset of the fleet that receives a change first, with a defined bake window before the change proceeds to the rest, so a defect surfaces on a few sites instead of all of them.
+In use: "Flash the two lowest-impact regional offices as canary, four-hour bake, then batch two."
+Misuse: calling a rollout "canaried" when the first batch is 25% of the fleet or the "bake window" is skipped because a deadline is close — a canary only does its job if it's small and if it's actually watched before the rest proceeds.
+
+**Bake window** — The fixed monitoring period after a change reaches a canary or batch, before the rollout is allowed to continue, during which specific signals (protocol reconvergence, reconnect success rate) are watched for a regression.
+In use: "24-hour bake on batch two before we touch the remaining sites — BGP and VPN reconnect rate both have to hold."
+Misuse: treating the bake window as a calendar delay to satisfy change management rather than an active check against named failure signals — nobody actually looks at the metrics during it.
+
+**Out-of-band (OOB) management** — A path to reach and administer a device (console server, cellular failover, dedicated management VLAN) that does not depend on the production network path the device itself provides or that could fail alongside it.
+In use: "Confirm the console-server path into those two sites is on its own circuit before we flash anything — we can't recover over the same VPN service we're about to break."
+Misuse: assuming the admin VPN or jump box counts as out-of-band when it in fact terminates on the same device, link, or power circuit as what's being changed — it only counts as OOB if it survives the specific failure being planned for.
+
+**Rollback trigger** — The specific, pre-committed condition (a metric threshold or state check) that ends a rollout and reverts, decided before the push starts rather than judged in the moment.
+In use: "Trigger's written into the ticket: any batch site failing OSPF reconvergence inside the bake window, or reconnect success under 98% of baseline."
+Misuse: proceeding on a vague "we'll pull it if something looks wrong" instead of a number decided in advance — without a pre-committed threshold, the person watching the bake window under incident pressure tends to explain away the first bad signal instead of reverting.
+
+**KEV clock** — The 14-calendar-day (internet-facing) or 45-day (everything else) remediation deadline that starts once a CVE is added to CISA's Known Exploited Vulnerabilities catalog, per Binding Operational Directive 22-01 — distinct from a CVSS score or a routine patch cycle.
+In use: "CVSS 9.8 isn't what's driving the timeline — it's on the KEV list now, so the clock is 14 days, internet-facing."
+Misuse: treating a high CVSS score alone as the deadline-setter, or assuming the KEV deadline means "patch everything tonight" rather than "complete a staged rollout inside this window" — the clock sets the outer bound, not the rollout method.
+
+**RFC 1918 overlap** — Two private (non-routable) address ranges in use on networks that are about to be connected (merger, tunnel, peering) that happen to cover the same address space, causing silent routing conflicts once connected.
+In use: "Before that tunnel goes up, pull both address plans — if they're both sitting on 10.0.0.0/8 unscoped, we have an overlap problem, not a routing problem."
+Misuse: diagnosing the resulting intermittent connectivity loss as a hardware or protocol fault and re-troubleshooting the tunnel for weeks, instead of checking for address-space overlap first — the symptom looks like flaky routing, not like a numbering conflict.
+
+**Route withdrawal (BGP)** — A router or backbone announcing that it can no longer reach a given prefix, removing it from the routing table; this can take down services (like DNS resolvers) that depend on those addresses without anything being wrong with the service itself.
+In use: "The DNS servers didn't fail — their prefixes got withdrawn in the backbone audit, so nothing could route to them."
+Misuse: treating "DNS is down" as a DNS-layer problem and restarting resolver services, when the actual fault is a routing-layer withdrawal upstream that just presents as a naming failure.
+
+**Toil** — Manual, repetitive operational work that scales linearly with the size of the system and produces no lasting improvement once done — as distinct from work that, once completed, removes the need to do it again.
+In use: "Restarting that service by hand every on-call rotation is toil — it's not part of the job, it's the thing we haven't automated yet."
+Misuse: treating recurring manual fixes as an unavoidable fact of the role rather than a backlog item to eliminate — Google SRE's toil cap (roughly half an engineer's time) is a target to push under, not a description of normal workload.
+
+**Ticket opened:closed ratio** — The month-over-month trend between how many incidents/tickets are opened versus closed; a rising ratio is read as a staffing or process signal at the team level, not evidence about any individual's performance.
+In use: "The ratio's been climbing three months straight — that's a capacity conversation with the business, not a coaching conversation with the on-call engineer."
+Misuse: responding to a rising ratio by telling individual admins to work faster or clear tickets quicker, when the trend is a team-level staffing or automation signal that individual effort can't fix.
+
+**ASV scan** — A vulnerability scan run by a PCI-accredited Approved Scanning Vendor against internet-facing, cardholder-data-environment systems, required quarterly under PCI DSS 11.3.2; an internal or unaccredited scan does not satisfy the requirement even if it finds the same issues.
+In use: "That's a Tenable internal scan, not an ASV scan — it doesn't count toward the quarterly PCI requirement even though it flagged the same CVE."
+Misuse: treating any vulnerability scan as interchangeable with the compliance-mandated ASV scan, or treating a passing quarterly ASV scan as current coverage — a new KEV-listed CVE the following week isn't covered by last quarter's clean result.
+
+**Password rotation vs. compromise-triggered rotation** — NIST 800-63B guidance: rotate credentials only on suspected or confirmed compromise, not on a fixed calendar; favor length (64+ characters permitted) over composition rules.
+In use: "We're not resetting the fleet's passwords on the 90-day GPO — that's calendar rotation, not a response to an actual compromise indicator."
+Misuse: treating scheduled rotation itself as a security control that stops credential-stuffing attacks, when in practice it mainly trains users into predictable incremental password patterns (Password1!, Password2!) without addressing the actual compromise risk.
+
+**Incident Command (IC) structure** — A named-commander model for major incidents: one person coordinating, a goal-setting meeting at the start, fixed-interval leadership updates, and work executed in capped time blocks rather than open-ended debugging.
+In use: "We're standing up IC for this — I'm commander, hourly updates to leadership, work in one-hour blocks."
+Misuse: running a major incident as an open Slack channel with whoever's available typing fixes in, and calling that "incident response" — without a named commander and a fixed update cadence, work stretches into an unstructured all-nighter instead of a bounded, communicated process.
+
+**Change/CAB ticket** — The change-advisory-board artifact of record for a fleet-wide push: scope, rollout stages, rollback trigger, and deadline, written and approved before the first canary goes out, not reconstructed afterward as documentation.
+In use: "Ticket's filed before batch one — scope, canary sites, bake windows, and the rollback trigger are all in it already."
+Misuse: treating the CAB ticket as a formality filled in after the work is done, or as a place to write "will roll out carefully" instead of the actual canary/bake/rollback numbers — the point is that the plan exists and is reviewable before anything ships, not that a form got completed.


### PR DESCRIPTION
Rubric score: 18/18

## Resolution rationale

Read computer-systems-analyst (15-1211.00) and computer-information-systems-manager (11-3021.00) in full; also checked sibling roles devops-sre and network-architect for context. Network and Computer Systems Administrators (15-1244.00) is hands-on day-to-day operation of an org's internal network/server infrastructure: configuring routers/switches/firewalls, provisioning and troubleshooting user accounts and access, patch management and OS/software maintenance on servers and workstations, monitoring network/server performance and diagnosing outages, running backup and disaster-recovery procedures, and day-to-day security hardening (not risk-acceptance policy). computer-information-systems-manager is explicitly the business-facing, budget/strategy owner ABOVE this discipline (its own Identity section lists devops-sre and software-engineer as the individual engineering disciplines it sits above — a sysadmin role is exactly this kind of discipline, and none of that manager's Decision framework — TCO framing, technical-debt-as-financial-debt, security risk acceptance authority — gives correct guidance for e.g. sizing a backup rotation, diagnosing a DNS outage, or hardening a firewall ruleset). computer-systems-analyst is about requirements elicitation, feasibility studies (TELOS), and system-replacement/migration projects — a project-based analytical function, not operating live network/server infrastructure; its Decision framework (RTM, gap analysis, cutover/rollback planning for a replacement project) would misdirect a practitioner asked to troubleshoot a routing loop or rotate backup credentials. education-administrator-other is irrelevant. This fails the practitioner-nod test hard for both real candidates — a sysadmin doing exactly this job would get wrong or inapplicable guidance from either. No reasonable parent exists among the three candidates offered. Note for the generation step: the repo already has network-architect (15-1241.00, network design/topology/capacity-planning) and devops-sre (cloud/product SRE) as neighboring-but-distinct occupations in the same family; the new role should be scoped to traditional internal-IT network/systems administration (accounts, patching, backup/DR, day-to-day troubleshooting) to stay non-overlapping with both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the new `network-systems-administrator` role (O*NET 15-1244.00) for internal IT network/server operations at spec‑2. Scoped to avoid overlap with `network-architect` and `devops-sre`, and updates counts/checklist.

- **New Features**
  - Added `roles/network-systems-administrator/` with `SKILL.md` (spec‑2) and references: `playbook.md`, `red-flags.md`, `vocabulary.md` covering canary/bake/rollback, Incident Command, KEV timelines, NIST 800‑63B password policy, PCI ASV scans, and RFC1918 overlap checks.
  - Inserted role entry in `data/roles.json` (category: operations, status: active) describing triage, patching, access control, backup/DR, and circuit planning.
  - Updated `README.md` and `ROADMAP.md` to 161 roles (151 mapped; 119 at spec‑2), 14.9% O*NET coverage, operations +1; marked 15‑1244.00 as drafted with link.

<sup>Written for commit 2c70079489d00939e122ccea7bd49934043499f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

