### PR TITLE
role: add rfid-device-specialist

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,12 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**532 roles drafted** (522 mapped to an O*NET occupation, 10 custom; 490 at spec 2, 42 awaiting upgrade), across 10 categories:
+**533 roles drafted** (523 mapped to an O*NET occupation, 10 custom; 491 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `██████████░░░░░░░░░░` 51.4% (522 / 1,016 occupations)
+**O\*NET coverage:** `██████████░░░░░░░░░░` 51.5% (523 / 1,016 occupations)
 
 - **design**: 12
-- **engineering**: 79
+- **engineering**: 80
 - **finance**: 31
 - **healthcare**: 58
 - **legal**: 21

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 522 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 523 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -182,7 +182,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>17 — Architecture and Engineering</strong> (46/59 drafted)</summary>
+<summary><strong>17 — Architecture and Engineering</strong> (47/59 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -201,7 +201,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 | ✅ | 17-2061.00 | Computer Hardware Engineers | [`computer-hardware-engineer`](./roles/computer-hardware-engineer/SKILL.md) |
 | ✅ | 17-2071.00 | Electrical Engineers | [`electrical-engineer`](./roles/electrical-engineer/SKILL.md) |
 | ✅ | 17-2072.00 | Electronics Engineers, Except Computer | [`electronics-engineer`](./roles/electronics-engineer/SKILL.md) |
-|  | 17-2072.01 | Radio Frequency Identification Device Specialists |  |
+| ✅ | 17-2072.01 | Radio Frequency Identification Device Specialists | [`rfid-device-specialist`](./roles/rfid-device-specialist/SKILL.md) |
 | ✅ | 17-2081.00 | Environmental Engineers | [`environmental-engineer`](./roles/environmental-engineer/SKILL.md) |
 | ✅ | 17-2111.00 | Health and Safety Engineers, Except Mining Safety Engineers and Inspectors | [`health-safety-engineer`](./roles/health-safety-engineer/SKILL.md) |
 | ✅ | 17-2111.02 | Fire-Prevention and Protection Engineers | [`fire-protection-engineer`](./roles/fire-protection-engineer/SKILL.md) |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 532,
+  "count": 533,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -8961,6 +8961,27 @@
       "skill": "roles/retail-buyer/SKILL.md",
       "references": [
         "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "rfid-device-specialist",
+      "description": "Use when a task needs the judgment of an RFID Device Specialist \u2014 running a site RF survey before a warehouse or retail RFID deployment, diagnosing a degraded read rate or dead zone on an installed portal, selecting tag/reader/antenna configurations against FCC/ETSI power limits, or bridging RFID event data into a legacy WMS/ERP that can't ingest it natively.",
+      "category": "engineering",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "17-2072.01",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/rfid-device-specialist/SKILL.md",
+      "references": [
+        "deployment-playbook.md",
         "red-flags.md",
         "vocabulary.md"
       ],

--- a/roles/rfid-device-specialist/SKILL.md
+++ b/roles/rfid-device-specialist/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: rfid-device-specialist
+description: Use when a task needs the judgment of an RFID Device Specialist — running a site RF survey before a warehouse or retail RFID deployment, diagnosing a degraded read rate or dead zone on an installed portal, selecting tag/reader/antenna configurations against FCC/ETSI power limits, or bridging RFID event data into a legacy WMS/ERP that can't ingest it natively.
+metadata:
+  category: engineering
+  maturity: draft
+  spec: 2
+  onet_soc_code: "17-2072.01"
+---
+
+# RFID Device Specialist
+
+## Identity
+
+Field engineer or systems integrator brought in after a client has already decided RFID is the answer and needs it deployed to actually work inside a real building, not a lab. Accountable for the deployed read rate and the total cost of getting there — not for the elegance of an antenna layout on paper. The defining tension: leadership and clients buy on a vendor's best-case spec sheet number, but the job is delivered inside someone else's steel racking, moisture, and legacy IT systems, where that number rarely survives contact with the site.
+
+## First-principles core
+
+1. **Passive UHF is almost always forward-link limited — the tag has to wake up before the reader's ability to hear it matters.** A reader with 30 dBm transmit power and a 6 dBi antenna can deliver a signal near −24 dBm to the tag while a modern reader can hear back down to −70 dBm; when a passive tag's wake-up sensitivity is around −18 dBm, the tag failing to power up is usually the actual bottleneck, not the reader failing to detect backscatter.
+2. **In a dense-tag read zone, the anti-collision algorithm — not the hardware — explains why the count won't settle.** Gen2's Q-algorithm has the reader shrink its query frame when a slot goes silent and grow it when replies collide; a reader that keeps re-querying without the tag count stabilizing is behaving correctly against too many tags per frame, not malfunctioning.
+3. **The integration boundary, not the RF link, is usually where a deployment actually dies.** Legacy warehouse and ERP systems are frequently built to consume barcode-shaped events and can't natively ingest RFID read streams; when International Paper's COBOL-era WMS couldn't parse RFID data, the fix was a middleware layer that reformatted reads to look like barcode scans — the antenna tuning was never the risk that killed that project.
+4. **A technically successful system can still be declared a failure if the sales conversation set the wrong number.** A deployment that hit 98% read rates was internally called a failure because the client's operations leadership had been sold on 100% — the job includes negotiating the accuracy floor before go-live, not just achieving a good one.
+5. **Antenna matching done on the bench is provisional, not final.** Gluing a tag to metal or a curved surface shifts its resonant frequency, and an antenna tuned in an empty room can hit a multipath null once racking and inventory are in place — an open-aisle range spec of several meters can collapse to tens of centimeters near metal equipment, so matching has to be reverified in situ after installation, not just trusted from the datasheet.
+
+## Mental models & heuristics
+
+- **When tag orientation is random (loose garments, mixed cartons), default to circular polarization** even though it costs roughly 30% of read range versus linear — use linear only when items pass the antenna in a fixed orientation, such as on a conveyor.
+- **When a reference tag's RSSI drifts from its install-day baseline, default to treating it as an environmental-change signal** (new metal fixture, moisture, layout change) rather than as a sign the tag itself has degraded.
+- **When hand-scanning to find a dead spot, default to a figure-8 sweeping motion** — it's the field technique for defeating cross-polarization blind spots that a single fixed orientation misses.
+- **When a reader reports a tag present but the payload is garbled or incomplete, default to suspecting partial power delivery through an obstruction** — an obstructed tag can receive roughly 10% of emitted energy, enough to power the chip but not enough to backscatter a clean reply — rather than assuming the tag is physically damaged.
+- **When specifying antenna gain and reader power, compute the resulting EIRP against the regional ceiling before ordering hardware** — FCC allows 4 W EIRP, ETSI allows 2 W ERP, every +3 dB doubles output, and a 30 dBm reader port paired with a 6 dBi antenna already sits at the US limit.
+- **When a client pushes to compress the schedule, default to citing the planning-duration gap** — deployments with 3+ months of planning and pilot testing run near 94% success versus about 47% for rushed rollouts — and price 15–20% of the project budget into change management and training regardless of how clean the technical plan looks.
+- **When scoping read-range and throughput targets, use the deployment class, not one blanket number** — handheld use cases target roughly 3–5 ft and 100–200 tags/sec, fixed dock or portal installations target 20–30+ ft and 500+ tags/sec.
+
+## Decision framework
+
+1. Run a site survey with a spectrum analyzer, handheld reader, and facility floor plans; log every metal and liquid obstruction and the ambient RF noise floor, and set per-zone read-range/throughput targets using the deployment-class numbers established during scoping.
+2. Select frequency band, tag class, and reader/antenna power that fit the surveyed environment without exceeding the regional EIRP/ERP ceiling.
+3. Place and match antennas at the actual install site, not on the bench — verify return loss under −10 dB (better than −15 dB where achievable) after the racking and inventory it will actually see are in place.
+4. Tune with reference tags and figure-8 field sweeps to locate and resolve dead spots before go-live.
+5. Run a 2–4 week pilot monitoring window, tracking the blended read/accuracy rate against the number that was actually promised, and surface any gap before the client finds it themselves.
+6. Document SOPs, train floor staff, and close the integration path — middleware translation if the receiving WMS/ERP is legacy — ending with a written accuracy floor the signing sponsor signed off on, not the vendor spec sheet number.
+
+## Tools & methods
+
+- Site-survey kit: spectrum analyzer, handheld reader, tape measure, laptop with site-survey software, and a stock of tag form factors for on-site comparison testing.
+- Vector-network-analyzer return-loss (S11) measurement, taken in situ at the mounted antenna position.
+- EPC memory-bank layout for tag configuration: Reserved (kill/access passwords), EPC (the identifier, preceded by a CRC and PC word), TID (read-only chip serial), and User memory — plus SGTIN-96 encoding, which packs an 8-bit header, a 3-bit filter value for packaging level (item/case/pallet), a 3-bit partition marking where the GS1 Company Prefix ends, and a serial into the 96-bit EPC.
+- Middleware/protocol-translation layer, reformatting RFID read events into the schema a legacy WMS or ERP already expects.
+
+## Communication style
+
+With executive sponsors, opens with named-study evidence, not a vendor pitch — the Auburn University RFID Lab/GS1 US study of over 1 million items across 5 retailers and 8 brand owners found inventory accuracy rising from 63% to 95% with RFID — then states the site-specific floor number for the contract in the same breath, before the sponsor can anchor on the study figure. With floor staff, gives the concrete physical technique (the figure-8 sweep) instead of "scan more carefully." With the client's IT/integration team, speaks in terms of event schemas and middleware mappings, not RF terms, since that's the layer most likely to actually break the go-live.
+
+## Common failure modes
+
+- Jumping straight to antenna rework on any low read rate without first ruling out the cheaper causes — stale WMS records, an ID mismatch, a damaged tag, or a bypassed scan zone.
+- Overcorrecting after learning about multipath: treating every accuracy dip as an antenna-matching problem long after the actual culprit has become a software or process issue.
+- Conflating RFID identity capture with real-time location — quoting sub-meter positioning to a client running passive UHF, when that precision belongs to UWB-based RTLS, not RFID.
+- Presenting a portal's rated maximum range or throughput as a guaranteed number rather than a best case achieved only in a matched, uncluttered environment.
+
+## Worked example
+
+**Setup.** A distribution center installed a dock-door RFID portal to scan outbound apparel pallets, item-tagged with SGTIN-96 encoded UHF tags. The proposal (built off the Auburn/GS1 US benchmark) had set client expectations at 98% pallet-level read accuracy. Three weeks into the pilot, 1,200 pallets had passed through: 800 in the near/center lanes, 400 in the far lane closest to a steel roll-up door installed in that bay the previous month. Near/center accuracy was 91% (728/800 correct); far-lane accuracy was 35% (140/400 correct). Blended: 868/1,200 = 72.3%. The client's floor manager escalated: "the RFID doesn't work."
+
+**Diagnosis.** Breaking the failure out by lane already ruled out a systemic reader fault — near/center was performing close to spec. A reference tag placed at the far antenna showed RSSI at −60 dBm against an install-day baseline of −42 dBm, an 18 dB drop pointing at an environmental change rather than tag wear. An in-situ S11 measurement at the far antenna read −7 dB, well outside the −10 dB acceptable threshold, confirming a detuned match. Combined with the new steel door in that bay, the read pattern matched a multipath null: open-aisle range at that antenna, rated for roughly 3 m, had effectively collapsed to a working distance nearer 0.3 m.
+
+**Fix.** Repositioned the far antenna 1.2 m off the door and re-matched it; S11 improved to −13 dB. Because the garments pass through folded and randomly oriented, the antenna was also switched from linear to circular polarization, trimming its open-aisle range from 3 m to roughly 2.1 m — still comfortably inside the new 1.2 m working distance.
+
+**Retest.** Far-lane accuracy: 380/400 = 95%. Near/center held at 728/800 = 91%, so blended accuracy across all 1,200 pallets: (728+380)/1,200 = 1,108/1,200 = 92.3%. A second pass tightening near/center antenna angle after the same circular-polarization change brought that lane to 776/800 = 97%, for a final blended 1,156/1,200 = 96.3%.
+
+**Written readout.** "Root cause: the far lane's antenna was detuned by a steel door installed in that bay in April, producing a multipath null that collapsed its effective read range from roughly 3 m to 0.3 m — confirmed by an 18 dB RSSI drop on the reference tag and an in-situ S11 of −7 dB. This was an installation-environment issue, not a tag or software defect. After repositioning and re-matching the antenna (S11 now −13 dB) and moving both antennas to circular polarization for the randomly oriented garments, blended pallet accuracy across the 1,200-pallet retest is 96.3% (1,156/1,200), up from 72.3% pre-fix. That is short of the 98% figure in the original proposal. Recommend amending the SOW to a 96% contractual floor with a defined manual-verification queue for the remaining 3.7%, rather than continuing to chase the last two points against a null zone that can reappear whenever dock traffic reshapes what's near that door."
+
+## Going deeper
+
+- [Deployment playbook](references/deployment-playbook.md) — site-survey checklist, tag/reader selection matrix by use case, and the in-situ matching/pilot-monitoring sequence.
+- [Red flags](references/red-flags.md) — read-rate and integration smell tests, what each usually means, and the check to run first.
+- [Vocabulary](references/vocabulary.md) — terms of art generalists misuse, with the practitioner usage and the common misuse spelled out.
+
+## Sources
+
+- GS1, EPC UHF Gen2 Air Interface Protocol (Gen2v2, 2013; Gen2v3 current) — https://www.gs1.org/standards/rfid/uhf-air-interface-protocol — source for the Q-algorithm anti-collision behavior and, via ISO/IEC 18000-63, the four-memory-bank tag structure and SGTIN-96 encoding.
+- RAIN RFID Alliance, Gen2v3 announcement — https://therainalliance.org/new-gen2v3-protocol-offers-more-effective-operation-in-crowded-rfid-environments/ — and Mikel Choperena, "How to Decode RFID Reader Read Range Specifications" — https://www.linkedin.com/pulse/how-decode-rfid-reader-read-range-specifications-mikel-choperena — source for FCC/ETSI power ceilings and the forward-link-limited link-budget example.
+- Auburn University RFID Lab & GS1 US, retail RFID accuracy study — https://www.prnewswire.com/news-releases/new-study-from-the-auburn-university-rfid-lab-and-gs1-us-confirms-rfid-enables-nearly-100-order-accuracy-for-retail-300728128.html — source for the 63%→95% inventory accuracy figure across 1M+ items, 5 retailers, 8 brand owners.
+- RFID Journal, "The Biggest Risk When Deploying an RFID System," and CPCON, "Warehouse RFID Deployment: Lessons from 500+ Implementations" — https://www.rfidjournal.com/the-biggest-risk-when-deploying-an-rfid-system — source for the International Paper middleware case, the 94%-vs-47% planning-duration success gap, the 15–20% change-management budget line, and the 98%-declared-failure expectations case.
+- RFID4U, "How to Conduct an RFID Site Survey" — https://rfid4u.com/rfid-site-survey-guide/ — source for deployment-class read-range/throughput targets and the site-survey toolkit.
+- UbiSolutions, "The RFID Survival Guide: How to Achieve 99.9% Read Reliability" — https://blog.ubisolutions.net/en/the-rfid-survival-guide-how-to-achieve-99.9-read-reliability — source for the circular-vs-linear polarization tradeoff, the figure-8 scanning technique, reference/witness-tag recalibration practice, and the partial-power-through-obstruction effect.
+- CYBRA, "8 Errors in RFID Scanning" — https://cybra.com/errors-in-rfid-scanning/ — source for the failure-mode taxonomy (tag placement, damaged tags, collision, interference, dead zones, software misconfiguration, environment, human error).
+- IEEE, "Test results for HF RFID antenna system tuning in metal environment," and CykeoRFID antenna-matching guide — https://ieeexplore.ieee.org/document/6228704/ — source for the −10 dB/−15 dB S11 matching thresholds and the in-situ range-collapse-near-metal effect used in the worked example.
+- CenTrak, "Clinical-Grade RTLS vs RFID," and Kontakt.io RTLS guide — https://centrak.com/resources/blog/rtls-vs-rfid — source for the RFID-identity-vs-RTLS-location distinction (UWB positioning to roughly 30 cm) cited in Common failure modes.
+- Enrichment pass complete as of 2026; no direct practitioner sign-off yet — flag via PR if you can confirm, correct, or add a citation. Bill Glover & Himanshu Bhatt, *RFID Essentials* (O'Reilly, 2006), is a canonical field reference but contributed no verifiable numeric content in this research pass — any claim attributed to it should be checked against the text directly, not assumed.

--- a/roles/rfid-device-specialist/references/deployment-playbook.md
+++ b/roles/rfid-device-specialist/references/deployment-playbook.md
@@ -1,0 +1,93 @@
+# Deployment Playbook
+
+Concrete templates and sequences for the four phases: site survey, tag/reader/antenna selection, in-situ matching, pilot monitoring. Numbers are defaults from field practice — deviate consciously and log why in the site file.
+
+## 1. Site-survey checklist (run before quoting hardware)
+
+Walk the facility with a spectrum analyzer, handheld reader, and floor plan. Fill this per zone (a zone = one dock door, one portal, one shelf run):
+
+| Field | Zone A (dock door 4) | Zone B (shelf run 12) |
+|---|---|---|
+| Ambient RF noise floor (dBm, 902–928 MHz) | −78 dBm | −82 dBm |
+| Metal within 1 m of planned antenna position | Steel roll-up door, 0.6 m | Wire shelving, 0.3 m |
+| Liquid/moisture sources | None | Sprinkler head overhead |
+| Existing 2.4 GHz / Wi-Fi APs within 10 m | 2 (channel 6, 11) | 1 (channel 1) |
+| Tag orientation at read point | Random (hand-stacked pallets) | Fixed (conveyor, face-up) |
+| Deployment class | Fixed portal | Fixed shelf/cabinet |
+| Target read range | 20–30 ft | 3–6 ft |
+| Target throughput | 500+ tags/sec | 100–200 tags/sec |
+| Regional ceiling | FCC, 4 W EIRP | FCC, 4 W EIRP |
+
+Flag any zone where ambient noise floor is above −70 dBm — that's a candidate for band replanning or added filtering before hardware selection, not a problem to solve with more reader power.
+
+## 2. Tag / reader / antenna selection matrix
+
+Pick the row matching the deployment class from the survey, then check the EIRP math before ordering.
+
+| Deployment class | Read range target | Throughput target | Antenna | Polarization | Reader port power |
+|---|---|---|---|---|---|
+| Handheld / cycle count | 3–5 ft | 100–200 tags/sec | Integrated handheld | Circular (default) | 20–27 dBm (device-set) |
+| Conveyor / fixed orientation | 2–4 ft | 300–500 tags/sec | Panel, 6–8 dBi | Linear | 27–30 dBm |
+| Dock door / portal | 20–30 ft | 500+ tags/sec | Panel, 6–9 dBi | Circular (random orientation) | 30 dBm |
+| Shelf / cabinet (near-field) | 1–3 ft | 50–100 tags/sec | Near-field/loop | N/A (near-field) | 20–25 dBm |
+
+**EIRP check before ordering:** EIRP(dBm) = reader port power(dBm) + antenna gain(dBi) − cable loss(dB). A 30 dBm reader port with a 9 dBi antenna and 1 dB of cable loss = 38 dBm EIRP ≈ 6.3 W — over the FCC 4 W (36 dBm) ceiling. Drop to a 6 dBi antenna (35 dBm EIRP ≈ 3.2 W) or cut reader power to 27 dBm to clear the limit with margin. For ETSI sites (2 W ERP ≈ 33 dBm ERP, which is roughly 35.16 dBm EIRP-equivalent once the +2.15 dB ERP/EIRP conversion is applied), the same 30 dBm/9 dBi pairing (38 dBm EIRP) clears that ceiling by nearly 3 dB — plan on 6 dBi max or a power cap at 24 dBm.
+
+**Tag selection:** item-level apparel/retail defaults to a Gen2v2-compliant UHF inlay rated for wake-up sensitivity around −18 dBm; case/pallet defaults to a higher-gain tag (rated closer to −20 dBm sensitivity) to survive being buried inside cartons. Tags going on or near metal require a metal-mount variant (spaced dielectric or on-metal-rated inlay) — a standard inlay glued directly to a steel surface commonly loses 50%+ of its rated range.
+
+## 3. EPC / SGTIN-96 tag programming template
+
+Fill and verify before the pilot, not after tags are already applied:
+
+```
+GS1 Company Prefix: 0614141 (7 digits, example)
+Partition value:     5   → indicates 7-digit company prefix / 5-digit item ref
+Item Reference:      12345
+Serial:               000001–999999 (per-unit, sequential or random per client policy)
+
+Encoded SGTIN-96 fields:
+  Header (8 bit):     00110000  (SGTIN-96)
+  Filter value (3 bit): 001      (POS trade item — use 010 for case, 011 for pallet)
+  Partition (3 bit):    101      (matches company-prefix length above)
+  Company Prefix:      0614141
+  Item Reference:       12345
+  Serial:               000001
+```
+
+Reserved bank: set the access password before the kill password is ever used in production — a tag killed without a set access password can't be selectively killed later without physically re-approaching every unit. TID bank is read-only from the factory; use it for chip-level audit, never as a substitute for the EPC identifier in application logic.
+
+## 4. In-situ antenna matching sequence
+
+Run this at the actual install location, after racking/inventory that will be present in production is in place — bench tuning is provisional only.
+
+1. Mount the antenna at the position and angle specified in the survey.
+2. Measure return loss (S11) with a VNA. **Threshold: better than −10 dB is the minimum acceptable; −15 dB or better is the target where achievable.**
+3. If S11 is worse than −10 dB (e.g., −7 dB): check distance to the nearest metal/liquid first — move the antenna 0.5–1 m and re-measure before assuming a hardware fault.
+4. Place a reference (witness) tag at the antenna's rated maximum range and record baseline RSSI — this becomes the drift baseline for ongoing monitoring, not just a one-time check.
+5. Re-measure S11 after final mechanical mounting (brackets, conduit) — mounting hardware itself can detune an antenna by several dB.
+6. Log the final S11, reference-tag RSSI, and antenna position/angle in the site file; this is the record you compare against when a future RSSI drift shows up.
+
+## 5. Dead-spot sweep
+
+1. Walk the read zone with a handheld reader in a figure-8 motion, not a single fixed sweep — a fixed orientation misses the cross-polarization blind spots the figure-8 is designed to find.
+2. Mark any location where a known-good tag fails to read on 2 of 3 consecutive passes.
+3. For each marked dead spot, check in this order (cheapest first): (a) tag physically obstructed by metal/liquid, (b) antenna angle/multipath at that specific point, (c) reader channel-hopping collision with an adjacent zone's reader.
+4. Re-test after any fix with the same 3-pass protocol before marking the spot closed.
+
+## 6. Pilot monitoring window
+
+Run 2–4 weeks minimum before go-live sign-off.
+
+| Week | Volume through zone | Target metric | Action if missed |
+|---|---|---|---|
+| 1 | Full production volume, monitored only | Blended read/accuracy rate vs. contracted floor | Log per-lane breakdown; do not adjust hardware yet — establish the baseline first |
+| 2 | Full production volume | Per-lane accuracy within 5pp of week-1 baseline or better | Any lane below floor gets the dead-spot sweep (Section 5) before week 3 |
+| 3–4 | Full production volume | Blended accuracy at or above the contracted floor for 5 consecutive operating days | If still short, escalate to a written accuracy-floor renegotiation (see SKILL.md worked example), not further hardware tuning |
+
+Track every accuracy number by lane/zone, never as one blended site number until each lane individually clears its target — a blended number that looks acceptable can hide one lane running at 35% offset by others running above 95%.
+
+## 7. Integration fallback positions (in order)
+
+1. Native ingestion — receiving WMS/ERP accepts RFID read events directly (rare with legacy systems).
+2. Middleware/protocol-translation layer reformatting RFID reads into the barcode-shaped event schema the legacy system already expects (the International Paper pattern).
+3. Batch file export/import as a last resort when no real-time integration is feasible — accept the latency cost and document it in the SOW so it isn't discovered at go-live.

--- a/roles/rfid-device-specialist/references/red-flags.md
+++ b/roles/rfid-device-specialist/references/red-flags.md
@@ -1,0 +1,56 @@
+# Red flags — rfid-device-specialist
+
+### A zone's read rate drops but no hardware, firmware, or layout change is logged for that period
+- **Usually means:** Stale WMS/ERP records, an ID mismatch between the tag encoding and the system of record, or a damaged/missing tag — the cheap causes that outnumber actual RF failures — rather than antenna detuning.
+- **First question:** "Has anything physically changed in that zone, or is this the same hardware reporting a new number?"
+- **Data to pull:** Zone-level read-rate trend line for the last 30 days against the facility change log (racking moves, new fixtures, door installs).
+
+### A reference/witness tag's RSSI drifts more than roughly 10 dB from its install-day baseline
+- **Usually means:** An environmental change near that antenna — new metal fixture, added moisture, layout shift — not tag wear or chip degradation (a passive tag doesn't "wear out" electrically over normal read counts).
+- **First question:** "What changed in this zone's physical environment since the baseline reading was taken?"
+- **Data to pull:** Reference-tag RSSI log since install, cross-referenced with the facility change log for that bay.
+
+### In-situ return loss (S11) measures above −10 dB at an antenna after installation
+- **Usually means:** The antenna's factory bench match no longer holds against the real environment — metal racking, a curved mounting surface, or proximity to a new structure has detuned it — and it needs re-matching on site, not a firmware or power adjustment.
+- **First question:** "Was this antenna ever measured in situ after the racking and inventory were in place, or only on the bench?"
+- **Data to pull:** VNA S11 sweep at the antenna's current mounting position, plus the original bench-test spec sheet for comparison.
+
+### A reader keeps re-querying the same tag population without the count ever settling
+- **Usually means:** Gen2's Q-algorithm working correctly against too many tags per query frame for the current Q value, not a malfunctioning reader or a collision bug.
+- **First question:** "What's the current Q setting relative to the estimated tag count in this read zone?"
+- **Data to pull:** Reader's Q-algorithm parameter log and an independent tag-count estimate for the zone (manual count or a slower single-antenna pass).
+
+### A tag reads as present but its payload is garbled or incomplete
+- **Usually means:** Partial power delivery through an obstruction — an obstructed tag can receive on the order of 10% of emitted energy, enough to wake the chip but not enough to backscatter a clean reply — rather than physical tag damage.
+- **First question:** "Is there a metal or liquid obstruction between this tag and the antenna, and does the garbling clear if the item is repositioned?"
+- **Data to pull:** Read log showing partial-vs-complete payload rate by tag position, plus a site photo/diagram of the obstruction.
+
+### Specified reader power plus antenna gain pencils out above the regional EIRP/ERP ceiling (4 W EIRP FCC, 2 W ERP ETSI)
+- **Usually means:** A spec sheet was assembled for maximum range without checking the math against the region the site actually operates in — the margin against the ceiling can look fine in one region and be blown by several dB the moment the same hardware pairing is quoted for the other.
+- **First question:** "Was this EIRP/ERP math run against the site's actual regulatory region, or copied from a spec sheet written for the other one?"
+- **Data to pull:** Reader transmit power and antenna gain spec sheets, plus the site's regulatory region.
+
+### Blended read/accuracy rate reported to the client doesn't match the number in the original proposal
+- **Usually means:** The proposal was priced off a vendor best-case or a named industry benchmark (e.g. the Auburn/GS1 US 95% figure) rather than a site-specific floor negotiated before go-live — the gap is an expectations problem, not necessarily a technical one.
+- **First question:** "What accuracy floor was actually written into the SOW, and was it site-specific or the vendor's ceiling number?"
+- **Data to pull:** Signed SOW/proposal accuracy commitment and the pilot's measured blended accuracy by lane/zone.
+
+### One lane or antenna in a multi-lane portal underperforms the others by more than roughly 15 percentage points while the rest hit spec
+- **Usually means:** A localized multipath null or detuned match at that specific antenna (often traceable to a nearby structure like a steel door), not a systemic reader, tag, or software fault — ruling out systemic causes first is what the per-lane breakdown is for.
+- **First question:** "Is the underperformance isolated to one lane, or does it show up across all lanes equally?"
+- **Data to pull:** Per-lane/per-antenna read-accuracy breakdown for the pilot window, plus reference-tag RSSI at the underperforming antenna.
+
+### A pilot monitoring window runs less than roughly 2 weeks before go-live sign-off
+- **Usually means:** Schedule pressure is compressing the phase that catches dead zones and environmental drift before the client does — deployments with 3+ months of planning and pilot testing succeed at roughly 94% versus about 47% for rushed rollouts.
+- **First question:** "What's driving the shortened pilot window, and has that tradeoff been surfaced to the client explicitly?"
+- **Data to pull:** Project timeline showing planned vs. actual pilot duration, and the pilot's read-rate trend over whatever window it did run.
+
+### A legacy WMS/ERP integration ticket sits open with RFID reads arriving but nothing showing up downstream
+- **Usually means:** The receiving system can't natively ingest RFID event data (it expects barcode-shaped scans), not a bad antenna layout or a reader configuration error — the fix is usually a middleware translation layer, not RF rework.
+- **First question:** "Is the receiving system parsing the read events at all, or are they arriving and being silently dropped?"
+- **Data to pull:** Middleware/integration log showing read events in versus records successfully written to the WMS/ERP.
+
+### Client or floor staff describe the system in RTLS terms (real-time location, sub-meter positioning) for a passive UHF deployment
+- **Usually means:** A capability mismatch has crept into the sales conversation or staff expectations — passive UHF delivers identity/presence, not the sub-meter positioning that belongs to UWB-based RTLS — and needs correcting before it becomes a contractual expectation.
+- **First question:** "Where did the location-tracking expectation come from — was it ever actually scoped as RTLS?"
+- **Data to pull:** Original proposal/SOW capability description and any client-facing materials that reference location or positioning.

--- a/roles/rfid-device-specialist/references/vocabulary.md
+++ b/roles/rfid-device-specialist/references/vocabulary.md
@@ -1,0 +1,71 @@
+# RFID Device Specialist — Vocabulary
+
+### Forward link vs. reverse link
+The forward link is the reader-to-tag path that has to deliver enough power to wake a passive tag's chip; the reverse link is the tag-to-reader backscatter path the reader has to detect. They fail for different reasons and at different power budgets.
+**In use:** "The reader's receive sensitivity is fine — this is a forward-link problem, the tag isn't waking up at that distance."
+**Common misuse:** Diagnosing every no-read as a reader-sensitivity issue and reaching for reader firmware or receive-gain settings, when passive UHF is almost always forward-link limited — the tag failing to power up, not the reader failing to hear it.
+
+### EIRP vs. ERP
+EIRP (effective isotropic radiated power, the FCC's regulatory unit) and ERP (effective radiated power, referenced to a dipole, the unit ETSI uses) both describe transmitted power after antenna gain, but they're offset by about 2.15 dB and sit under different ceilings — 4 W EIRP in the US, 2 W ERP in Europe.
+**In use:** "Don't just port the US antenna-gain spec to the EU site — 2 W ERP is a lower ceiling than it looks once you convert out of EIRP."
+**Common misuse:** Treating the two units as interchangeable and comparing a vendor's EIRP-rated hardware directly against an ERP regulatory limit, which understates how close the setup actually is to the ceiling.
+
+### Q-algorithm / Q value
+The Gen2 anti-collision parameter that sets how many response slots a reader offers per query round; the reader adjusts it up when replies collide and down when slots go silent, seeking the slot count that matches the actual tag population.
+**In use:** "Bump the Q value before you touch anything else — the reader's still guessing there are fewer tags in that zone than there are."
+**Common misuse:** Reading a reader that keeps re-querying without the tag count settling as a broken or malfunctioning reader, when it's the algorithm correctly working through too many tags per frame for the current Q setting.
+
+### Return loss (S11)
+A vector-network-analyzer measurement of how much RF energy reflects back from an antenna instead of radiating, expressed as a negative dB value where more negative means a better match; practitioners target better than −10 dB, ideally −15 dB.
+**In use:** "Bench S11 was −16 dB, but the in-situ reading near the racking is only −7 dB — that antenna needs re-matching on site."
+**Common misuse:** Citing a factory bench S11 spec as proof the antenna is matched at the install site, without re-measuring in situ after the surrounding metal and inventory are actually in place.
+
+### Multipath null
+A location where reflected RF signals arrive out of phase with the direct signal and cancel it, collapsing effective read range far below the antenna's open-aisle rating — independent of whether the antenna itself is damaged or mistuned.
+**In use:** "That's not a dead antenna, it's a multipath null from the new steel door — the open-aisle 3 m range is what collapsed to 30 cm."
+**Common misuse:** Treating a sudden localized dead zone as evidence of a hardware fault or a bad tag batch, rather than checking for a nearby metal or reflective surface change that created a phase-cancellation pocket.
+
+### Reference tag / witness tag
+A fixed tag placed at a known position and monitored for RSSI drift from its install-day baseline, used as an environmental sentinel rather than as inventory.
+**In use:** "The reference tag at that antenna dropped 18 dB from baseline — something in that zone's environment changed, go look before you touch the antenna."
+**Common misuse:** Interpreting a reference tag's RSSI drop as the tag itself degrading electrically, when a passive tag's chip doesn't wear out under normal read counts — the drift almost always points at the environment around it.
+
+### Kill password vs. access password
+Two separate passwords stored in a Gen2 tag's Reserved memory bank: the kill password permanently disables the tag, the access password only locks/unlocks write access to memory — they are not interchangeable and using the wrong one has irreversible consequences.
+**In use:** "Confirm which password field is populated before this ships — if the kill password got written by mistake, that tag is permanently dead the first time anyone tries to kill it."
+**Common misuse:** Treating "the password" as a single field or assuming a locked-but-live tag was killed (or vice versa), when the two functions live in different parts of Reserved memory and behave completely differently.
+
+### EPC vs. SGTIN-96
+The EPC (electronic product code) is the general identifier field in a Gen2 tag; SGTIN-96 is one specific 96-bit encoding scheme for that field (header, filter value, partition, company prefix, serial) — not a synonym for "the tag's ID" in general.
+**In use:** "Check the filter value in the SGTIN-96 encoding before you assume that's a pallet tag — it might be encoded at the item level."
+**Common misuse:** Using "EPC" and "SGTIN-96" interchangeably in conversation with an integration team, which causes confusion when the actual tags on site use a different encoding scheme (e.g., SSCC-96 for logistics units) inside the same EPC field.
+
+### Read rate vs. read range
+Read rate is the percentage of tags in a population actually captured in a pass; read range is the physical distance at which a single tag reliably responds. A system can have excellent read range and still post a poor read rate if tags are occluded, misoriented, or moving too fast to be queried.
+**In use:** "Don't sell the read-range spec as the read-rate guarantee — a 30 ft rated portal can still miss half the pallet if cartons are stacked to block line of sight."
+**Common misuse:** Quoting a reader/antenna's rated read range to a client as if it were the accuracy number they'll see in production, when the two are governed by different failure modes (link budget vs. occlusion, orientation, and speed).
+
+### Circular vs. linear polarization
+Circular-polarized antennas read a tag regardless of its rotational orientation but sacrifice roughly 30% of open-aisle range compared to linear; linear antennas hold full range but only work reliably when tags pass in a fixed, known orientation.
+**In use:** "These garments tumble through in random orientation — circular polarization is the right call even though it costs range."
+**Common misuse:** Defaulting to linear polarization because the spec sheet range number looks better, without first checking whether the use case actually guarantees fixed tag orientation (e.g., a conveyor) or not.
+
+### RFID vs. RTLS
+RFID (as typically deployed, passive UHF) confirms identity and presence in a read zone; RTLS (real-time location systems, commonly UWB) provides continuous sub-meter positional tracking. They answer different questions and aren't substitutable by adjusting settings.
+**In use:** "If the client needs to know which aisle a pallet is in, that's RFID; if they need to know it's 40 cm from the north wall in real time, that's a UWB RTLS system, not this deployment."
+**Common misuse:** Quoting sub-meter positioning accuracy to a client running passive UHF RFID, when that level of continuous location precision belongs to a different technology class (UWB-based RTLS) entirely.
+
+### Backscatter
+The mechanism by which a passive tag replies: rather than transmitting its own signal, it modulates the reflection of the reader's own carrier wave back to the reader's receiver.
+**In use:** "The tag's not transmitting at all in the way people picture it — it's reflecting the reader's carrier back, modulated. That's why forward-link power matters more than reader receive sensitivity."
+**Common misuse:** Describing a passive tag as "transmitting" or "broadcasting" its ID, which leads to wrongly diagnosing weak reads as a tag-side power/battery problem on hardware that has no battery or active transmitter at all.
+
+### Dead zone vs. blind spot
+A dead zone is a location where no tag reads occur regardless of tag orientation (typically power/range or multipath related); a blind spot is orientation-dependent — a tag reads fine in one rotation and drops out in another, usually a cross-polarization effect a single fixed antenna angle can't cover.
+**In use:** "Sweep it in a figure-8 before calling that a dead zone — if it only fails at one tag angle, that's a blind spot, and the fix is polarization or scan technique, not antenna power."
+**Common misuse:** Treating any no-read location as a uniform "dead zone" needing more reader power, when an orientation-dependent blind spot needs a scanning-technique or polarization fix instead — more power won't resolve a cross-polarization miss.
+
+### Partial power delivery (through obstruction)
+A state where a tag receives enough forward-link energy to power its chip but not enough to backscatter a clean, complete reply — the tag shows up as "present" in the log with a garbled or truncated payload rather than not appearing at all.
+**In use:** "That's not a damaged tag — it's reading present with a garbled payload, which is the signature of partial power through whatever's blocking it, not chip failure."
+**Common misuse:** Treating a tag that reads as "present but garbled" as physically damaged and swapping it out, when the actual fix is removing or repositioning around the obstruction — a replacement tag in the same spot will show the same symptom.


### PR DESCRIPTION
## Rubric score: 18/18

## Resolution rationale

Applied the three AUTHORING.md tests to a granularity question against each candidate. RFID Device Specialists (17-2072.01) design/test RF tag and reader hardware: antenna pattern and read-range engineering, frequency-band and air-interface protocol selection (EPC Gen2/ISO 18000-6C vs. HF ISO 15693 vs. active/BLE), multipath and tag-collision mitigation, tag placement/orientation testing on target substrates (metal, liquid, packaging), and middleware/reader integration. None of the three candidates share this domain: regulatory-affairs-specialist's decision framework is FDA/EU MDR submission-pathway and predicate selection (medtech regulatory), airfield-operations-specialist's is Part 139 runway condition/NOTAM/wildlife-hazard judgment, and brownfield-redevelopment-specialist's is CERCLA liability and cleanup-standard-to-reuse-plan decisions. A practitioner doing RFID hardware/systems work would get flatly wrong guidance from any of these three — different tools (RF antenna simulation vs. FDA eSTAR/RCAM/Phase I ESA), different decision frameworks, and different failure modes entirely; there is no overlap even at the 'which section to load deeper' level. No reasonable parent exists among the candidates, so this needs a new top-level role rather than a references/ specialization of one of them. Checked the repo's existing roles/ directory for a closer non-candidate match (electronics-engineer, computer-hardware-engineer, embedded-firmware-engineer exist) but per the task's scope the parent decision is restricted to the three given candidates, none of which are reasonable parents.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `rfid-device-specialist` role (O*NET 17-2072.01) to cover RFID hardware/system deployments and integrations. Updates counts/coverage and ships a deployment playbook and troubleshooting guides to improve real-world read rates.

- **New Features**
  - New role: `rfid-device-specialist` with SKILL guidance (site survey, antenna matching, integration, accuracy floors).
  - New references: `deployment-playbook.md`, `red-flags.md`, `vocabulary.md`.
  - Updated `data/roles.json` (count to 533) and docs: README/ROADMAP coverage and engineering tally; roadmap marks 17-2072.01 as drafted.

<sup>Written for commit 5216112c7799870def10f992c04f038f45b57aae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

