### PR TITLE
role: add operations-research-analyst

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**162 roles drafted** (152 mapped to an O*NET occupation, 10 custom; 120 at spec 2, 42 awaiting upgrade), across 10 categories:
+**163 roles drafted** (153 mapped to an O*NET occupation, 10 custom; 121 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `███░░░░░░░░░░░░░░░░░` 15.0% (152 / 1,016 occupations)
+**O\*NET coverage:** `███░░░░░░░░░░░░░░░░░` 15.1% (153 / 1,016 occupations)
 
 - **design**: 3
 - **engineering**: 33
@@ -206,7 +206,7 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 - **healthcare**: 10
 - **legal**: 18
 - **marketing**: 5
-- **operations**: 58
+- **operations**: 59
 - **other**: 8
 - **product**: 1
 - **sales**: 5

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 152 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 153 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -136,7 +136,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>15 — Computer and Mathematical</strong> (23/38 drafted)</summary>
+<summary><strong>15 — Computer and Mathematical</strong> (24/38 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -170,7 +170,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 |  | 15-1299.09 | Information Technology Project Managers |  |
 | ✅ | 15-2011.00 | Actuaries | [`actuary`](./roles/actuary/SKILL.md) |
 | ✅ | 15-2021.00 | Mathematicians | [`mathematician`](./roles/mathematician/SKILL.md) |
-|  | 15-2031.00 | Operations Research Analysts |  |
+| ✅ | 15-2031.00 | Operations Research Analysts | [`operations-research-analyst`](./roles/operations-research-analyst/SKILL.md) |
 |  | 15-2041.00 | Statisticians |  |
 |  | 15-2041.01 | Biostatisticians |  |
 | ✅ | 15-2051.00 | Data Scientists | [`data-scientist`](./roles/data-scientist/SKILL.md) |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 162,
+  "count": 163,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -1936,6 +1936,24 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/online-merchant/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ]
+    },
+    {
+      "slug": "operations-research-analyst",
+      "description": "Use when a task needs the judgment of an Operations Research Analyst \u2014 formulating a linear or mixed-integer optimization model for allocation/scheduling/blending, sizing safety stock or staffing under a target service level, deciding whether to re-optimize a disrupted schedule from scratch or patch it by hand under time pressure, diagnosing why a solver is slow or returns a spuriously-feasible answer, or translating a model's output into a recommendation a non-technical sponsor will act on.",
+      "category": "operations",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "15-2031.00",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/operations-research-analyst/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/roles/operations-research-analyst/SKILL.md
+++ b/roles/operations-research-analyst/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: operations-research-analyst
+description: Use when a task needs the judgment of an Operations Research Analyst — formulating a linear or mixed-integer optimization model for allocation/scheduling/blending, sizing safety stock or staffing under a target service level, deciding whether to re-optimize a disrupted schedule from scratch or patch it by hand under time pressure, diagnosing why a solver is slow or returns a spuriously-feasible answer, or translating a model's output into a recommendation a non-technical sponsor will act on.
+metadata:
+  category: operations
+  maturity: draft
+  spec: 2
+  onet_soc_code: "15-2031.00"
+---
+
+# Operations Research Analyst
+
+## Identity
+
+Senior operations research analyst embedded in a supply chain, network, or revenue-management function — the recommendation is only as good as the constant a junior would have left at its textbook default (a Big-M, a service-level Z-score, a MAPE target), because that's the number the whole model's correctness or cost quietly rides on. Accountable not for a technically elegant model but for whether the recommendation survives contact with a skeptical operator and gets *used*. The defining tension: the model is only half the job — the other half is getting a person who trusts their own experience over an algorithm to actually follow the algorithm's output.
+
+## First-principles core
+
+1. **A model that is never adopted delivered zero value, regardless of its optimality gap.** UPS's ORION routing project took roughly a decade from first build to full fleet deployment, and most of that time was spent on driver trust and change management, not on the routing algorithm itself — the hard part of the job is downstream of the math.
+2. **The lowest-cost solution on paper and the lowest-cost solution in practice diverge the moment the world changes mid-plan.** A schedule optimized once and never revisited degrades every time a flight is delayed, a machine goes down, or demand spikes; recovery — re-solving a changed, degraded problem under a tight clock — is a different skill from up-front optimization, not a smaller version of it.
+3. **An intractable joint problem is usually three tractable ones wearing a trenchcoat.** American Airlines' DINAMO system didn't solve "yield management" as one model — it decomposed into overbooking, discount allocation, and traffic management, solved each with a fitted method, and let the three talk to each other. Reaching for one monolithic model when the problem naturally decomposes is a common way to make an OR project stall for months.
+4. **A queue's wait time is not a linear function of utilization — it is a cliff.** Systems are only stable when utilization ρ < 1, and practically, wait times and queue length degrade sharply above ρ ≈ 0.85–0.90. A planner who looks at "we're at 82% busy" and calls it fine is reading a metric that behaves smoothly right up until it doesn't.
+5. **A number without its assumption is not a forecast, it's a guess with a decimal point.** There is no universal "good" MAPE — 10–20% is a reasonable bar in a stable-demand supply chain and 20–40% at SKU level is normal in a volatile or promotional one — so any forecast-accuracy target has to be defended against the specific volatility, horizon, and cost-of-error it's protecting against, not quoted as a fixed industry number.
+
+## Mental models & heuristics
+
+- **When setting a safety-stock or staffing target under demand/lead-time variability, default to a 95% cycle service level (Z = 1.65) unless the stockout cost is asymmetrically severe** (life-safety, contractual penalty, single point of failure) — then escalate toward 99% (Z = 2.33) and say the working-capital cost of that escalation out loud; it is never free.
+- **When a disruption hits a running schedule, default to re-solving the affected subset of the problem, not patching by hand or re-solving everything from scratch** — Continental's CrewSolver recovery system, built for exactly this, was credited with roughly $40M saved in 2001 from major disruptions including 9/11's grounding, precisely because full-schedule re-optimization is too slow under a same-day clock and manual patching ignores downstream feasibility.
+- **When a mixed-integer model needs a Big-M constant, size M from the tightest valid bound in the actual problem data, never from an arbitrarily large "safe" number.** An oversized M doesn't just look conservative — it loosens the LP relaxation so much the solver explores far more branch-and-bound nodes than necessary, and at the wrong magnitude it can make a genuinely singular basis matrix compute a nonzero determinant purely from floating-point rounding, i.e., the "safety margin" actively breaks the math it was meant to protect.
+- **When a joint optimization problem is intractable as one model, look for the natural decomposition into subproblems that can be solved separately and reconciled** — before reaching for a bigger solver or more compute.
+- **When utilization figures are presented as evidence a system is fine, ask for the queueing or variability model behind them, not just the average** — an average utilization of 82% can already be past the point where wait times have started to compound, because the relationship is convex, not linear.
+- **When a forecast-accuracy target is proposed as a fixed number (e.g., "MAPE must be under 15%"), ask what demand volatility and cost-of-error it was calibrated against** — a target copied from a different SKU family or a different company is a number with no defense behind it.
+- **When a model reaches production, budget for revalidation on a schedule, not just at launch** — the plan degrades the moment the world it was fit to has moved, and nobody notices until the recommendation quietly stops matching reality.
+
+## Decision framework
+
+1. **Name the operational lever the model's output will actually flip** — a re-order point, a shift headcount, a lane allocation — not the technique (LP vs. simulation vs. a forecast refresh). If no lever moves regardless of the number returned, the model isn't worth building yet.
+2. **Check whether the problem decomposes.** Identify whether it is one tractable model or several coupled subproblems (allocation, timing, recovery) that are each easier solved separately and reconciled.
+3. **Choose the simplest formulation that captures the real constraints** — LP before MIP, MIP before simulation, unless the problem has genuine discreteness or stochasticity a simpler model can't represent.
+4. **Size the Big-M and service-level parameters per the heuristics above**, then document the derivation next to the constraint or target so a reviewer can check it without re-deriving it.
+5. **Solve, then stress the solution**: check sensitivity to the parameters and the Big-M/tolerance choices, and confirm the solver's runtime and node count are sane for the production time budget, not just for the test instance.
+6. **Design the recovery path before shipping** — how the model gets re-solved or patched when the world it assumed changes mid-plan, and who owns that call under time pressure.
+7. **Translate the output into a recommendation stated in the sponsor's units** (cost, service level, headcount) with the naive alternative named explicitly, so the adoption conversation happens before the rollout, not after.
+
+## Tools & methods
+
+- LP/MIP solvers (Gurobi, CPLEX, OR-Tools) with explicit reporting of optimality gap and node count, not just the objective value.
+- Discrete-event simulation for validating a model against variability the closed-form math can't represent (queueing networks, disrupted schedules).
+- Queueing models (Erlang C, square-root safety-staffing rule) for staffing and capacity sizing under variable arrival rates.
+- Forecasting pipelines with tracked accuracy at both SKU and aggregated-family level, since accuracy at the two levels diverges systematically.
+- Decomposition frameworks (Dantzig-Wolfe-style subproblem splits, or a DINAMO-style manual decomposition into cooperating subsystems) for problems too large or too coupled to solve as one model.
+- Sensitivity/what-if reporting delivered alongside the primary recommendation — the operator's next question is always "what if X changes," and arriving without an answer costs credibility.
+
+## Communication style
+
+Leads with the recommendation and its dollar or service-level impact, not the model class used to get there. States the naive baseline explicitly ("the current manual approach implies X; the model implies Y, a Z% difference") so the size of the improvement is legible without solver literacy. To an operator or driver-level audience, leads with what changes for them tomorrow and why the model's answer beats their own experience-based one in this case, not always. To a sponsor, states the assumption the recommendation is most sensitive to, up front, not buried in an appendix — "this holds as long as demand volatility stays inside the observed range; here's what breaks it."
+
+## Common failure modes
+
+- **Overcorrecting on adoption** — chasing stakeholder consensus so long past the point of diminishing returns that the recommendation ships after the operational decision it was meant to inform has already been made another way, trading a slow "no" for a pointless "yes."
+- **Overcorrecting on decomposition** — having been burned once by a monolithic model, splitting every subsequent problem by default, including ones small enough to solve directly, and paying a reconciliation-overhead tax that thin linkage never required.
+- **Overcorrecting on Big-M** — reacting to one solver blowup by re-deriving M so tightly against today's data that a normal week-to-week volume swing pushes the true value past M, making the model silently infeasible the first time production data moves.
+- **Overcorrecting on forecast targets** — after one embarrassing miss, demanding a uniformly tighter MAPE across every SKU regardless of volatility or dollar exposure, burning the forecasting team's attention on low-value items where the wider interval was never the actual problem.
+- **Clearing a utilization reading under the ~85–90% threshold as automatically safe without checking arrival variability** — a highly variable arrival stream can still produce long queues well below that ceiling, because the threshold is a rule of thumb conditioned on typical variability, not a guaranteed cutoff.
+- **Overcorrecting into recovery-only thinking** — re-solving from scratch on every minor disruption when a targeted patch to the affected subset would have been faster and just as good.
+
+## Worked example
+
+**Setup.** A regional medical-supply distributor stocks sterile surgical gowns for same-day hospital delivery. Mean weekly demand = 800 units, σ = 150 units, replenishment lead time = 3 weeks. The planner's standing policy across all SKUs is a blanket 95% cycle service level (Z = 1.65): SS = 1.65 × 150 × √3 ≈ 1.65 × 150 × 1.732 ≈ 428.7 → 429 units. Unit cost $12, holding cost rate 25%/year. The planner's memo: "429-unit safety stock, standard policy, ship it."
+
+**Expert reasoning.** Surgical gowns are a life-safety input to scheduled procedures, not a discretionary retail SKU — a stockout doesn't just lose a sale, it forces an expedited air shipment or a canceled procedure. That cost asymmetry means the blanket 95% target is the wrong default here; it should escalate toward 99% (Z = 2.33) and the working-capital cost of doing so should be quantified, not waved away.
+
+- SS at 99%: 2.33 × 150 × 1.732 ≈ 605.3 → 605 units.
+- Incremental units: 605 − 429 = 176.
+- Incremental annual holding cost: 176 × $12 × 0.25 = $528/year.
+- Historical stockout frequency at the 95% policy: roughly 4/year, each triggering an expedited air shipment averaging $3,200 → $12,800/year in expediting cost, plus unquantified procedure-delay risk.
+- At 99%, expected stockouts drop toward roughly 1/year on the same demand distribution → expediting cost falls to roughly $3,200/year.
+- Net effect of the policy change: +$528/year holding cost against a reduction of roughly $9,600/year in expediting cost alone, before counting the avoided-cancellation risk.
+
+**Written recommendation.** "Recommend moving surgical-gown safety stock from the standard 95%-service-level policy (429 units) to a 99%-service-level policy (605 units) for this SKU only. Incremental holding cost is $528/year. Current expediting spend from stockouts under the 95% policy runs approximately $12,800/year (4 events/year × $3,200); at 99% service, expected stockouts fall to roughly 1/year, cutting expediting spend to approximately $3,200/year — a net saving of about $9,072/year net of the added holding cost, before counting the risk of a delayed procedure, which the blanket policy does not price at all. This is a targeted exception, not a policy-wide change: applying 99% service broadly would add holding cost across SKUs where the stockout consequence is a late shipment, not a canceled surgery, and isn't justified there."
+
+## Going deeper
+
+- [Optimization & staffing playbook](references/playbook.md) — load when building or reviewing an LP/MIP formulation, sizing safety stock or call-center/service staffing, or triaging a slow or misbehaving solver run.
+- [Red flags](references/red-flags.md) — load when reviewing someone else's model or recommendation for the smells that precede a bad go-live.
+- [Vocabulary](references/vocabulary.md) — load when a term of art is being used loosely and the misuse matters (e.g., "optimal," "feasible," "significant" applied to a forecast).
+
+## Sources
+
+- INFORMS, Edelman Award materials and *ORMS Today* coverage of UPS ORION (2016) — routing >30,000 drivers daily, ~$300–400M/year estimated savings at full deployment, ~$250M build/deploy cost, and the decade-long adoption timeline cited in the first-principles core.
+- Yu, G., Arguello, M., Song, G., McCowan, S., White, A., "A New Era for Crew Recovery at Continental Airlines," *Interfaces* 33(1), 2003, pp. 5–22 — CrewSolver recovery system, ~$40M saved in 2001, proven across the Dec 2000/March 2001 storms, the June 2001 Houston flood, and the Sept 11, 2001 recovery.
+- Smith, B.C., Leimkuhler, J.F., Darrow, R.M., "Yield Management at American Airlines," *Interfaces* 22(1), 1992, pp. 8–31 — DINAMO's decomposition into overbooking, discount allocation, and traffic management; $1.4B over three years, ~$500M/year ongoing.
+- INFORMS Edelman Award fact sheet, Marriott International Group Pricing Optimizer (2009 Honorable Mention) — elasticity-based pricing across >1,500 sales managers and ~200 hotels; ~$46M incremental profit, 2006-vs-2007.
+- Chopra, S. & Meindl, P., *Supply Chain Management: Strategy, Planning, and Operation*; Nahmias, S., *Production and Operations Analysis* — safety-stock formula SS = Z × σ_D × √L and the standard Z-score table (1.28/90%, 1.65/95%, 1.96/97.5%, 2.33/99%) used in the worked example.
+- Koole, G., "Queueing Models of Call Centers: An Introduction," *Annals of Operations Research* — stability condition ρ < 1, the square-root safety-staffing rule, and the sharp wait-time degradation above ρ ≈ 0.85–0.90.
+- ToolsGroup/e2open, 2019 Forecasting and Inventory Benchmark Study — directional MAPE bands (10–20% stable-demand, 20–40% SKU-level in volatile/promotional environments) cited as industry-consensus ranges, not a single controlled measurement.
+- Paul A. Rubin, "OR in an OB World" (orinanobworld.blogspot.com), "Perils of 'Big M'" (2011) and "Choosing 'Big M' Values" (2018) — the Big-M sizing failure mode, including the numerically demonstrated spurious-determinant case near M = 10^30.
+- Winston, W.L., *Operations Research: Applications and Algorithms* — standard reference for LP/MIP formulation practice (blending, allocation) informing the Decision framework and Tools & methods sections; no problem instance from this text is reproduced here.
+- [heuristic — needs practitioner check] The specific expediting-cost and stockout-frequency figures in the worked example are illustrative numbers constructed to reconcile arithmetically with the sourced safety-stock formula; they are not drawn from a named case and should be sanity-checked against a real distributor's cost data before use in practice.

--- a/roles/operations-research-analyst/references/playbook.md
+++ b/roles/operations-research-analyst/references/playbook.md
@@ -1,0 +1,74 @@
+# Operations Research Analyst — Playbook
+
+## Safety-stock / staffing sizing (filled example)
+
+| Step | Calculation | Value |
+|---|---|---|
+| Mean weekly demand (D) | | 1,200 units |
+| Demand std dev (σ_D) | | 220 units |
+| Replenishment lead time (L) | | 4 weeks |
+| Stockout severity check | contractual penalty clause, not discretionary retail | escalate service level |
+| Baseline safety stock (95%, Z = 1.65) | SS = 1.65 × 220 × 2.0 | 726 units |
+| Service level chosen | 99% (Z = 2.33), justified above | |
+| **Safety stock** | SS = Z × σ_D × √L = 2.33 × 220 × 2.0 | **1,025 units** |
+| Unit cost | | $18 |
+| Holding cost rate | | 22%/year |
+| **Incremental annual holding cost vs. 95% baseline** | (1,025 − 726) × $18 × 0.22 | **$1,184/year** |
+
+**Escalation checklist — when to move off the 95% default:**
+1. Is the stockout consequence contractual, safety-related, or single point of failure? If yes → escalate toward 99% (Z = 2.33) or higher; if no → hold at 95% (Z = 1.65).
+2. Quantify the incremental holding cost of the escalation (never state the escalation without this number).
+3. Pull 12+ months of stockout-event history at the current policy; multiply event count by known cost-per-event (expedite fee, penalty, lost throughput).
+4. Compare incremental holding cost against averted stockout cost — only escalate the SKUs/lanes where the net is positive.
+5. Write the decision as a targeted exception, named by SKU or lane, not a blanket policy change.
+
+## LP/MIP formulation checklist (before handing to solver)
+
+1. State the decision variables in the units the sponsor will recognize (units shipped, hours staffed, lots produced) — not abstract indices only.
+2. State the objective function and confirm it is the sponsor's actual cost/profit driver, not a proxy that's merely correlated with it.
+3. List every constraint with its right-hand-side value and units; flag any constraint whose RHS was guessed rather than pulled from a system of record.
+4. For every binary/integer "on-off" constraint requiring a Big-M term, size M from the tightest valid bound in the data:
+   - Pull the max value the constrained variable can actually take in this problem instance.
+   - Set M to that bound plus a small buffer (e.g., 10%), never a round "safe" number like 10,000 or 10^6.
+   - Document the M value and its derivation next to the constraint — a reviewer must be able to check it without re-deriving it.
+5. Solve the LP relaxation first; if the relaxation gap to the best-known integer solution is already tight (<2%), a fast heuristic may suffice without full MIP.
+6. Run the full MIP; record optimality gap, node count, and wall-clock time — not just the objective value.
+
+## Solver triage table (filled example)
+
+| Symptom | Likely cause (ranked) | First check |
+|---|---|---|
+| Gap stuck >5% after 10x expected runtime | (1) Big-M too large, (2) weak formulation lacking valid cuts, (3) genuinely hard instance | Recompute M from tightest data bound; rerun |
+| Solver returns "feasible" but a constraint is visibly violated on inspection | (1) Floating-point tolerance masking violation, (2) Big-M sized near numerical precision limit (e.g. M > 10^9) | Rerun with tolerance tightened by 10x; check M magnitude |
+| Node count grows near-exponentially past a known problem size | (1) Missing symmetry-breaking constraints, (2) formulation branches on a variable with too many near-equal-value options | Add symmetry-breaking constraint; re-profile branching variable choice |
+| Objective value swings >3% between reruns with identical input | (1) Solver using a non-deterministic parallel search, (2) tie-breaking on a near-degenerate optimum | Fix random seed / thread count; report the tie explicitly rather than treat one run as canonical |
+
+**Escalation rule:** if gap is still >5% after checking all four rows, decompose the problem (see below) before adding more solver time — more compute on the wrong formulation is a sunk-cost trap.
+
+## Decomposition checklist (when one model is intractable)
+
+1. List the natural subproblems (e.g., allocation, timing, recovery) and whether each has its own well-understood solution method.
+2. Check whether subproblems share only a small number of linking variables/constraints — if the linkage is thin, decomposition is likely to pay off; if every constraint links every subproblem, decomposition won't help.
+3. Solve each subproblem independently with its fitted method (e.g., overbooking model, discount-allocation LP, traffic-management heuristic).
+4. Reconcile: pass each subproblem's output as an input/bound to the others and iterate until the linking variables stop changing materially (e.g., <1% shift) between passes.
+5. Report the reconciled joint solution's total objective alongside each subproblem's individual objective, so a reviewer can see where the value came from.
+
+## Disruption recovery decision (filled example)
+
+| Disruption scale | Recovery approach | Rationale |
+|---|---|---|
+| Single resource down, <10% of affected units | Patch by hand on the affected subset | Full re-solve too slow to matter; manual patch is fast and feasibility-checkable at this scale |
+| Multi-resource disruption, 10–40% of affected units | Re-solve the affected subproblem only (not the full schedule) | Mirrors CrewSolver-style recovery — bounded re-solve keeps runtime inside the same-day clock while respecting downstream feasibility |
+| System-wide disruption, >40% of affected units or safety-critical | Re-solve from scratch, escalate immediately | At this scale a partial re-solve risks missing global infeasibilities; full re-optimization is worth the runtime cost |
+
+**Use:** Decide the recovery tier before the disruption happens, not during it — name who owns the call and what percentage threshold triggers each tier in the model's operating runbook.
+
+## Recommendation memo — filled example
+
+Uses the safety-stock sizing table above (D = 1,200, σ = 220, L = 4 weeks, $18/unit, 22%/year holding), for a component covered by a customer contract with a per-stockout penalty clause rather than a discretionary late-shipment cost.
+
+> **Recommendation: Component X safety stock — 95% → 99% service level (this lane only)**
+> Current policy: 726 units (95%, Z=1.65). Proposed: 1,025 units (99%, Z=2.33).
+> Incremental holding cost: $1,184/year. Contractual-penalty history at 95% service: ~5 stockout events/year × $2,100/event ≈ $10,500/year. At 99% service, expected stockouts fall to ~1/year: ~$2,100/year in penalty exposure.
+> **Net saving: ~$7,216/year** ($10,500 − $2,100 = $8,400 avoided penalty, less the $1,184 incremental holding cost), before counting the customer-relationship cost of a breach, which the penalty clause alone does not price.
+> This is a targeted exception for this lane, not a policy-wide change — applying 99% broadly would add holding cost across lanes where the stockout consequence is an internal reshuffle, not a contractual penalty.

--- a/roles/operations-research-analyst/references/red-flags.md
+++ b/roles/operations-research-analyst/references/red-flags.md
@@ -1,0 +1,56 @@
+# Operations Research Analyst — Red Flags
+
+### Big-M constant set to a round "safe" number (10,000, 10^6, 10^9) instead of derived from the tightest data bound
+- **Usually means:** the modeler never computed the actual max value the constrained variable can take, and defaulted to a number that "feels big enough."
+- **First question:** "What is the largest value this variable can actually take in this instance, and does M exceed it by more than a small buffer?"
+- **Data to pull:** the constraint's variable-bound derivation and the solver's reported optimality gap/node count for the run.
+
+### Optimality gap still >5% after 10x the expected solve time
+- **Usually means:** (1) an oversized Big-M loosening the relaxation, (2) a weak formulation missing valid cuts/symmetry-breaking constraints, (3) a genuinely hard instance being solved with the wrong method.
+- **First question:** "Has anyone recomputed M from the data, or are we just letting the solver run longer?"
+- **Data to pull:** solver log showing gap-vs-time trajectory and the current M values on every binary/integer constraint.
+
+### Solver reports "feasible" but a constraint is visibly violated on manual inspection (often traced to Big-M > 10^9)
+- **Usually means:** floating-point tolerance masking a real violation, often because a Big-M was sized near the solver's numerical precision limit (M > 10^9).
+- **First question:** "What tolerance is the solver using, and how does it compare to the magnitude of the largest Big-M in the model?"
+- **Data to pull:** solver tolerance settings and the magnitude of every Big-M constant in the formulation.
+
+### Objective value swings more than 3% between reruns on identical input
+- **Usually means:** a non-deterministic parallel search or tie-breaking on a near-degenerate optimum being reported as if one run were canonical.
+- **First question:** "Is the random seed and thread count fixed, and if not, how many of these 'optimal' solutions are actually ties?"
+- **Data to pull:** solver run logs across at least 3 reruns with the same input, plus seed/thread configuration.
+
+### A single monolithic model covering an entire multi-stage process (allocation + timing + recovery) that has never converged in test runs
+- **Usually means:** the problem naturally decomposes into subproblems with thin linkage, and forcing one model to solve all of it at once is why it's intractable.
+- **First question:** "Do these subproblems share more than a handful of linking variables, or could each be solved separately and reconciled?"
+- **Data to pull:** the constraint matrix's block structure (which constraints touch which variable groups) and node-count history on the joint model.
+
+### Safety-stock or staffing target quoted as a fixed number (e.g., "95% service level" or "MAPE under 15%") with no stated cost-of-error or volatility behind it
+- **Usually means:** the number was copied from a different SKU family, a prior project, or a textbook default rather than sized against this problem's stockout consequence.
+- **First question:** "What is the stockout or forecast-error consequence here, and is it life-safety/contractual or a discretionary late shipment?"
+- **Data to pull:** 12+ months of stockout/forecast-error event history with per-event cost, and the demand or lead-time volatility (σ) used in the calculation.
+
+### Utilization reported as a single average (e.g., "we're at 82% busy") used to justify no staffing change
+- **Usually means:** the average is masking a convex wait-time relationship that has already started compounding — utilization above roughly 85–90% degrades wait times sharply, not linearly.
+- **First question:** "What does the queueing or simulation model say about wait time at this utilization, not just the average itself?"
+- **Data to pull:** arrival-rate distribution and the queueing/simulation model's wait-time output at the reported utilization.
+
+### A recommendation memo that states the optimized answer with no naive-baseline comparison
+- **Usually means:** the sponsor has no legible reference point to judge the size of the improvement, which stalls adoption regardless of the model's quality.
+- **First question:** "What would the current manual approach have produced on this same instance, in the same units?"
+- **Data to pull:** the manual/status-quo policy's output on the identical scenario, expressed in the sponsor's units (cost, service level, headcount).
+
+### A production model with no revalidation date on the calendar
+- **Usually means:** the model was fit once at launch and nobody owns checking whether the world it assumed still holds; degradation is silent until the recommendation quietly stops matching reality.
+- **First question:** "When is this model scheduled to be revalidated against current data, and who owns that trigger?"
+- **Data to pull:** the model's original fitting-period data and the most recent 3 months of actuals, compared side by side.
+
+### Every disruption, regardless of scale, triggers a full from-scratch re-solve (or, inversely, every disruption gets patched by hand)
+- **Usually means:** there's no tiered recovery runbook — recovery approach is being chosen by habit or panic rather than by the disruption's actual scale (% of affected units, safety criticality).
+- **First question:** "What percentage of the schedule does this disruption affect, and does that cross the threshold where a full re-solve is actually warranted?"
+- **Data to pull:** the disruption's affected-unit count as a percentage of the total, and the recovery-tier runbook (if one exists).
+
+### A forecast or model result reported without a sensitivity/what-if attached
+- **Usually means:** the analyst treated the point estimate as the deliverable and skipped the "what if this assumption moves" question the sponsor will ask next, costing credibility in the room.
+- **First question:** "Which single assumption is this recommendation most sensitive to, and what happens if it moves 10%?"
+- **Data to pull:** a one-way sensitivity table on the top 2-3 input parameters against the recommended decision.

--- a/roles/operations-research-analyst/references/vocabulary.md
+++ b/roles/operations-research-analyst/references/vocabulary.md
@@ -1,0 +1,74 @@
+# Vocabulary
+
+Terms of art an operations research analyst uses precisely, that generalists routinely
+misuse — usually by borrowing the word's everyday meaning instead of its technical one.
+
+- **Optimal**
+  Definition: the provably best solution *given the constraints and objective as modeled* — not the best solution to the real-world problem.
+  In use: "The routing model returns the optimal solution for this cost function, but it doesn't yet penalize driver overtime."
+  Misuse: treating "optimal" as a synonym for "correct" or "good," when a model can be mathematically optimal against a wrong or incomplete formulation. An optimal answer to the wrong problem is still the wrong answer.
+
+- **Feasible**
+  Definition: a solution that satisfies every stated constraint, independent of whether it is any good.
+  In use: "The schedule is feasible — it meets every crew-rest rule — but it's not close to the cost-minimizing one."
+  Misuse: using "feasible" to mean "acceptable" or "reasonable." A feasible solution can still be wildly expensive; feasibility is a floor, not an endorsement.
+
+- **Significant**
+  Definition: outside the range explainable by random noise at a stated confidence level — a statistical claim with a threshold attached.
+  In use: "The demand lift is significant at p < 0.05 against the holdout period."
+  Misuse: using it as a synonym for "large" or "important." A tiny, practically meaningless effect can be statistically significant with enough data, and a large, real effect can fail to reach significance with too little.
+
+- **Robust**
+  Definition: a solution or model whose performance degrades gracefully as inputs move away from their assumed values — the opposite of a solution that is optimal at one point and collapses elsewhere.
+  In use: "We chose the robust staffing plan, which costs 3% more at the base case but doesn't fall apart if arrivals spike 20%."
+  Misuse: using "robust" as vague praise for "well-built" or "thorough." Technically it means a specific, checkable property (bounded performance loss under specified parameter variation), not general solidity.
+
+- **Sensitivity analysis**
+  Definition: a systematic check of how the optimal solution and objective value change as specific input parameters vary within a defined range — not a one-off "what if we tried a different number."
+  In use: "The sensitivity analysis shows the plan stays optimal for lead times between 2.5 and 3.5 weeks, but the basis changes outside that band."
+  Misuse: treating a single alternate-scenario rerun as sensitivity analysis. Real sensitivity analysis reports the range over which a conclusion holds, not just a second data point.
+
+- **Big-M**
+  Definition: a large constant used in a mixed-integer formulation to "switch off" a constraint when a binary variable is 0 — its correctness and solver performance both depend on it being sized from the problem's actual bounds, not chosen arbitrarily.
+  In use: "We resized Big-M from the tightest valid bound in this instance's data, which cut branch-and-bound nodes by an order of magnitude."
+  Misuse: picking an arbitrarily huge Big-M "to be safe." An oversized M loosens the LP relaxation, slows the solver, and at extreme magnitudes can produce a spuriously feasible or wrong answer from floating-point rounding — the opposite of safe.
+
+- **Degenerate (solution/basis)**
+  Definition: a basic feasible solution in which one or more basic variables equal zero, which can cause the simplex method to cycle or stall without technique-specific safeguards.
+  In use: "The solver kept re-visiting the same objective value — that's a degenerate basis, not a bug in the model."
+  Misuse: using "degenerate" loosely to mean "broken" or "bad." It's a specific structural property of a solution that has known causes and known fixes (e.g., Bland's rule), not a general insult.
+
+- **Optimality gap**
+  Definition: the certified percentage difference between the best solution found so far and a proven lower (for minimization) or upper (for maximization) bound on the true optimum — the number that tells you how far from provably optimal a solver's current answer is.
+  In use: "We stopped the solver at a 0.8% optimality gap after four hours because further runtime bought negligible improvement."
+  Misuse: quoting only the objective value and omitting the gap, which lets a merely "pretty good" answer masquerade as optimal. Without the gap, "the solver found X" is meaningless — X could be 1% or 40% off true optimum.
+
+- **NP-hard**
+  Definition: a formal complexity classification meaning no algorithm is known that solves every instance of the problem in polynomial time — not a claim that a specific instance is unsolvable or even hard in practice.
+  In use: "Vehicle routing is NP-hard in general, but this instance's structure lets a good heuristic get within 2% of optimal in seconds."
+  Misuse: using "NP-hard" to mean "impossible" or as an excuse to skip modeling effort. Most NP-hard problems encountered in practice are solved to a useful gap routinely — the classification describes worst-case scaling, not this Tuesday's instance.
+
+- **Heuristic**
+  Definition: a method that produces a good, fast solution with no guarantee of optimality (and often no bound on how far from optimal it can be), used when an exact method is too slow for the time budget.
+  In use: "We use a greedy-insertion heuristic for the daily reroute since a same-day clock doesn't allow for an exact solve."
+  Misuse: treating "heuristic" as a lesser or embarrassing fallback rather than a deliberate, often correct engineering choice — and conversely, presenting a heuristic's output with the same confidence as a solver's certified-optimal one without saying so.
+
+- **Stochastic**
+  Definition: involving genuine randomness in the model itself (demand, arrivals, service times drawn from a distribution) — distinct from a deterministic model merely being "uncertain" because its inputs were guessed.
+  In use: "We moved from a deterministic EOQ model to a stochastic one because lead time itself varies, not just the point forecast of it."
+  Misuse: calling any model with imprecise inputs "stochastic." A model with a single best-guess input is still deterministic; stochastic modeling means the variability is represented explicitly (a distribution), not just acknowledged in prose.
+
+- **Service level**
+  Definition: a specific, quantified target — most commonly cycle service level (probability of not stocking out in a replenishment cycle) or fill rate (fraction of demand met from stock) — that must be stated with which definition is meant, since the two produce different safety-stock numbers for the same target percentage.
+  In use: "Confirm whether the 95% target is cycle service level or fill rate before I size safety stock — they're not interchangeable."
+  Misuse: quoting a service-level percentage without specifying which metric, or treating a single company-wide number as universally correct rather than something to be set from the specific stockout-cost asymmetry of the SKU in question.
+
+- **Utilization**
+  Definition: the fraction of available capacity actually in use (ρ), meaningful only in the context of the queueing relationship it drives — wait time and queue length are convex, not linear, functions of ρ, and the system is only stable at all when ρ < 1.
+  In use: "Utilization is at 82%, which on this arrival-variability profile already means wait times are past the knee of the curve."
+  Misuse: reading utilization as a linear health indicator ("we're fine, we're under 100%"), missing that the wait-time cost of the last few points of utilization is far larger than the cost of the first few.
+
+- **Decomposition**
+  Definition: splitting one intractable joint optimization problem into multiple coupled subproblems that are each solved with a fitted method and reconciled, rather than solved as one monolithic model.
+  In use: "Yield management here decomposes into overbooking, discount allocation, and traffic management — each solved separately, the way DINAMO did it."
+  Misuse: assuming any problem with multiple components should be decomposed by default, or conversely never checking for a natural decomposition and stalling on a monolithic model that was never going to solve in time.


### PR DESCRIPTION
## Rubric score
18/18

## Resolution rationale
Read all three candidates' full SKILL.md. Operations Research Analyst (O*NET 15-2031.00) is a mathematical-modeling discipline — formulating and solving optimization problems (LP/IP), building simulation and queuing models, decision-tree/sensitivity analysis under uncertainty, and validating model assumptions against real-world constraints. None of the candidates' Decision frameworks, Tools & methods, or worked examples cover this: logistics-analyst's core is domain-specific total-landed-cost and mode-breakeven arithmetic for freight/carrier decisions (no optimization modeling, no simulation, no formal decision analysis); project-management-specialist's core is EVM/schedule mechanics (CPI/SPI, float, RAID) for a single project's execution tracking, not building or validating a mathematical model; clinical-research-coordinator is unrelated (clinical trial operations/compliance). A practitioner tasked with e.g. building a linear-programming production-allocation model, running a Monte Carlo simulation for capacity planning, or doing a formal decision-tree analysis under uncertainty would get no usable guidance — or actively wrong tool guidance (freight-audit checklists, EVM formulas) — from any of the three. No reasonable parent exists among them since the failure isn't 'less depth' but a genuinely different toolkit (mathematical/statistical optimization vs. domain-specific cost arithmetic or project-control mechanics). Existing roles/ directory has no OR-analyst-adjacent quantitative-modeling role (checked: financial-quantitative-analyst is finance-specific, data-scientist is ML/analytics-specific), confirming this needs a new top-level (parent) role. Proposed slug 'operations-research-analyst' matches existing kebab-case, O*NET-title-derived naming convention used throughout roles/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new top-level `operations-research-analyst` role (O*NET 15-2031.00) with spec-2 guidance on LP/MIP optimization, simulation, queueing, and decision analysis. Updates counts and the O*NET checklist and links the role in Computer & Mathematical.

- **New Features**
  - Added `roles/operations-research-analyst/SKILL.md` with core principles, heuristics, decision framework, tools, failure modes, and a worked example.
  - Added references: `references/playbook.md`, `references/red-flags.md`, `references/vocabulary.md`.
  - Registered the role in `data/roles.json` (category: operations; spec: 2; O*NET: 15-2031.00).
  - Updated `README.md` and `ROADMAP.md`: roles 162 → 163, O*NET-mapped 152 → 153, spec-2 120 → 121, operations 58 → 59, O*NET coverage 15.0% → 15.1%, progress 153/1016, Computer & Mathematical 23/38 → 24/38, and marked 15-2031.00 as drafted with link.

<sup>Written for commit 9532b6b6c567f9a4be621f8bd32a848ac4370fa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

