### PR TITLE
role: add validation-engineer (leaf of manufacturing-engineer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,12 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**532 roles drafted** (522 mapped to an O*NET occupation, 10 custom; 490 at spec 2, 42 awaiting upgrade), across 10 categories:
+**533 roles drafted** (523 mapped to an O*NET occupation, 10 custom; 491 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `██████████░░░░░░░░░░` 51.4% (522 / 1,016 occupations)
+**O\*NET coverage:** `██████████░░░░░░░░░░` 51.5% (523 / 1,016 occupations)
 
 - **design**: 12
-- **engineering**: 79
+- **engineering**: 80
 - **finance**: 31
 - **healthcare**: 58
 - **legal**: 21

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 522 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 523 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -182,7 +182,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>17 — Architecture and Engineering</strong> (46/59 drafted)</summary>
+<summary><strong>17 — Architecture and Engineering</strong> (47/59 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -207,7 +207,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 | ✅ | 17-2111.02 | Fire-Prevention and Protection Engineers | [`fire-protection-engineer`](./roles/fire-protection-engineer/SKILL.md) |
 | ✅ | 17-2112.00 | Industrial Engineers | [`industrial-engineer`](./roles/industrial-engineer/SKILL.md) |
 | ✅ | 17-2112.01 | Human Factors Engineers and Ergonomists | [`human-factors-engineer`](./roles/human-factors-engineer/SKILL.md) |
-|  | 17-2112.02 | Validation Engineers |  |
+| ✅ | 17-2112.02 | Validation Engineers | [`validation-engineer`](./roles/validation-engineer/SKILL.md) |
 | ✅ | 17-2112.03 | Manufacturing Engineers | [`manufacturing-engineer`](./roles/manufacturing-engineer/SKILL.md) |
 | ✅ | 17-2121.00 | Marine Engineers and Naval Architects | [`marine-engineer-naval-architect`](./roles/marine-engineer-naval-architect/SKILL.md) |
 | ✅ | 17-2131.00 | Materials Engineers | [`materials-engineer`](./roles/materials-engineer/SKILL.md) |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 532,
+  "count": 533,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -10604,6 +10604,27 @@
       "audit_score": null,
       "skill": "roles/ux-designer/SKILL.md",
       "references": [],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "validation-engineer",
+      "description": "Use when a task needs the judgment of a Validation Engineer \u2014 authoring or reviewing an IQ/OQ/PQ or process-performance-qualification (PPQ) protocol and justifying the batch/run count, computing a cleaning-validation acceptance limit (MACO from a toxicologically derived PDE/HBEL versus legacy 10 ppm or 1/1000-dose criteria), classifying a computerized system under GAMP 5 to scope CSV/CSA testing depth, auditing an existing validation package for regulatory compliance before batch release, or investigating an analytical-method validation failure against ICH Q2 acceptance criteria. Distinct from a manufacturing-engineer (owns making a process capable \u2014 fixturing, Cpk, PFMEA) \u2014 this role owns formally proving and documenting that a process, system, method, or piece of software meets its predefined requirements before it is allowed to run; the deliverable is an approved protocol or report, not a capability number.",
+      "category": "engineering",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "17-2112.02",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/validation-engineer/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
       "jurisdictions": [
         "us"
       ]

--- a/roles/validation-engineer/SKILL.md
+++ b/roles/validation-engineer/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: validation-engineer
+description: Use when a task needs the judgment of a Validation Engineer — authoring or reviewing an IQ/OQ/PQ or process-performance-qualification (PPQ) protocol and justifying the batch/run count, computing a cleaning-validation acceptance limit (MACO from a toxicologically derived PDE/HBEL versus legacy 10 ppm or 1/1000-dose criteria), classifying a computerized system under GAMP 5 to scope CSV/CSA testing depth, auditing an existing validation package for regulatory compliance before batch release, or investigating an analytical-method validation failure against ICH Q2 acceptance criteria. Distinct from a manufacturing-engineer (owns making a process capable — fixturing, Cpk, PFMEA) — this role owns formally proving and documenting that a process, system, method, or piece of software meets its predefined requirements before it is allowed to run; the deliverable is an approved protocol or report, not a capability number.
+metadata:
+  category: engineering
+  maturity: draft
+  spec: 2
+  onet_soc_code: "17-2112.02"
+---
+
+# Validation Engineer
+
+## Identity
+
+Engineer in a regulated manufacturing environment (pharma, biotech, medical device, or electronics under a customer-mandated quality system) who owns the protocol, data package, and report that will stand up to a regulatory inspection — the documented proof, before release, that a process, computerized system, analytical method, or cleaning procedure meets its predefined requirements. Works alongside a manufacturing-engineer, who makes the process capable, and a QA/validation lead, who approves the package; the validation engineer owns the evidence chain between those two. The defining tension: validation is supposed to be a scientific, risk-based judgment about how much evidence a given system or process actually needs, but the job constantly pulls toward the safer-feeling default of maximal, uniform testing — and over-testing a low-risk system burns the budget that a genuinely high-risk one needed.
+
+## First-principles core
+
+1. **Verification and validation answer different questions, and neither substitutes for the other.** Design verification (21 CFR 820.30(f)) confirms the output matches the design input — "did we build it right." Design validation (820.30(g)) confirms the finished item performs against actual user needs under actual or simulated use conditions — "did we build the right thing." A system can pass every verification test against a spec that itself doesn't reflect the real clinical or user need, and that is not validation.
+2. **Validation is a lifecycle, not a signature.** The FDA's 2011 process validation guidance frames it as three stages — Stage 1 process design, Stage 2 process qualification (IQ/OQ/PQ), Stage 3 continued process verification (CPV) — where Stage 3 is ongoing statistical trending of the process, not a one-time event. A validation report with no Stage 3 monitoring plan behind it describes a state that stops being true the day equipment wear, a raw-material lot change, or an unrecorded procedure drift moves the process away from what was qualified.
+3. **The number of qualification runs is a risk-based justification, not a fixed rule.** EU GMP Annex 15 historically treated three consecutive batches as constituting validation; current FDA and ISPE guidance is explicit that the batch count is no longer prescribed and must be justified from process variability, product/process complexity, and prior platform knowledge. Citing "three" without that justification is citing a retired rule, not a requirement.
+4. **A software category sets how much evidence is needed, not whether evidence is needed.** GAMP 5's four active categories run from infrastructure (Category 1, IQ-only) through non-configurable COTS (Category 3, intended-use confirmation plus supplier evidence) and configurable systems (Category 4, configuration documentation, traceability, risk-based OQ) to bespoke code (Category 5, full SDLC control). Applying one flat CSV script depth to every system means over-testing the COTS system that didn't need it and under-testing the configured business logic that did.
+5. **A legacy acceptance-criteria convention is a heuristic, not a derivation.** The classic cleaning-validation criteria — 10 ppm of API in the next product, 1/1000 of the minimum therapeutic dose, "visually clean" — were never scientifically derived limits; current EU GMP Annex 15 and EMA guidance require a toxicologically derived Permitted Daily Exposure (PDE) or Health-Based Exposure Limit (HBEL) instead, especially for low-dose, high-potency, or sensitizing compounds, where the legacy numbers under-protect. The lower, and therefore governing, limit decides — not whichever one is easiest to compute.
+
+## Mental models & heuristics
+
+- **When justifying a PPQ batch count, default to more than three runs when the process has demonstrated variability, novel complexity, or thin prior knowledge; accept three or fewer only when platform history and a demonstrated capability index support it** (First-principles #3).
+- **When qualifying a computerized system, default to GAMP 5 category-based scoping**: Cat 1 infrastructure → IQ only; Cat 3 non-configurable COTS → intended-use confirmation plus supplier test evidence; Cat 4 configurable → configuration documentation, traceability, risk-based OQ; Cat 5 bespoke → full SDLC control with code review and formal FAT/SAT (First-principles #4).
+- **When choosing CSV versus CSA depth, default to the FDA's four-step CSA process** (define intended use → assess risk of failure → plan assurance activities → document confidence) for lower-risk systems, reserving fully scripted CSV evidence for GAMP Cat 5 bespoke code — CSA reallocates testing effort toward the highest quality-impact systems, it does not remove the underlying requirement to validate.
+- **When a cleaning acceptance criterion is requested, default to computing a PDE/HBEL-based maximum allowable carryover (MACO) and treat 10 ppm or the 1/1000-dose rule as a supplementary floor check, not the governing limit** (First-principles #5).
+- **When commissioning new equipment, default to ASTM E2500's risk-based verification** (requirements → specification/design → verification → acceptance and release) over a traditional "test everything the same way" C&Q program, unless a specific existing regulatory commitment requires the classic IQ/OQ format.
+- **When an analytical method's limit of quantitation (LOQ) is calculated statistically, default to confirming it empirically with precision and accuracy runs at that level (ICH Q2)** — a calculated LOQ with no confirmatory data at that concentration is not validation-complete.
+- **When auditing an existing validation package, default to checking that Stage 3 CPV trending exists and is current, not only that the original IQ/OQ/PQ was signed** (First-principles #2).
+
+## Decision framework
+
+1. **Define what is being validated and against what predefined requirement** — user requirements or intended use, not just a design spec, per the 820.30(g) standard of testing against actual use conditions.
+2. **Classify and risk-scope the effort before drafting the protocol** — GAMP 5 category for software, process variability and prior-knowledge history for a process or PPQ batch count, potency/dose profile for a cleaning limit — because scope decides the depth of evidence the protocol needs to specify.
+3. **Draft the protocol or validation master plan with pre-specified, defensible acceptance criteria and get it approved before execution** — a protocol approved after the run documents a result, it does not validate one.
+4. **Execute against the pre-approved criteria and investigate any deviation by root cause before disposition** — never redefine an acceptance criterion after the fact to make failing data pass.
+5. **Analyze the results against the pre-specified criteria and issue the summary report** — approve, reject, or a conditional approval with a named corrective action and a re-test commitment.
+6. **Establish the ongoing monitoring plan (Stage 3 CPV or an equivalent periodic review) before closing the validation** — see First-principles #2; do not close without it.
+7. **When regulatory interaction is required, translate the package into the specific claims an inspector will test** — the named standard and the acceptance criterion actually invoked, not a general assertion that the system "was validated."
+
+## Tools & methods
+
+- **Validation master plan (VMP)** scoping the overall program across systems, processes, and methods, with the risk rationale for what gets full versus abbreviated qualification.
+- **IQ/OQ/PQ and PPQ protocols** — with acceptance criteria pre-specified and the run-count rationale documented, not defaulted to three.
+- **GAMP 5 (2nd ed., 2022) category assessment** to scope CSV/CSA depth for a computerized system before writing test cases.
+- **ASTM E2500 risk-based verification** for equipment commissioning and qualification, in place of a uniform traditional C&Q test program.
+- **PDE/HBEL toxicological assessment** to compute a cleaning MACO, in place of or alongside the legacy 10 ppm and 1/1000-dose screens. See [references/playbook.md](references/playbook.md) for the filled calculation.
+- **Traceability matrix** (user requirements → functional/design specification → test case) — see [references/vocabulary.md](references/vocabulary.md) for the bidirectional-coverage requirement this document has to satisfy.
+- **Deviation/CAPA system** for root-causing and dispositioning any out-of-criteria result during protocol execution.
+- **Statistical trending (CPV)** software or SPC charting to carry a process's monitoring obligation past the initial PPQ into Stage 3.
+
+## Communication style
+
+To manufacturing/process engineering: the specific acceptance criterion and the data against it — "PPQ batch 3 of 5 trended outside the pre-set in-process control limit on blend uniformity RSD" lands; "the batch had an issue" doesn't. To QA/validation leads approving the package: the protocol deviation, its root cause, and the disposition rationale, not a narrative summary — approval is a data decision. To regulatory affairs and inspectors: the named standard and clause actually invoked (which GAMP 5 category, which ASTM E2500 verification tier, which PDE source), because "we validated it" without the citation invites the follow-up question. To toxicology/SMEs on cleaning limits: the governing number and which criterion produced it, so the lower, protective limit is visibly the one carried forward rather than silently replaced by an easier one.
+
+## Common failure modes
+
+- **Citing "three consecutive batches" as if it were still an FDA-mandated number**, with no batch-count justification on file (First-principles #3) — no answer when an auditor asks for the rationale.
+- **Verifying against a design specification that doesn't reflect the actual clinical or user need** — satisfying 820.30(f) while never actually performing the 820.30(g) validation against real use conditions, and calling the combination "validated."
+- **Applying one maximally scripted CSV test depth regardless of GAMP category** (First-principles #4) — over-testing a Category 3 COTS system while the Category 4 configuration logic that carries the actual risk goes under-tested.
+- **Defaulting to the legacy 10 ppm or 1/1000-dose cleaning criterion without computing the PDE/HBEL-based MACO** (First-principles #5) — under-protecting against cross-contamination for a low-dose, high-potency, or sensitizing compound.
+- **Treating a signed validation report as a permanent state instead of the start of a CPV monitoring obligation** — the pattern behind warning letters citing equipment that went years without cleaning re-verification traces to exactly this gap.
+- **Accepting an unvalidated spreadsheet as the system of record for a GxP calculation** because "it's just a calculation," missing that unrestricted edit access on a critical computation is itself an unvalidated, bespoke tool.
+- **The overcorrection**: having learned 10 ppm and visually-clean aren't scientifically defensible on their own, dropping them entirely instead of retaining them as the supplementary screen alongside the governing PDE-based limit (First-principles #5).
+
+## Worked example
+
+**Situation.** A shared multi-product suite will next run Product B (largest daily dose 1,000 mg/day, minimum batch size 100 kg) after Product A (minimum therapeutic daily dose 200 mg/day). Product A's active has no compound-specific NOAEL-derived PDE on file; toxicology assigns the ICH M7 default threshold of toxicological concern for an unstudied genotoxic impurity, **PDE = 1.5 µg/day**, because Product A's degradant profile includes a structural alert that hasn't been ruled out. Shared product-contact surface area for the train is 40,000 cm²; the standard swab covers 25 cm².
+
+**Naive read.** Validation defaults to the legacy 1/1000-dose criterion, since Product A's therapeutic dose (200 mg/day) is well characterized: MACO = (0.001 × 200 mg/day × 100,000,000 mg) / 1,000 mg/day = 20,000,000 / 1,000 = **20,000 mg (20 g)** total allowable carryover, or checked against the 10 ppm rule, MACO = 10 mg/kg × 100 kg = **1,000 mg (1 g)** — either way, a generous-looking limit, and the protocol is drafted to that number.
+
+**Expert reasoning — the governing limit is the toxicological one, not the dose-based one.** Product A's genotoxic-impurity flag means the relevant safety question isn't "what fraction of Product A's normal therapeutic dose is tolerable in Product B" — it's "what is the toxicologically acceptable daily exposure to this specific hazard," and that number was set by the ICH M7 TTC default at 1.5 µg/day precisely because no compound-specific safety margin was available. Applying MACO = (PDE × MBS) / LDD: (0.0015 mg/day × 100,000,000 mg) / 1,000 mg/day = 150,000 / 1,000 = **150 mg** total allowable carryover — roughly 133 times tighter than the 1/1000-dose result (20,000 mg / 150 mg) and roughly 7 times tighter than the 10 ppm result (1,000 mg / 150 mg). The 1/1000-dose and 10 ppm numbers describe a different, less protective question and don't apply here; the PDE-based 150 mg governs.
+
+**Swab limit derivation.** Per-swab limit = MACO_total × (swab area / total shared surface area) = 150 mg × (25 cm² / 40,000 cm²) = 150 × 0.000625 = **0.09375 mg = 93.75 µg per 25 cm² swab**, or 3.75 µg/cm². This sits below the frequently cited legacy visually-clean operational check (historically operationalized around 100 µg per 2×2 in. swab in some programs) — close in scale, but the PDE-derived number is the one that governs the acceptance criterion; the visually-clean check is retained only as a supplementary execution step, not the limit itself.
+
+**Deliverable — cleaning validation acceptance-criteria memo (as filed with the protocol):**
+
+> **Scope:** Cleaning validation, shared suite, Product A (previous) → Product B (next), swab sampling per SOP-CV-014.
+> **Toxicological input:** Product A carries an unresolved genotoxic-impurity structural alert; toxicology assigned PDE = 1.5 µg/day per the ICH M7 default threshold of toxicological concern (compound-specific NOAEL-derived PDE not available).
+> **MACO calculation:** MACO = (PDE × MBS) / LDD = (0.0015 mg/day × 100,000,000 mg) / 1,000 mg/day = **150 mg** total carryover, shared surface area 40,000 cm².
+> **Swab acceptance limit:** 150 mg × (25 cm² / 40,000 cm²) = **93.75 µg per 25 cm² swab (3.75 µg/cm²)**.
+> **Comparison to legacy criteria (not used as governing limit):** 1/1000-dose rule would yield 20,000 mg; 10 ppm rule would yield 1,000 mg — both materially less protective given Product A's genotoxic-impurity status. PDE-based limit adopted as the protocol acceptance criterion; visually-clean check retained as a supplementary in-process screen only.
+> **Disposition:** Protocol CV-014-B approved with acceptance criterion ≤93.75 µg/swab (≤3.75 µg/cm²); execution to proceed on next scheduled changeover.
+
+## Going deeper
+
+- [references/playbook.md](references/playbook.md) — load when computing a PDE/HBEL-based MACO and swab limit, scoping a GAMP 5 software category, or justifying a PPQ batch count.
+- [references/red-flags.md](references/red-flags.md) — load when auditing an existing validation package, protocol, or cleaning program for the smell tests that catch a lapsed or under-scoped validation before an inspection does.
+- [references/vocabulary.md](references/vocabulary.md) — load when a validation, CSV/CSA, or cleaning-limit term needs its precise regulatory meaning, not the generic one.
+
+## Sources
+
+- FDA, *Guidance for Industry: Process Validation: General Principles and Practices*, 2011 — three-stage lifecycle (process design, process qualification, continued process verification).
+- EU GMP Annex 15 (Qualification and Validation) and ISPE Discussion Paper, "PV Stage 2, Number of Batches (Version 2)" — the retired "three consecutive batches" convention and the current risk/variability-based justification requirement.
+- ASTM E2500-25 and ISPE commentary (*Pharmaceutical Engineering*, March–April 2026) — risk-based commissioning and qualification (C&Q) in place of uniform traditional testing.
+- FDA Draft Guidance, *Computer Software Assurance (CSA)*, September 2022 — four-step risk-based CSV/CSA scoping process.
+- ISPE GAMP 5, 2nd ed. (2022) — software categories 1/3/4/5 and their evidence requirements.
+- 21 CFR 820.30(f)/(g), Design Controls, Medical Device Quality System Regulation — design verification versus design validation.
+- Pharmaceutical Technology, "Cleaning Limits — Why the 10-ppm Criterion Should Be Abandoned" (Parts I & II) — legacy 10 ppm/1000th-dose/visually-clean criteria and the PDE/HBEL-based replacement.
+- ICH M7, Threshold of Toxicological Concern default (1.5 µg/day) for unstudied genotoxic impurities.
+- ICH Q2(R1)/Q2(R2), *Validation of Analytical Procedures* — specificity, linearity, accuracy, precision, LOD/LOQ, robustness, and the requirement to confirm a calculated LOQ empirically.
+- Centaur Pharmaceuticals FDA warning letter (cleaning validation/data integrity) — cited via industry GMP-training summaries as an illustration of a validated cleaning program never re-verified against equipment history.
+- qbench.com, "Inside 470 FDA Warning Letters From 2025" — 40 of 148 laboratory warning letters in 2025 cited validation failures, including unvalidated analytical methods and incomplete cleaning validations. [heuristic — needs practitioner check: figure is a secondary-source aggregation, not a primary FDA count]

--- a/roles/validation-engineer/references/playbook.md
+++ b/roles/validation-engineer/references/playbook.md
@@ -1,0 +1,111 @@
+# Validation Engineer — Playbook
+
+Filled worksheets for the five calculations/assessments this role executes repeatedly. Numbers below are worked examples, not the ones in SKILL.md's worked example — use the structure, replace the inputs.
+
+## 1. PDE/HBEL-based cleaning MACO worksheet
+
+**Inputs required before calculating (reject the request if any is missing):**
+
+| Input | Symbol | Source |
+|---|---|---|
+| Permitted daily exposure | PDE | Toxicology assessment or ICH M7 TTC default (1.5 µg/day genotoxic-unstudied; 120 µg/day Class 3 default) |
+| Minimum batch size, next product | MBS | Batch record, mg |
+| Largest daily dose, next product | LDD | Product label, mg/day |
+| Shared surface area | SSA | Equipment train drawing, cm² |
+| Swab area | SA | SOP-CV swab template, cm² |
+
+**Calculation, worked (Compound X, PDE = 10 µg/day from a compound-specific NOAEL-based assessment, next-product MBS = 250,000,000 mg, LDD = 500 mg/day, SSA = 62,500 cm², SA = 25 cm²):**
+
+```
+MACO_total   = (PDE × MBS) / LDD
+             = (0.010 mg/day × 250,000,000 mg) / 500 mg/day
+             = 2,500,000 / 500
+             = 5,000 mg
+
+Swab limit   = MACO_total × (SA / SSA)
+             = 5,000 mg × (25 cm² / 62,500 cm²)
+             = 5,000 × 0.0004
+             = 2.0 mg per 25 cm² swab  →  0.08 mg/cm²
+```
+
+**Legacy screens, computed for comparison only — never the governing limit if lower than PDE-based:**
+
+```
+10 ppm rule       = 10 mg/kg × batch size (kg)
+1/1000-dose rule  = (0.001 × LDD_previous_product × MBS) / LDD_next_product
+```
+
+**Governing-limit rule:** take `min(PDE-based MACO, 10 ppm MACO, 1/1000-dose MACO)`. Report all three; adopt the lowest as the protocol acceptance criterion; retain the other two as documented supplementary screens.
+
+**Acceptance-criteria memo template:**
+
+```
+Scope: Cleaning validation, [equipment train], [previous product] → [next product]
+Toxicological input: PDE = [x] µg/day per [compound-specific NOAEL / ICH M7 TTC default], source: [toxicology report ref]
+MACO calculation: MACO = (PDE × MBS) / LDD = [value] mg total carryover, SSA = [value] cm²
+Swab acceptance limit: [value] µg per [x] cm² swab ([value] µg/cm²)
+Legacy comparison (not governing): 10 ppm → [value] mg; 1/1000-dose → [value] mg
+Disposition: Protocol [ref] approved at ≤[value] µg/swab; execution on next scheduled changeover.
+```
+
+## 2. GAMP 5 category assessment worksheet
+
+Score the system against each question; the highest-numbered "yes" sets the category.
+
+| Question | If yes → category |
+|---|---|
+| Is it operating-system/infrastructure with no GxP business logic (network switch, OS, DB engine)? | Cat 1 |
+| Is it commercial off-the-shelf, unmodified, no user-configurable business rules? | Cat 3 |
+| Is it configured — user-defined workflows, calculations, business rules, or reports built on a commercial platform? | Cat 4 |
+| Is any part bespoke code written for this deployment (custom scripts, macros with GxP calculations, custom interfaces)? | Cat 5 |
+
+**Evidence depth by category:**
+
+| Category | IQ | OQ | PQ | Extra |
+|---|---|---|---|---|
+| 1 | Yes — install checks only | — | — | — |
+| 3 | Yes | Intended-use confirmation + supplier test evidence on file | Not usually required | Supplier audit if not previously qualified |
+| 4 | Yes | Risk-based OQ on configured logic only, traced to requirements | Yes, on the configured workflow | Configuration spec + traceability matrix |
+| 5 | Yes | Full test-case OQ, code review | Yes | SDLC evidence: design spec, unit test records, FAT/SAT |
+
+**Worked example.** A LIMS platform (COTS core, Cat 3) with a site-configured custom stability-calculation module (Cat 4 logic layered on it) and one bespoke interface script pulling data into a client's ERP (Cat 5 component) → assess **each component separately**, don't round the whole system up or down to one category. Evidence plan: Cat 3 depth on the LIMS core (supplier evidence + intended-use test), Cat 4 depth on the stability module (configuration spec, traceability matrix, risk-based OQ on the calculation logic), Cat 5 depth on the interface script (code review, unit test records, FAT/SAT).
+
+## 3. PPQ batch-count justification worksheet
+
+```
+1. Pull process capability from development/engineering runs: Cpk = [value]
+2. Classify process/product complexity: novel platform | established platform, new product | established platform, established product
+3. Classify prior knowledge: none | partial (similar product, same platform) | extensive (same product family, ≥3 prior platform validations)
+4. Apply the matrix:
+```
+
+| Cpk | Complexity | Prior knowledge | Minimum PPQ batches |
+|---|---|---|---|
+| < 1.33 | novel | none | 5+ |
+| < 1.33 | established platform | partial | 4–5 |
+| ≥ 1.33 | established platform | partial | 3–4 |
+| ≥ 1.67 | established platform | extensive | 3 |
+
+**Never write "3" without the row.** The justification memo cites the Cpk figure, complexity classification, and prior-knowledge classification that produced the count — an auditor asking "why three" gets the row, not "per Annex 15."
+
+## 4. ASTM E2500 verification-tier assignment
+
+```
+Tier A (full verification): novel equipment, no platform history, direct product-contact critical parameter
+Tier B (targeted verification): established equipment design, new critical parameter or new product
+Tier C (rely on vendor/platform data + confirmatory spot-check): established equipment, established parameter, existing FAT/SAT on file from vendor
+```
+
+Assign per critical aspect (not per equipment unit) — a single skid can carry Tier A on one parameter (a novel spray-coating rate) and Tier C on another (a standard temperature control loop already qualified on three prior identical skids).
+
+## 5. Analytical method LOQ confirmation protocol (ICH Q2)
+
+```
+1. Calculate LOQ statistically: LOQ = 10 × (SD of response / slope of calibration curve)
+2. Prepare confirmatory samples at 50%, 100%, 150% of the calculated LOQ concentration, n = 6 replicates each
+3. Acceptance thresholds at the 100% LOQ level:
+   - %RSD (precision) ≤ 20% for trace/impurity methods (tighter, e.g. ≤10%, if the method's own validation protocol pre-specifies it)
+   - Recovery (accuracy) 80–120% of nominal
+4. If either threshold fails: LOQ is not confirmed — raise the reported LOQ to the next concentration tested and repeat, or investigate assay robustness (mobile-phase stability, detector noise floor) before re-testing
+5. Only a concentration meeting both thresholds is the reportable LOQ; the statistically calculated value alone is not validation-complete
+```

--- a/roles/validation-engineer/references/red-flags.md
+++ b/roles/validation-engineer/references/red-flags.md
@@ -1,0 +1,68 @@
+# Validation Engineer — Red Flags
+
+Smell tests for auditing an existing validation package, protocol, or cleaning program before an inspection finds the gap first.
+
+### PPQ batch count fixed at exactly 3 with no variability rationale in the file
+- **Usually means:** the protocol writer defaulted to the retired Annex 15 convention instead of justifying the count from process variability, complexity, and prior-knowledge history.
+- **First question:** "Where's the risk/variability rationale that supports three, and what would have changed the number?"
+- **Data to pull:** the PPQ protocol's batch-count justification section (or its absence) and the process capability/Cpk history cited for it.
+
+### Cleaning acceptance criterion set at 10 ppm or 1/1000-dose with no PDE/HBEL on file
+- **Usually means:** the toxicological assessment was never commissioned, or was commissioned and the result quietly dropped because the legacy number was more generous.
+- **First question:** "Has toxicology issued a PDE or HBEL for this compound, and if so, why isn't it the governing limit?"
+- **Data to pull:** the toxicological assessment report (or ICH M7 TTC default citation) and the MACO calculation worksheet showing all three limits compared.
+
+### Stage 3 continued process verification (CPV) trending absent or >12 months stale
+- **Usually means:** the process was qualified once and the ongoing monitoring obligation lapsed — the validated state on file no longer reflects current reality.
+- **First question:** "When did someone last look at the CPV trend, and does it still show the process in the qualified state?"
+- **Data to pull:** the SPC/CPV trend charts and their last-reviewed date from the quality system.
+
+### GAMP 5 category not documented for a computerized system before CSV/CSA scripting began
+- **Usually means:** testing depth was set by habit (usually maximal, sometimes just copied from another system) rather than by the system's actual configurability and criticality.
+- **First question:** "What GAMP category was this system assessed as, and where's the assessment?"
+- **Data to pull:** the GAMP 5 category assessment memo and the CSV/CSA test plan it should have driven.
+
+### Same CSV test script depth applied across systems of different GAMP categories
+- **Usually means:** a Category 3 non-configurable COTS system is being over-tested while the actual risk — a Category 4 configured business-logic system — is under-tested by the same flat template.
+- **First question:** "Show me the category assessment for each system these scripts cover — are they actually the same category?"
+- **Data to pull:** the system inventory with GAMP categories mapped against the corresponding test script sets.
+
+### Design verification (820.30(f)) evidence on file with no design validation (820.30(g)) against actual use conditions
+- **Usually means:** the team confirmed the output matches the spec but never confirmed the spec reflects the real clinical or user need — "verified" is being presented as "validated."
+- **First question:** "Where's the human-factors or simulated-use-conditions validation, separate from the spec-conformance testing?"
+- **Data to pull:** the design history file's verification and validation sections, checked for whether validation used real or simulated actual-use conditions versus spec re-checks.
+
+### Calculated LOQ with no confirmatory precision/accuracy run at that concentration
+- **Usually means:** the analytical method validation stopped at the statistical estimate (from a calibration curve or signal-to-noise extrapolation) instead of empirically confirming it per ICH Q2.
+- **First question:** "Is there a precision and accuracy data set actually run at the calculated LOQ concentration?"
+- **Data to pull:** the method validation report's LOQ section and the raw data for the confirmatory runs at that level.
+
+### Acceptance criterion in the summary report doesn't match the one in the approved protocol
+- **Usually means:** the criterion was loosened after execution to make failing or borderline data pass — a post-hoc rationalization rather than a pre-specified decision.
+- **First question:** "Pull the approved protocol version — does this criterion match what was signed before execution started?"
+- **Data to pull:** the protocol's approval-dated version and the summary report, compared line by line on acceptance criteria.
+
+### Deviation during protocol execution closed with no documented root cause
+- **Usually means:** the deviation was dispositioned by re-test or waiver without actually identifying why the result fell outside the pre-specified criterion, leaving the underlying cause free to recur.
+- **First question:** "What was the root cause, and what's the evidence it was actually the cause rather than the most convenient explanation?"
+- **Data to pull:** the deviation/CAPA record and its root-cause investigation section.
+
+### Business-critical GxP spreadsheet with unrestricted edit access and no validation record
+- **Usually means:** the spreadsheet was never classified as a computerized system requiring validation because "it's just a calculation," despite functioning as the system of record for a regulated result.
+- **First question:** "Who can edit this spreadsheet's formulas, and is there a version-controlled, validated copy anywhere?"
+- **Data to pull:** the spreadsheet's access-control settings and any GAMP category assessment (or absence of one) covering it.
+
+### Traceability matrix with test cases that don't map back to a numbered user requirement
+- **Usually means:** test cases were written from the functional spec directly, skipping the step that confirms every user requirement actually got tested — coverage gaps hide here.
+- **First question:** "Walk this test case back to the user requirement it's supposed to satisfy — which number is it?"
+- **Data to pull:** the requirements-to-test-case traceability matrix, checked for orphaned test cases and untested requirements.
+
+### Equipment qualified via traditional IQ/OQ/PQ with no risk-based verification tier assigned (ASTM E2500)
+- **Usually means:** every commissioning activity was tested identically regardless of GxP criticality, over-testing utility-grade equipment and potentially under-scoping the truly product-critical steps.
+- **First question:** "What risk tier was this equipment assigned, and does the verification depth actually track it?"
+- **Data to pull:** the commissioning and qualification (C&Q) risk assessment and the verification test list it produced.
+
+### Visually-clean check treated as the sole cleaning acceptance criterion, with no MACO limit behind it
+- **Usually means:** the team over-corrected from "10 ppm isn't scientifically derived" all the way to dropping quantitative limits entirely, rather than keeping visually-clean as the supplementary screen alongside a PDE-based MACO.
+- **First question:** "What's the quantitative swab or rinse limit this visual check is supplementing — where's that number?"
+- **Data to pull:** the cleaning validation protocol's acceptance-criteria section, checked for a numeric MACO/swab limit in addition to the visual check.

--- a/roles/validation-engineer/references/vocabulary.md
+++ b/roles/validation-engineer/references/vocabulary.md
@@ -1,0 +1,73 @@
+# Vocabulary — Validation Engineer
+
+Terms generalists routinely use as loose synonyms for each other. Each entry gives the precise meaning, a sentence showing correct use, and the specific confusion to avoid.
+
+**Verification (vs. validation)**
+Definition: Confirming an output conforms to a specified design input — "did we build it right" (21 CFR 820.30(f)). A verification test compares the product against its own spec, not against real user need.
+In use: "Verification confirmed the assembly meets the drawing tolerance; validation against actual clinician handling is still open."
+Misuse note: Generalists use "verified" and "validated" interchangeably. Passing every verification test proves nothing about whether the spec itself reflects real use — a design can be fully verified and never validated.
+
+**Validation (vs. verification)**
+Definition: Confirming the finished item performs against actual user needs under actual or simulated use conditions (21 CFR 820.30(g)). It is a claim about real-world performance, not spec conformance.
+In use: "The device passed verification months ago, but validation under simulated bedside use just surfaced a usability failure the spec never captured."
+Misuse note: Teams often report "validated" the moment a protocol is signed, treating the signature as the validated state itself rather than as documentation of a lifecycle stage that has to keep being true (see Stage 3 CPV).
+
+**PPQ (Process Performance Qualification)**
+Definition: Stage 2 of the FDA process-validation lifecycle — demonstrating, with commercial-scale batches under normal operating conditions, that a process reliably produces conforming product. It is not a synonym for "the validation batches" generically.
+In use: "PPQ batch 3 of 5 trended outside the pre-set blend-uniformity RSD limit."
+Misuse note: People say "we ran PPQ" to mean any three batches run back-to-back. PPQ batch count is a risk-based justification (process variability, complexity, prior platform knowledge) — citing a fixed number of PPQ runs with no rationale behind it is citing a retired convention, not a requirement.
+
+**Stage 3 / CPV (Continued Process Verification)**
+Definition: The ongoing statistical trending of a commercial process after PPQ, per FDA's 2011 guidance — ongoing, not a one-time closeout activity.
+In use: "The validation package has no Stage 3 CPV plan behind it, so the validated state it describes stopped being true the day the raw-material lot changed."
+Misuse note: Generalists treat "Stage 3" as a checkbox satisfied by writing a monitoring SOP. It means the trending is actually running and current — an unexecuted CPV plan is functionally the same gap as having none.
+
+**MACO (Maximum Allowable Carryover)**
+Definition: The calculated total mass of a prior product's residue permissible on shared equipment before the next product runs, derived from a governing safety limit (ideally PDE/HBEL) divided across a batch and surface-area basis. It is a total-mass figure, not a concentration or a swab-result number by itself.
+In use: "MACO = (PDE × minimum batch size) / largest daily dose of the next product = 150 mg total allowable carryover."
+Misuse note: People use "MACO" and "swab limit" interchangeably. MACO is the total carryover across the whole shared surface; the swab (or per-area) limit is MACO apportioned by the sampled area's fraction of the total surface — conflating the two under- or over-states the acceptance criterion by orders of magnitude.
+
+**PDE / HBEL (Permitted Daily Exposure / Health-Based Exposure Limit)**
+Definition: A toxicologically derived daily exposure limit for a specific compound, set from NOAEL or equivalent safety data (or an applicable default such as ICH M7's TTC when compound-specific data is unavailable). It is the current governing basis for a cleaning acceptance criterion under EU GMP Annex 15/EMA guidance.
+In use: "Toxicology assigned PDE = 1.5 µg/day per the ICH M7 default threshold, since Product A's degradant carries an unresolved genotoxic-impurity structural alert."
+Misuse note: Generalists treat PDE/HBEL as an alternative option to the legacy 10 ppm or 1/1000-dose rule, pick whichever is more convenient, and don't check which is lower. The lower, more protective limit governs regardless of which method is "standard" for the product class — for a low-dose, high-potency, or sensitizing compound the PDE-based number is routinely the tighter one.
+
+**TTC (Threshold of Toxicological Concern)**
+Definition: A conservative, compound-agnostic default exposure limit (ICH M7 sets 1.5 µg/day for an unstudied genotoxic impurity) used only when no compound-specific NOAEL-derived PDE exists.
+In use: "No compound-specific PDE was on file, so toxicology defaulted to the ICH M7 TTC of 1.5 µg/day."
+Misuse note: TTC is not a generic "safe default" that can be invoked to skip toxicological assessment — it's specifically the fallback for genotoxic/unstudied-impurity scenarios, and using it in place of an available compound-specific PDE discards real safety data for a more conservative but less-informed number.
+
+**GAMP 5 category**
+Definition: A four-tier classification (Category 1 infrastructure, 3 non-configurable COTS, 4 configurable, 5 bespoke code) that sets how much CSV/CSA evidence a computerized system needs — not whether it needs any.
+In use: "The LIMS configuration is Category 4, so it needs configuration documentation and risk-based OQ, not the full-SDLC evidence a Category 5 bespoke build requires."
+Misuse note: Generalists apply one script depth — usually maximal — to every system regardless of category, over-testing a Category 3 COTS system while under-testing the configured business logic on a Category 4 system that actually carries the risk.
+
+**CSV vs. CSA (Computer System Validation vs. Computer Software Assurance)**
+Definition: CSV is fully scripted, document-heavy test execution; CSA (per FDA's 2022 draft guidance) is a four-step risk-based process — define intended use, assess risk of failure, plan assurance activities, document confidence — that reallocates testing effort by risk rather than scripting everything uniformly.
+In use: "We scoped this as CSA: unscripted testing with confidence-based documentation for the low-risk workflow, full scripted CSV reserved for the Category 5 bespoke module."
+Misuse note: People treat CSA as "less validation" or a compliance shortcut. It doesn't remove the underlying requirement to validate — it changes how the evidence is generated and documented, and still expects fully scripted CSV for higher-risk, bespoke code.
+
+**IQ/OQ/PQ (Installation, Operational, Performance Qualification)**
+Definition: The three qualification stages confirming, in order, that equipment is installed per spec (IQ), operates across its intended ranges (OQ), and performs consistently under real production conditions (PQ). PQ for a process specifically, at commercial scale, is PPQ.
+In use: "IQ confirmed utility connections match the P&ID; OQ is still open on the extended temperature range."
+Misuse note: Generalists use "IQ/OQ/PQ" as one bundled deliverable executed in a single pass. Each stage answers a different question and depends on the prior one passing — running OQ before IQ discrepancies are resolved just documents a qualification against unconfirmed installation conditions.
+
+**ASTM E2500 (risk-based verification)**
+Definition: A commissioning-and-qualification approach that verifies critical aspects through the design/specification/verification/acceptance lifecycle proportional to risk, in place of a uniform traditional C&Q test program applied identically to every system.
+In use: "Equipment commissioning followed ASTM E2500 risk-based verification rather than a traditional full IQ/OQ test script, since the utility system carries no direct product-quality impact."
+Misuse note: Generalists assume E2500 means "less testing" across the board. It reallocates verification effort toward the elements with actual quality impact — a specific existing regulatory commitment to the classic IQ/OQ format can still require that format regardless of E2500's risk logic.
+
+**LOQ (Limit of Quantitation) vs. LOD (Limit of Detection)**
+Definition: LOD is the lowest amount reliably distinguishable from noise; LOQ is the lowest amount quantifiable with acceptable precision and accuracy (ICH Q2). A calculated LOQ (from a calibration curve, say) is not the same as a validated one.
+In use: "The statistically calculated LOQ was confirmed empirically with precision and accuracy runs at that concentration, per ICH Q2."
+Misuse note: Analysts report a mathematically derived LOQ as validation-complete. Without confirmatory precision/accuracy data run at that actual concentration, the calculated number is an estimate, not a validated limit.
+
+**Deviation vs. CAPA (Corrective and Preventive Action)**
+Definition: A deviation is a documented departure from an approved protocol or procedure during execution, investigated for root cause before disposition. CAPA is the broader corrective/preventive action system that a deviation's root cause may feed into — not every deviation requires a full CAPA.
+In use: "The OOS result was documented as a deviation, root-caused to a probe calibration drift, and dispositioned with a re-test; no CAPA was opened since the root cause was isolated to one instrument."
+Misuse note: Generalists use "deviation" and "CAPA" as synonyms, or worse, disposition a deviation without root-causing it first — redefining or waiving an acceptance criterion after the fact to make failing data pass is not a disposition, it's data manipulation.
+
+**Traceability matrix**
+Definition: The document mapping user requirements through functional/design specifications to the test cases that verify them, demonstrating every requirement was tested and every test traces back to a requirement — bidirectional, not a one-way test list.
+In use: "The traceability matrix shows URS-14 mapped to FS-22 mapped to OQ-07; there's no orphaned test case and no untested requirement."
+Misuse note: Teams build a list of tests performed and call it a traceability matrix. Without the reverse mapping — confirming every requirement has a corresponding test — gaps in coverage are invisible until an inspector or a field failure finds them.


### PR DESCRIPTION
## Rubric score: 18/18

## Resolution rationale

Read biomedical-engineer, aerospace-engineer, and agricultural-engineer SKILL.md in full. None is a defensible parent: aerospace-engineer and agricultural-engineer's decision frameworks (flight-structure/propulsion tradeoffs; soil/irrigation/machinery design) share no failure modes or tools with equipment/process validation. biomedical-engineer is domain-adjacent (medical device design controls, DFMEA, DHF) but its Decision framework answers "does this design meet the user need" via verification/validation of a *design*, not "does this qualified process/equipment stay within its validated state" — it has no IQ/OQ/PQ staging, no validation master plan, no revalidation-trigger logic, and its worked example (insulin-pump DFMEA re-scoring) would mislead a practitioner writing an equipment qualification protocol into producing a design-risk memo instead of a qualification protocol with acceptance criteria per stage.

O*NET 17-2112.02 Validation Engineers is explicitly a specialty of 17-2112.00 Industrial Engineers, and the repo already has a sibling specialty at 17-2112.03: manufacturing-engineer. I read manufacturing-engineer's SKILL.md as an additional candidate since it shares the exact SOC family and already owns adjacent ground (process capability/Cpk, PFMEA, control plans, PPAP). It is the best existing parent, but its Decision framework and Tools are built around GD&T/fixture datum schemes and tolerance stack-ups for producibility — a practitioner tasked with "write the IQ/OQ/PQ protocol and validation master plan for a new fill-finish line, or decide whether a process change requires revalidation" would get zero applicable guidance from manufacturing-engineer's framework (no DQ/IQ/OQ/PQ staging, no three-stage FDA process-validation model, no revalidation-trigger heuristics, no validation master plan artifact) — a different set of decisions and tools, not just less depth on the same ones. That satisfies the granularity/counterfactual/non-derivability tests for a new leaf, with manufacturing-engineer as the natural parent (same 17-2112.xx family, adjacent process-engineering domain, and the one role a Validation Engineer hands qualified fixtures/processes off to or receives them from).

Slug 'validation-engineer' follows existing naming convention (bare occupation title, singular/kebab-case, matches sibling 'manufacturing-engineer', 'industrial-engineer') and is unused in roles/.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `validation-engineer` role mapped to O*NET 17-2112.02, with a full SKILL profile and reference docs, and updates counts/roadmap to include it. This expands the engineering domain with clear guidance for IQ/OQ/PQ, PPQ, GAMP 5 scoping, CSA vs CSV, and PDE/HBEL-based cleaning limits.

- **New Features**
  - Added `roles/validation-engineer/` with SKILL, and reference docs: `playbook.md`, `red-flags.md`, `vocabulary.md`.
  - Registered the role in `data/roles.json` (spec 2, category `engineering`, US jurisdiction) and linked it in the ROADMAP under 17-2112.02.
  - Updated README/ROADMAP counts: roles to 533, O*NET-mapped to 523 (51.5% coverage), engineering to 80; Architecture & Engineering drafted to 47/59.

<sup>Written for commit 009ec6a7a1be76bedf90fd7e1027e6bd0a0fee47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

