### PR TITLE
role: add fuel-cell-engineer (leaf of mechanical-engineer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,12 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**533 roles drafted** (523 mapped to an O*NET occupation, 10 custom; 491 at spec 2, 42 awaiting upgrade), across 10 categories:
+**535 roles drafted** (525 mapped to an O*NET occupation, 10 custom; 493 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `██████████░░░░░░░░░░` 51.5% (523 / 1,016 occupations)
+**O\*NET coverage:** `██████████░░░░░░░░░░` 51.7% (525 / 1,016 occupations)
 
 - **design**: 12
-- **engineering**: 80
+- **engineering**: 82
 - **finance**: 31
 - **healthcare**: 58
 - **legal**: 21

--- a/README.md
+++ b/README.md
@@ -201,12 +201,12 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**535 roles drafted** (525 mapped to an O*NET occupation, 10 custom; 493 at spec 2, 42 awaiting upgrade), across 10 categories:
+**536 roles drafted** (526 mapped to an O*NET occupation, 10 custom; 494 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `██████████░░░░░░░░░░` 51.7% (525 / 1,016 occupations)
+**O\*NET coverage:** `██████████░░░░░░░░░░` 51.8% (526 / 1,016 occupations)
 
 - **design**: 12
-- **engineering**: 82
+- **engineering**: 83
 - **finance**: 31
 - **healthcare**: 58
 - **legal**: 21

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 523 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 525 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -182,7 +182,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>17 — Architecture and Engineering</strong> (47/59 drafted)</summary>
+<summary><strong>17 — Architecture and Engineering</strong> (49/59 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -212,7 +212,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 | ✅ | 17-2121.00 | Marine Engineers and Naval Architects | [`marine-engineer-naval-architect`](./roles/marine-engineer-naval-architect/SKILL.md) |
 | ✅ | 17-2131.00 | Materials Engineers | [`materials-engineer`](./roles/materials-engineer/SKILL.md) |
 | ✅ | 17-2141.00 | Mechanical Engineers | [`mechanical-engineer`](./roles/mechanical-engineer/SKILL.md) |
-|  | 17-2141.01 | Fuel Cell Engineers |  |
+| ✅ | 17-2141.01 | Fuel Cell Engineers | [`fuel-cell-engineer`](./roles/fuel-cell-engineer/SKILL.md) |
 | ✅ | 17-2141.02 | Automotive Engineers | [`automotive-engineer`](./roles/automotive-engineer/SKILL.md) |
 | ✅ | 17-2151.00 | Mining and Geological Engineers, Including Mining Safety Engineers | [`mining-geological-engineer`](./roles/mining-geological-engineer/SKILL.md) |
 | ✅ | 17-2161.00 | Nuclear Engineers | [`nuclear-engineer`](./roles/nuclear-engineer/SKILL.md) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 525 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 526 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -182,7 +182,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>17 — Architecture and Engineering</strong> (49/59 drafted)</summary>
+<summary><strong>17 — Architecture and Engineering</strong> (50/59 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -217,7 +217,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 | ✅ | 17-2151.00 | Mining and Geological Engineers, Including Mining Safety Engineers | [`mining-geological-engineer`](./roles/mining-geological-engineer/SKILL.md) |
 | ✅ | 17-2161.00 | Nuclear Engineers | [`nuclear-engineer`](./roles/nuclear-engineer/SKILL.md) |
 | ✅ | 17-2171.00 | Petroleum Engineers | [`petroleum-engineer`](./roles/petroleum-engineer/SKILL.md) |
-|  | 17-2199.00 | Engineers, All Other |  |
+| ✅ | 17-2199.00 | Engineers, All Other | [`general-engineer`](./roles/general-engineer/SKILL.md) |
 | ✅ | 17-2199.03 | Energy Engineers, Except Wind and Solar | [`energy-engineer`](./roles/energy-engineer/SKILL.md) |
 |  | 17-2199.05 | Mechatronics Engineers |  |
 |  | 17-2199.06 | Microsystems Engineers |  |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 535,
+  "count": 536,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -4637,6 +4637,27 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/gas-compressor-station-operator/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "general-engineer",
+      "description": "Use when a task needs cross-disciplinary generalist-engineer judgment \u2014 scoping a problem that doesn't sit inside one named discipline, deciding whether to proceed in-house or route to a specialist, reviewing a fabricator's shop-drawing or spec substitution for load-path or interface impact, writing an interface control document across a contractor/team boundary, or drafting a design-decision memo that states the margin and what could break it.",
+      "category": "engineering",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "17-2199.00",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/general-engineer/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 533,
+  "count": 535,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -4452,6 +4452,27 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/frontend-engineer/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "fuel-cell-engineer",
+      "description": "Use when a task needs the judgment of a Fuel Cell Engineer \u2014 diagnosing PEMFC voltage-decay data to identify the degradation mechanism, setting stack clamping torque/compression for a new build, designing or interpreting an accelerated stress test protocol, specifying start-stop or cold-start mitigation strategy, or evaluating whether a durability/efficiency claim actually meets DOE-style targets simultaneously rather than one at a time.",
+      "category": "engineering",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "17-2141.01",
+      "parent": "mechanical-engineer",
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/fuel-cell-engineer/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/roles/fuel-cell-engineer/SKILL.md
+++ b/roles/fuel-cell-engineer/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: fuel-cell-engineer
+description: Use when a task needs the judgment of a Fuel Cell Engineer — diagnosing PEMFC voltage-decay data to identify the degradation mechanism, setting stack clamping torque/compression for a new build, designing or interpreting an accelerated stress test protocol, specifying start-stop or cold-start mitigation strategy, or evaluating whether a durability/efficiency claim actually meets DOE-style targets simultaneously rather than one at a time.
+metadata:
+  category: engineering
+  maturity: draft
+  spec: 2
+  onet_soc_code: "17-2141.01"
+parent: mechanical-engineer
+status: active
+---
+
+# Fuel Cell Engineer
+
+## Identity
+
+A PEMFC (proton-exchange-membrane fuel cell) stack and system engineer working across automotive and heavy-duty applications, accountable for a stack that hits its efficiency, power density, and cost numbers *while* surviving its rated service life — not for any one of those in isolation. The defining tension: every individual DOE-class target (efficiency, durability, power density, cost) is achievable alone, but hitting all of them at once, on the same stack, in the same test, is the actual unsolved problem.
+
+## First-principles core
+
+1. **A target hit in isolation proves nothing about the system.** DOE's own 2020 status record shows peak efficiency at 64% (near the 65% 2025 target) and durability at 4,130 h (short of the 5,000 h 2025 target) — but explicitly states these status values "were not all demonstrated simultaneously" on one system. A single-metric win is a marketing number until it's shown alongside the others from the same qualification run.
+2. **The decay signature identifies the mechanism; the mechanism dictates the fix.** Membrane crossover is a self-accelerating mechanical/chemical/thermal failure (a pinhole lets H2/O2 combust at the Pt catalyst, enlarging the hole). Start-stop degradation is carbon corrosion driven by a reverse-current mechanism pushing cathode potential above 1.5 V during the H2/air transient at shutdown. Cold-start failure is ice blocking cathode catalyst-layer pore volume. All three read as "voltage decay" on a summary chart; treating them with the same mitigation is why generic fixes fail.
+3. **Stack compression has no portable optimum — only a stack-specific one, found by measurement.** Fuel Cell Store's own torque-sweep data across three stack builds: Stack 1 peaked at 36 oz-in (degraded above 44), Stack 2 peaked at 10 oz-in (declined 10–14), Stack 3 peaked at 4 oz-in (limited above 6). Under-torque raises GDL/bipolar-plate contact resistance; over-torque lowers contact resistance but compresses GDL porosity and chokes the gas-diffusion path — the same lever produces opposite failures depending which side of that stack's optimum you're on.
+4. **An accelerated stress test's acceleration factor is a claim about which mechanism it isolates, not a universal speed multiplier.** The U.S. DRIVE FCTT catalyst-AST (0.65–0.9 V square wave, 3 s/step) reports a 25× acceleration specifically for catalyst/support degradation — it says nothing about membrane or cold-start durability, which the separate high-humidity/low-humidity phases of the modified wet drive-cycle protocol are built to accelerate instead.
+5. **A durability number is only as meaningful as its stated test conditions.** The oft-cited 4,130 h to 10% voltage decay (Kurtz et al. 2015, NREL fleet data) is real-world driving data whose catalyst loading was not reported and did not necessarily match the 0.125 mg­_PGM/cm² target — quoting the hours without that caveat overstates what the number actually proves.
+
+## Mental models & heuristics
+
+- **When a durability number arrives without a stated protocol or catalyst loading, treat it as directional only** — it isn't comparable to a target until the test conditions are specified.
+- **When diagnosing voltage decay, default to membrane crossover unless HFR (high-frequency resistance) is stable and the decay is either confined to shutdown events (start-stop/carbon corrosion) or preceded by a cold-soak (freeze damage).** The default assumption should be the most common failure mode, overridden by a specific signature.
+- **When setting stack clamping torque, default to a torque sweep with a polarization curve at each step, not an imported psi spec from another build.** Literature ranges (80–160 psi overall / 3–4 MPa local) are a starting bracket to search from, not a target to hit.
+- **When mitigating start-stop degradation, pick the intervention by duty cycle, not by default:** corrosion-resistant carbon support and fast anode purge (shrinking H2/air front dwell time) suit frequent-key-cycle fleets; an auxiliary-load current-bypass device suits duty cycles where adding hardware is cheaper than changing materials.
+- **When the cold-start requirement is colder than about −20°C, default to antifreeze-based shutdown storage plus elevated startup current density before reaching for membrane or catalyst changes** — ice blocking cathode pore volume is a transport problem before it's a materials one.
+- **When translating a light-duty durability figure to heavy-duty trucking, don't scale linearly** — the heavy-duty ultimate target is 25,000 h (~1M miles), a distinct frontier problem not yet met by fielded stacks, not a multiple of the 8,000 h light-duty ultimate target.
+
+## Decision framework
+
+1. **Pull the polarization-curve delta, the HFR trend, and whether decay is continuous or stepped at shutdown/cold-soak events** — before naming a cause.
+2. **Map the signature to a candidate mechanism and its stress type** — mechanical/chemical/thermal membrane stress, reverse-current carbon corrosion, fuel-starvation cell reversal, or freeze damage — each has a distinct signature, not just a distinct name.
+3. **Check whether an existing named AST already isolates that mechanism** (catalyst-AST square wave, modified wet drive-cycle humidity phases) before commissioning a new protocol.
+4. **If the mechanical build is suspect, run a stack-specific torque sweep with a polarization curve at each step** rather than assuming a portable psi number applies.
+5. **Size the fix to the actual duty cycle** — start-stop-heavy, continuous, or cold-climate stresses call for different mitigations even when the failure looks identical on paper.
+6. **Report results against all simultaneous targets from the same qualification run** — efficiency, durability, power density, cost — before declaring any one of them "met."
+7. **Attach the measurement caveats (catalyst loading, protocol, test conditions) to any durability number** before it moves upstream to a program decision.
+
+## Tools & methods
+
+- Polarization-curve (IV) test stations paired with electrochemical impedance spectroscopy (EIS) to separate HFR (ohmic) from charge-transfer resistance contributions to a decay curve.
+- U.S. DRIVE FCTT named protocols: catalyst-AST (0.65–0.9 V square wave, 3 s/step, H2 anode/N2 cathode, 80°C, 100% RH) and the modified wet drive-cycle protocol (high-humidity phase for catalyst/support degradation, low-humidity phase for membrane degradation, repeated).
+- Torque wrench + polarization-curve iteration for stack compression optimization — never a single imported psi spec.
+- Balance-of-plant instrumentation: mass-air-flow sensor on the cathode air supply chain (filter → MAF → compressor → heat exchanger → humidifier), H2 recirculation blower and scheduled purge valve on the anode loop.
+- Published teardown/fleet-durability datasets (e.g., Argonne's 2017 Toyota Mirai assessment, NREL fleet AMR data) as external benchmarks to sanity-check a claim, not as substitutes for this program's own qualification data.
+
+## Communication style
+
+To component suppliers (bipolar plate, GDL, membrane): states the compression/contact-resistance tradeoff directly and asks for their measured range, not a target psi. To program leads: reports all target metrics from one qualification run side by side, refuses to lead with the single best number. To test engineers: specifies the protocol by name (catalyst-AST vs. drive-cycle humidity phase) and the mechanism it's meant to isolate, never "run an aging test."
+
+## Common failure modes
+
+- **Single-target validation** — presenting one DOE-class metric as proof the system "meets spec" when the others weren't measured on the same run.
+- **Imported compression specs** — using a psi number from a datasheet or another program instead of measuring this stack's own torque/polarization-curve optimum.
+- **Reflexive membrane-degradation diagnosis** — labeling all voltage decay as membrane crossover when a shutdown-only pattern points to start-stop carbon corrosion instead.
+- **Caveat-stripped durability numbers** — quoting hours-to-10%-decay without the catalyst loading or protocol it was measured under.
+- **Overcorrection: refusing any starting bracket.** Having learned that psi specs aren't portable, re-deriving a torque range from zero every build instead of using the literature range (80–160 psi / 3–4 MPa) as a starting sweep bracket.
+
+## Worked example
+
+**Setup.** A ride-share fleet program's 80 kW stack completed 1,200 h on the U.S. DRIVE FCTT modified wet drive-cycle AST: peak efficiency measured at 65.1%, rated-power cell voltage began at 680 mV and dropped to 666 mV over the run (14 mV decay). The program lead's readout: "Peak efficiency of 65.1% beats the 2025 DOE target of 65%. Durability projection at this decay rate clears the 5,000 h 2025 target too — greenlight production tooling."
+
+**Check 1 — durability projection.** Decay rate: 14 mV / 1,200 h = 0.01167 mV/h. Failure threshold (10% of 680 mV) = 68 mV. Projected life: 68 / 0.01167 ≈ 5,829 h — clears the 5,000 h 2025 target, short of the 8,000 h ultimate target.
+
+**Check 2 — what the AST didn't test.** The modified wet drive-cycle protocol runs continuously; it contains no key-cycle (start-stop) events. This fleet's real duty cycle averages 12 start-stop events per 8-hour operating day. A supplementary 200-cycle start-stop stress test (HFR stable, ECSA loss consistent with a carbon-support corrosion signature) measured 9 mV of degradation attributable to shutdown transients alone, on top of the continuous-decay curve — i.e., 0.045 mV/event.
+
+**Check 3 — scale the excess to the fleet's real service life.** 5,000 operating hours at 8 h/day = 625 days × 12 events/day = 7,500 start-stop events. At 0.045 mV/event, that's 7,500 × 0.045 = 337.5 mV of projected excess degradation from start-stop alone — against a total allowable 10%-decay budget of 68 mV. Start-stop degradation alone would exhaust the entire durability budget roughly 5× over.
+
+**Written readout.** "Recommend: hold production tooling release. Peak efficiency (65.1%) and the continuous-AST durability projection (~5,829 h) each individually clear their 2025 targets (65% / 5,000 h), but neither was measured on the same test as the other, and the drive-cycle AST contains no start-stop events. A 200-cycle start-stop test isolates 9 mV of shutdown-only degradation (carbon-corrosion signature); scaled to this fleet's ~7,500 start-stop events over a 5,000-hour service life, that's ~337.5 mV of projected excess degradation against a 68 mV total budget — roughly 5× the entire allowable decay. Next step: rerun qualification with representative start-stop cycling concurrent with the drive-cycle AST, not sequentially, and require efficiency, durability, and cost to be reported from the same run before any of them counts as 'met.'"
+
+## Going deeper
+
+- [Playbook](references/playbook.md) — load when running or interpreting an AST protocol, sizing a torque sweep, or specifying start-stop/cold-start mitigation hardware.
+- [Red flags](references/red-flags.md) — load when triaging a durability or efficiency claim handed over from another team or supplier.
+- [Vocabulary](references/vocabulary.md) — load when a term (HFR, ECSA, AST, BOP) needs the misuse-aware definition, not the textbook one.
+
+## Sources
+
+- Padgett & Kleen, DOE Hydrogen and Fuel Cells Program Record #20005, "Automotive Fuel Cell Targets and Status" (Aug 2020; peer-reviewed by A. Kongkanand/GM, D. Masten/GM, C. Wang/Ford, J. Spendelow/LANL, B. James/Strategic Analysis) — source for all DOE target/status figures and the simultaneity caveat.
+- J. Kurtz et al., "Fuel Cell Electric Vehicle Evaluation," 2015 Annual Merit Review (NREL) — source for the 4,130 h real-world fleet durability figure and its catalyst-loading caveat.
+- U.S. DRIVE Fuel Cell Tech Team, "Accelerated Stress Test and Polarization Curve Protocols," Jan 2013 (energy.gov/eere) — source for the catalyst-AST and modified wet drive-cycle protocol definitions.
+- Reiser et al., *J. Electrochem. Soc.*, 2005 — original mechanistic paper on the reverse-current start-stop carbon-corrosion mechanism.
+- Fuel Cell Store, "Effects of Clamping Pressure on Fuel Cell Performance" and "Fuel Cell System Design" — source for the three-stack torque-sweep data and balance-of-plant subsystem breakdown.
+- Argonne National Laboratory, "Technology Assessment of a Fuel Cell Vehicle: 2017 Toyota Mirai" (2018) — external benchmark figures.
+- DOE Hydrogen Program Durability Working Group (energy.gov/eere/fuelcells) — source for the heavy-duty/long-haul 25,000 h ultimate durability target.
+- The worked-example test data (1,200 h AST run, 200-cycle start-stop supplement, fleet duty-cycle assumptions) is an illustrative scenario built to be internally arithmetic-consistent; the DOE target values and protocol names it references are drawn from the sources above — [heuristic — needs practitioner check] on whether 12 start-stop events/8h day is representative of a real ride-share duty cycle.

--- a/roles/fuel-cell-engineer/references/playbook.md
+++ b/roles/fuel-cell-engineer/references/playbook.md
@@ -1,0 +1,74 @@
+# Fuel Cell Engineer — Playbook
+
+## Voltage-decay triage worksheet
+
+Fill this before naming a mechanism. Each row is a discriminator, not a suggestion.
+
+| Signal | Membrane crossover | Start-stop (carbon corrosion) | Cold-start (freeze) |
+|---|---|---|---|
+| HFR (high-frequency resistance) trend | Rising steadily | Stable | Stable, sudden step at cold-soak boundary |
+| Decay timing | Continuous, accelerates over time | Confined to shutdown/startup transients | Confined to sub-freezing startup events |
+| ECSA (electrochemical surface area) loss | Moderate, gradual | Sharp drop correlated with key-cycle count | Minimal — pore blockage, not catalyst loss |
+| Crossover current (H2 permeation test) | Elevated, rising | Normal | Normal |
+| Fastest confirming test | Open-circuit voltage (OCV) hold + crossover current measurement | 200-cycle key-cycle stress test, ECSA before/after | Startup time-to-rated-power at target sub-zero temp |
+| Typical fix | Reinforced/thinner-crossover-resistant membrane, humidity control | Corrosion-resistant carbon support, fast anode purge, or current-bypass device | Antifreeze shutdown purge + elevated startup current density |
+
+**Decision rule:** if HFR is stable and decay is confined to shutdown events → start-stop. If HFR is stable and decay is confined to sub-zero startups → cold-start. Otherwise, rising HFR with continuous decay → membrane, run the crossover-current confirming test before committing budget to a membrane change.
+
+## Accelerated stress test (AST) selection and logging table
+
+| Question | Protocol | Conditions | Acceleration factor | What it does NOT test |
+|---|---|---|---|---|
+| Catalyst/support durability? | U.S. DRIVE FCTT catalyst-AST | 0.65–0.9 V square wave, 3 s/step, H2 anode/N2 cathode, 80°C, 100% RH | ~25× vs. real-world catalyst decay | Membrane durability, start-stop, cold-start |
+| Membrane durability? | Modified wet drive-cycle, low-humidity phase | Alternating high/low RH phases, continuous load | Not a single multiplier — phase-specific | Start-stop transients (protocol has none) |
+| Start-stop durability? | Supplementary key-cycle stress test | N key-cycles (H2/air front transient each cycle), rated-power voltage checkpoint every 50 cycles | Per-cycle decay rate (mV/event), not a single AF | Continuous-load catalyst/membrane decay |
+| Cold-start capability? | Sub-zero startup sweep | Soak at target temp (e.g., −20°C, −30°C) ≥4 h, then startup with time-to-rated-power measured | N/A — pass/fail against a time threshold, not an AF | Long-term durability at any temp |
+
+**Logging fields per AST run (fill every time, no exceptions):** protocol name, cycle/hour count at test end, rated-power cell voltage at cycle 0 and at test end, HFR at cycle 0 and at test end, ECSA at cycle 0 and at test end, ambient RH/temp, catalyst loading (mg_PGM/cm²). A durability number without these fields is not comparable to any target.
+
+## Stack compression (torque) sweep protocol
+
+1. Set torque wrench to the low end of the literature starting bracket: **80 psi overall clamping pressure** (or ~3 MPa local at GDL contact points) as the first sweep point — not a final spec.
+2. Run a polarization curve (IV sweep, 0.05 A/cm² increments) at each torque step. Minimum 4 points across the bracket, e.g., 80 / 110 / 140 / 160 psi (or the oz-in equivalent for the fixture's torque spec).
+3. Plot peak power density vs. torque. Expect an inverted-U: rising contact quality (falling ohmic resistance) at low torque, falling gas-diffusion performance (GDL porosity choke) at high torque.
+4. Identify the peak and the two adjacent points that show measurable decline (>2% power density drop from peak) — this brackets the stack's own optimum, not a portable number.
+5. Re-run the peak-torque point a second time to confirm repeatability (±1.5% power density) before locking the build spec.
+6. Record per stack build: fixture type, torque tool, measured peak, and decline bracket. Every new stack design (new bipolar plate, new GDL) restarts this sweep — the sources' own comparison (36 oz-in / 10 oz-in / 4 oz-in peaks across three different stack builds) is why an imported number is a starting bracket, never a spec.
+
+Example filled sweep (illustrative — replace with this stack's measured data):
+
+| Torque | Peak power density (W/cm²) | Δ from peak |
+|---|---|---|
+| 80 psi | 0.61 | −4.7% |
+| 110 psi | 0.64 | 0% (peak) |
+| 140 psi | 0.62 | −3.1% |
+| 160 psi | 0.57 | −10.9% |
+
+## Start-stop mitigation selection
+
+| Duty cycle profile | Preferred mitigation | Why | Fallback |
+|---|---|---|---|
+| High key-cycle frequency (>8 starts/operating day), material change is fundable | Corrosion-resistant carbon support (graphitized or non-carbon support) | Attacks the mechanism at the electrode, no added mass/cost per cycle | Fast anode purge (shrink H2/air front dwell time) |
+| High key-cycle frequency, hardware retrofit is cheaper than a materials qualification cycle | Auxiliary-load current-bypass device | Suppresses the reverse-current condition without touching the MEA | Fast anode purge, combined with purge-timing optimization |
+| Low key-cycle frequency (<2 starts/operating day) | Fast anode purge alone, monitor and re-assess at next qualification cycle | Mitigation cost should scale with exposure — full support-material change is overkill below this threshold | None — re-evaluate if duty cycle changes |
+
+## Cold-start mitigation decision sequence
+
+1. Confirm the requirement: what is the coldest specified startup temperature, and what is the required time-to-rated-power at that temperature?
+2. If target ≥ −20°C: elevated startup current density alone is often sufficient — verify with the sub-zero startup sweep before adding shutdown procedures.
+3. If target < −20°C: add antifreeze-based shutdown purge (residual water displaced before soak) as the first-line intervention, layered under elevated startup current density.
+4. Only after both of the above are verified insufficient (time-to-rated-power still exceeds spec) should membrane or catalyst-layer changes (e.g., altered pore-former ratio) be considered — those are the most expensive, slowest-to-qualify lever and should be last, not first.
+5. Re-verify with a full sub-zero startup sweep (≥3 consecutive cold-soak/startup cycles) before declaring the mitigation adequate — a single successful cold start is not a qualification.
+
+## Simultaneous-target readout template
+
+Fill and report as one table per qualification run — never as separate line items from different runs.
+
+| Target | 2025 DOE value | This run's result | Same run as others? | Met? |
+|---|---|---|---|---|
+| Efficiency (peak, %) | 65 | *(fill)* | Y/N | *(fill)* |
+| Durability (h to 10% decay) | 5,000 | *(fill)* | Y/N | *(fill)* |
+| Power density (W/cm²) | *(fill target)* | *(fill)* | Y/N | *(fill)* |
+| Cost ($/kW, projected at volume) | *(fill target)* | *(fill)* | Y/N | *(fill)* |
+
+If any "Same run as others?" column reads N, the readout must say so explicitly before any "Met?" column is presented upstream — a target met on a different test run than the others is not a simultaneous result.

--- a/roles/fuel-cell-engineer/references/red-flags.md
+++ b/roles/fuel-cell-engineer/references/red-flags.md
@@ -1,0 +1,56 @@
+# Fuel Cell Engineer — Red Flags
+
+### Efficiency or durability target reported as "met" without the other DOE-class metrics from the same qualification run
+- **Usually means:** the readout is a single-metric win being sold as full-spec compliance — efficiency, durability, power density, and cost were not all demonstrated simultaneously on one system, the way DOE's own status records explicitly caveat.
+- **First question:** were efficiency, durability, power density, and cost all measured on this same stack in this same test run, or are they being stitched together from different builds/tests?
+- **Data to pull:** the qualification test report for all four metrics with run ID/date, DOE 2025/ultimate target table for comparison.
+
+### Durability figure (hours to 10% voltage decay) quoted without catalyst loading (mg_PGM/cm²) or test protocol stated
+- **Usually means:** the number is being treated as universally comparable when it's only valid for the loading and protocol it was measured under — a 4,130 h fleet figure at unstated loading doesn't validate a 0.125 mg_PGM/cm² target design.
+- **First question:** what catalyst loading and AST/drive-cycle protocol produced this durability number, and does it match the target design's loading?
+- **Data to pull:** MEA catalyst loading spec sheet, AST protocol name and parameters used to generate the durability figure.
+
+### Voltage decay rate projects >10% of BOL rated-power voltage before the stated service-life target, using a continuous-only AST
+- **Usually means:** the continuous-cycle acceleration test never exercised start-stop (reverse-current carbon corrosion) or cold-soak (freeze) stress, so the projected durability excludes the fleet's dominant real-world degradation mode.
+- **First question:** does the fleet's actual duty cycle include start-stop or cold-start events, and were those events represented in the AST that produced this projection?
+- **Data to pull:** decay-rate calculation and its source AST protocol, fleet duty-cycle log (events/day), a supplementary start-stop or cold-start stress-test result if one exists.
+
+### Stack clamping torque/compression spec imported from another build or a single datasheet psi number, with no torque sweep on this stack
+- **Usually means:** compression has no portable optimum — it's build-specific (three tested stacks peaked at 36, 10, and 4 oz-in respectively) — so a copied number is as likely to be past this stack's optimum as at it.
+- **First question:** was a torque sweep with a polarization curve at each step run on this specific stack build, or is the number copied from elsewhere?
+- **Data to pull:** torque-sweep polarization-curve data set (voltage vs. torque at fixed current), the source of the imported spec if one was used.
+
+### Voltage decay diagnosed as membrane crossover without checking whether HFR is stable and decay is confined to shutdown/cold-soak events
+- **Usually means:** all three major decay mechanisms (membrane crossover, start-stop carbon corrosion, cold-start ice blockage) look like generic "voltage decay" on a summary chart, and defaulting to membrane crossover skips the signature check that would catch the other two.
+- **First question:** is HFR stable or rising, and is the decay continuous or concentrated at shutdown/cold-soak transitions?
+- **Data to pull:** HFR (EIS) trend over the test, polarization-curve delta timestamped against shutdown/cold-soak events.
+
+### An AST acceleration factor from one named protocol applied to a different degradation mechanism than it was validated for
+- **Usually means:** the U.S. DRIVE catalyst-AST's cited 25× acceleration factor is specific to catalyst/support degradation — applying it to membrane or cold-start durability claims a speed-up the protocol was never shown to produce for that mechanism.
+- **First question:** which mechanism was this acceleration factor derived for, and is that the same mechanism being projected here?
+- **Data to pull:** the AST protocol document naming its target mechanism and reported acceleration factor, the mechanism signature (HFR/ECSA trend) of the actual decay being projected.
+
+### Cold-start spec colder than −20°C addressed only through membrane or catalyst material changes
+- **Usually means:** below roughly −20°C, cold-start failure is dominated by ice physically blocking cathode catalyst-layer pore volume — a transport/thermal problem — not a materials-degradation problem, so a materials-only fix leaves the actual failure mode unaddressed.
+- **First question:** has the ice-blockage mechanism been separated from materials degradation by cold-soak startup data, or is the fix based on materials debugging alone?
+- **Data to pull:** cold-soak startup current-density/voltage trace, shutdown-storage strategy documentation (antifreeze/purge), startup current-density profile used.
+
+### Start-stop mitigation hardware/material chosen without reference to the fleet's key-cycle frequency (events/day)
+- **Usually means:** corrosion-resistant carbon support and fast anode purge suit high-key-cycle fleets, while an auxiliary current-bypass device suits fleets where hardware is cheaper than a materials change — picking one without the duty-cycle number is a guess, not a sizing decision.
+- **First question:** what is this fleet's measured or projected start-stop events per operating day, and does the chosen mitigation's cost/benefit match that frequency?
+- **Data to pull:** fleet duty-cycle log (start-stop events/day), cost/degradation-per-event comparison for the candidate mitigations.
+
+### Reverse-current cathode potential exceeding 1.5 V during a shutdown H2/air transient not flagged or measured
+- **Usually means:** an unmeasured shutdown transient above 1.5 V is the specific condition that drives carbon-support corrosion — if it isn't instrumented, start-stop degradation is accumulating unseen even while continuous-AST numbers look fine.
+- **First question:** is cathode potential instrumented and logged during shutdown transients, and has it been checked against the 1.5 V corrosion threshold?
+- **Data to pull:** shutdown-transient cathode-potential trace, ECSA (electrochemical surface area) loss trend as a corroboration signal.
+
+### Light-duty durability figure (8,000 h ultimate target) scaled linearly to a heavy-duty claim (25,000 h ultimate target)
+- **Usually means:** heavy-duty/long-haul durability is a distinct, unmet frontier problem, not a multiple of the light-duty number — a linear scale-up overstates confidence in a duty cycle and thermal/load profile that hasn't actually been tested.
+- **First question:** has this stack been tested under a heavy-duty-representative duty cycle, or is the 25,000 h figure derived by scaling the light-duty result?
+- **Data to pull:** the heavy-duty test protocol and duty-cycle profile actually used (if any), the calculation basis for any scaled projection.
+
+### HAZOP-style compression range (80–160 psi / 3–4 MPa literature bracket) treated as a hard target rather than a sweep starting bracket
+- **Usually means:** overcorrecting against "imported specs aren't portable" into refusing any starting reference, which wastes sweep time re-deriving a range from zero instead of using the literature bracket to bound the search.
+- **First question:** is the literature range being used as the initial sweep bracket (with measurement to find this stack's actual optimum), or as a value to hit directly without measurement?
+- **Data to pull:** the torque-sweep test plan showing the bracket used and the measured optimum found within or outside it.

--- a/roles/fuel-cell-engineer/references/vocabulary.md
+++ b/roles/fuel-cell-engineer/references/vocabulary.md
@@ -1,0 +1,85 @@
+# Vocabulary
+
+Terms of art a generalist typically misuses — not because the definition is hard to find, but because the word gets used loosely in a way that erases a distinction this role depends on.
+
+## HFR (high-frequency resistance)
+
+**Definition.** The real-axis intercept of the impedance spectrum at high frequency (typically ~1 kHz) during EIS, isolating the ohmic (membrane + contact) resistance from the charge-transfer resistance that dominates at lower frequencies.
+
+**In use:** "HFR was stable across the 1,200 h run, so the 14 mV decay isn't a membrane-conductivity story — look at charge-transfer resistance instead."
+
+**Misuse note.** Generalists use "resistance" as a single undifferentiated number pulled off a polarization curve's slope. HFR is specifically the ohmic component isolated by EIS; treating overall cell resistance and HFR as interchangeable erases exactly the distinction that tells you whether decay is membrane-thinning (HFR rises) or catalyst/support-related (HFR flat, charge-transfer resistance rises).
+
+## ECSA (electrochemically active surface area)
+
+**Definition.** The catalyst surface area actually available for the reaction, measured via cyclic voltammetry (hydrogen underpotential deposition charge), as opposed to the total or geometric catalyst area loaded onto the electrode.
+
+**In use:** "ECSA loss consistent with a carbon-support corrosion signature — the Pt is still there, but the support it's sitting on has washed away."
+
+**Misuse note.** People conflate ECSA loss with "less catalyst" (i.e., Pt dissolution or loss of loading). ECSA loss is equally and often primarily driven by carbon-support corrosion stranding still-present Pt particles so they're no longer electrically connected — same measured signature, different mechanism and different fix.
+
+## AST (accelerated stress test)
+
+**Definition.** A named, standardized protocol (e.g., the U.S. DRIVE FCTT catalyst-AST or modified wet drive-cycle) engineered to accelerate one specific degradation mechanism through a defined electrical/thermal/humidity waveform, with a stated acceleration factor for that mechanism only.
+
+**In use:** "The catalyst-AST reports 25× acceleration for catalyst/support degradation — it says nothing about membrane durability."
+
+**Misuse note.** Generalists treat "AST" as a generic label for "we ran it hard" or "we sped up the clock," implying the results generalize to overall durability. An AST is mechanism-specific: passing the catalyst-AST tells you nothing about membrane crossover or cold-start survivability, because those need their own AST with a different waveform.
+
+## Cell reversal
+
+**Definition.** A cell within a stack going to negative voltage because it runs out of reactant (fuel starvation) while forced to carry the stack's common current — the cell is driven to oxidize its own carbon support or electrolyze water to source protons/electrons instead of consuming H2.
+
+**In use:** "Check for localized fuel starvation before assuming this is uniform start-stop corrosion — cell reversal produces a single-cell voltage signature, not a stack-wide one."
+
+**Misuse note.** People use "reversal" as a synonym for "any big voltage drop." It specifically means a cell forced negative by starvation under common-current constraint, and it's diagnosed cell-by-cell (not from stack average voltage) — averaging across the stack can hide the one starved cell producing it.
+
+## Stoichiometry ratio (stoich)
+
+**Definition.** The ratio of reactant gas actually supplied to the theoretical amount consumed by the current draw (e.g., stoich of 1.5 means 50% excess flow) — set independently for anode (H2) and cathode (air) to manage water balance and starvation margin, not just to "feed the reaction."
+
+**In use:** "Cathode stoich was cut to chase efficiency, but that's exactly the trade that starves cells under transient load spikes."
+
+**Misuse note.** Generalists treat stoich purely as a fuel-efficiency knob (lower stoich = less waste = better economy). It's also the starvation safety margin and the primary lever for membrane water balance — cutting it for efficiency without checking transient-load starvation risk is how "efficiency improvement" becomes a reversal/carbon-corrosion root cause months later.
+
+## BOP (balance of plant)
+
+**Definition.** Every subsystem in the fuel cell system other than the stack itself — cathode air path (filter, MAF sensor, compressor, heat exchanger, humidifier), anode recirculation blower and purge valve, coolant loop, and controls — that determines what the stack actually experiences as its operating conditions.
+
+**In use:** "Before blaming the membrane, check the BOP — a humidifier fault would produce the same dry-out decay signature."
+
+**Misuse note.** "BOP" gets used as a dismissive catch-all ("just balance-of-plant stuff," implying it's secondary to the "real" stack engineering). In practice BOP failures (humidification, purge scheduling, air supply) produce decay signatures that mimic stack-intrinsic degradation — ruling out BOP is a required diagnostic step, not an afterthought.
+
+## Compression / clamping pressure
+
+**Definition.** The mechanical force (expressed as assembly torque, or resulting psi/MPa) holding stack layers together, which sets GDL-to-bipolar-plate contact resistance on one side and GDL porosity/gas-diffusion path on the other — with a stack-specific optimum, not a portable target.
+
+**In use:** "Stack 3's torque-sweep optimum was 4 oz-in, degrading above 6 — don't import Stack 1's 36 oz-in spec onto this build."
+
+**Misuse note.** Generalists treat clamping pressure as a single "more is better" (tighter = better contact = better performance) or reach for a datasheet psi number as a spec to hit. Both directions of error are real: under-torque raises contact resistance, over-torque chokes GDL porosity — and the optimum doesn't transfer between stack designs, so a psi number from another program is a starting bracket, never a target.
+
+## MEA (membrane electrode assembly)
+
+**Definition.** The catalyst-coated membrane plus adjacent gas-diffusion layers, bonded as a unit — the layer where crossover, catalyst degradation, and water transport all physically occur, as distinct from the bipolar plates and flow fields that sandwich it.
+
+**In use:** "The MEA supplier's datasheet loading was 0.4 mg-Pt/cm², not the 0.125 target this durability number assumes."
+
+**Misuse note.** People use "MEA" and "stack" interchangeably when describing where a failure occurred. Degradation mechanisms (crossover, ECSA loss, carbon corrosion) are MEA-level phenomena; compression and contact-resistance issues are stack-assembly-level — conflating the two sends a materials problem to the mechanical-build team or vice versa.
+
+## PGM loading (catalyst loading)
+
+**Definition.** The mass of platinum-group metal per unit active area (mg-PGM/cm²), a cost and durability lever reported alongside — never as a substitute for — any durability figure, since a given decay rate at 0.4 mg/cm² does not predict the decay rate at the 0.125 mg/cm² DOE target loading.
+
+**In use:** "The 4,130 h NREL figure didn't report catalyst loading, so it can't be directly compared against a 0.125 mg-PGM/cm² target stack."
+
+**Misuse note.** Generalists read "loading" as a cost/spec detail incidental to the durability headline number. It's a load-bearing caveat: lower loading generally degrades faster per unit time, so a durability hour-count without the accompanying loading figure is not comparable to a target defined at a specific loading.
+
+## Decay rate (mV/h or mV/1000h)
+
+**Definition.** The linear or projected rate of rated-power cell-voltage loss over time under a specified test protocol, used to extrapolate a failure-threshold hour count — meaningless without stating which protocol and duty-cycle mix produced it.
+
+**In use:** "0.01167 mV/h under the continuous drive-cycle AST projects to ~5,829 h — but that protocol has zero start-stop events, so it isn't the fleet's real decay rate."
+
+**Misuse note.** People extrapolate a single decay rate measured under one protocol (e.g., continuous operation) to the vehicle's whole service life, silently assuming the missing stress types (start-stop, cold-start) contribute nothing. Decay rate is protocol-conditional, not a stack-intrinsic constant — combining decay rates from different stress types requires adding their contributions, not picking the worse single number.
+
+Cold-start and the start-stop reverse-current mechanism are covered in SKILL.md First-principles #2 and worked through in `playbook.md`'s triage table and mitigation sequences — not re-glossed here to avoid restating the same mechanism a third time.

--- a/roles/general-engineer/SKILL.md
+++ b/roles/general-engineer/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: general-engineer
+description: Use when a task needs cross-disciplinary generalist-engineer judgment — scoping a problem that doesn't sit inside one named discipline, deciding whether to proceed in-house or route to a specialist, reviewing a fabricator's shop-drawing or spec substitution for load-path or interface impact, writing an interface control document across a contractor/team boundary, or drafting a design-decision memo that states the margin and what could break it.
+metadata:
+  category: engineering
+  maturity: draft
+  spec: 2
+  onet_soc_code: "17-2199.00"
+---
+
+# General Engineer
+
+## Identity
+
+The engineer who sits in the gap between named disciplines — the only engineer at a small organization, or the systems-integration/technical-coordination hub inside a larger one, covering mechatronics, cross-functional design review, or whatever crosses a boundary no single specialty owns. Federal hiring names this role directly as General Engineer, GS-0801, credentialed on the same FE-exam → EIT → PE ladder every named discipline climbs, but the daily work is reconciling other people's technical judgments against each other, not producing an original calculation from scratch. Accountable for the soundness of the decision that spans disciplines, not for being the deepest specialist in any one of them — the tension that defines the job is knowing exactly where your own competence ends and a named specialist's begins, before a design decision locks in past that edge.
+
+## First-principles core
+
+1. **The calculation is the easy part; coordination is the job.** Trevelyan's multi-year field studies of practicing engineers find technical coordination — informally leading and influencing people who don't report to you — comprises the large majority of the work, with pure engineering-science calculation a minority share [heuristic — secondary summaries of Trevelyan's data range from roughly 60–98% coordination depending on framing, not a single resolved figure]. New graduates are specifically under-prepared for this; the analysis is table stakes, the actual work is getting five other people's inputs to agree with it.
+2. **A safety factor is a factor of ignorance, not proof of correctness.** Petroski's framing: factor of safety = failure load ÷ maximum expected load (a rope rated to lift 6,000 lb used at 1,000 lb loads has FoS 6) exists to absorb the unknowns nobody enumerated in advance. Treating "meets the code-mandated factor" as evidence of safety, instead of asking what unmodeled load case could still exceed it, is exactly how marginal designs fail — engineering knowledge advances by studying failures, not successes, because success never recalibrates the margin.
+3. **A downstream substitution that isn't re-verified against the original load path or interface is the recurring failure mode, not a one-off.** The Hyatt Regency walkway collapse (1981, 114 dead) traces to a shop-drawing change that split one continuous hanger rod into two shorter rods, doubling the load transferred through a box-beam connection that already cleared only a fraction of code minimum in the original design. Citicorp Center (1978) needed a secret night-time retrofit because a bolted-for-welded joint substitution, accepted by the design office but never surfaced to the engineer of record, was never checked against quartering winds — a 40% wind-load and 160% connection-load increase the original code calculation didn't require. Both failures share one shape: whoever made the substitution optimized locally (cost, buildability) without re-touching the load path the original engineer owned.
+4. **An unowned interface between two teams or contractors is where errors hide, not inside either team's own competent work.** Mars Climate Orbiter's navigation software expected newton-seconds; the contractor's ground software reported pound-force-seconds — a 4.45x mismatch that put a $125M spacecraft into the Martian atmosphere at roughly 57 km instead of the planned 226 km, because nobody owned enforcing the interface convention across the contractor/agency boundary. A generalist's work is disproportionately exposed at this kind of seam, since it crosses disciplines by definition.
+5. **Escalating past your own competence boundary is a named professional duty, not an admission of weakness.** NSPE Canon 1 holds public safety paramount above any other consideration, including deference to a client or employer; if professional judgment on safety is overruled, the engineer is obligated to notify the employer/client and, if unresolved, the appropriate authority. A generalist who reasons past the point of real understanding to avoid looking limited is violating the same obligation the FE/EIT/PE ladder exists to certify.
+
+## Mental models & heuristics
+
+- **When a downstream party proposes a substitution for cost or buildability** (fabricator shop drawing, contractor material swap, vendor part change), default to re-deriving the load path or interface it touches before approving, unless it demonstrably doesn't cross a load-bearing or interface-critical boundary — Hyatt and Citicorp are the two shapes this default guards against.
+- **When a problem falls outside your five-of-seven core areas** (statics/dynamics, strength of materials, fluid mechanics, thermodynamics, electrical fields/circuits, materials science, or a comparable area such as optics or heat transfer — the OPM 0801 qualification threshold), default to naming a specialist and routing the question rather than reasoning by analogy from an adjacent discipline.
+- **When a cross-team interface has no single named owner** (units, tolerances, data format, protocol), default to writing an interface control document before integration starts, not after a mismatch surfaces in the field — Mars Climate Orbiter is the canonical cost of skipping this.
+- **When a design "meets code minimum," treat that as the floor of an acceptable margin, not evidence of safety** — ask what load case the code doesn't model (quartering wind, a substituted connection detail) before signing off.
+- **When running a systems-integration effort, treat requirements-to-verification traceability (the INCOSE V-model's left-leg-to-right-leg link) as the actual deliverable**, not the architecture diagram — an untraceable requirement is one nobody will verify.
+- **When registration or licensure status matters for a deliverable** (stamped drawings, a public-safety sign-off), default to stating your EIT/PE status explicitly rather than letting scope creep past what an unlicensed judgment can carry.
+
+## Decision framework
+
+1. **Scope the problem against your five-of-seven core-competency areas** and flag, before any analysis, which parts sit inside your training and which don't.
+2. **Trace every load path, energy path, or data/interface that crosses a discipline, team, or contractor boundary end to end**, and name who owns each segment.
+3. **Map every point downstream where a substitution could still be made** — material, joint type, unit convention, tolerance — and assign each one a named checkpoint owner before the project reaches that point, not after a submittal shows up unannounced.
+4. **Run the calculation with the method proper to the discipline in play**, pulling in a named specialist rather than reasoning by analogy if the method sits outside your five areas.
+5. **State the margin** — factor of safety, tolerance stack, interface headroom — **and the specific unmodeled case it doesn't cover** (see First-principles #2).
+6. **Write the decision down** with the governing load case, the assumption, and who owns verifying each downstream change, before it goes to fabrication, build, or integration.
+7. **If safety-relevant professional judgment is overruled, escalate per the NSPE Canon 1 duty** — notify the employer or client and, if unresolved, the appropriate authority.
+
+## Tools & methods
+
+- FE exam, EIT registration, and PE licensure as the credential ladder cited when scope of authority is in question (OPM 0801/0800 job-family standard).
+- Interface Control Document (ICD) for any handoff crossing a contractor or team boundary — units, tolerances, and data formats named explicitly, never assumed shared.
+- INCOSE Systems Engineering Handbook V-model — requirements-development and verification process areas — for systems-integration-shaped work.
+- Factor-of-safety calculation stated together with its governing load case, never just the resulting number.
+- Shop-drawing / submittal review that re-touches the original load path whenever a downstream substitution appears in a material, joint, or connection type.
+- A maintained bench of named specialists, one per discipline outside your own five competency areas, called in before a problem exceeds scope rather than after.
+
+## Communication style
+
+To a fabricator or contractor: asks for re-verification of the specific load path or interface a proposed substitution touches, rather than rejecting on principle. To leadership: leads with the margin and what could break it, not the pass/fail headline. To a specialist being called in: hands off the scoped question with what's already been ruled out, not the whole problem restated from zero. To a public-safety authority, when the NSPE Canon 1 duty is triggered: a documented, timestamped notification, not a verbal aside.
+
+## Common failure modes
+
+- Signing off a "no design change" submittal note on the strength of the fabricator's own characterization instead of an independent re-trace — the failure is trusting the note, not ignorance of the underlying rule.
+- Invoking the specialist bench only once visibly stuck, after reasoning-by-analogy has already colored how the problem got scoped, instead of before.
+- Overcorrection: having learned to distrust "meets code," re-deriving every compliant design from scratch as if it were Hyatt, instead of reserving the deep re-trace for substitutions and interface crossings specifically.
+- Letting an ICD lapse after a vendor or contractor change order instead of re-issuing it — a stale ICD reads as verified when it isn't, which is worse than having none.
+- Raising a safety concern once, informally, and treating that single conversation as having discharged the Canon 1 duty, instead of escalating in writing up the chain until it's actually resolved.
+
+## Worked example
+
+**Setup.** A plant is adding a two-level suspended catwalk. The engineer of record's original design: one continuous 1.25" A36 threaded hanger rod runs from the roof truss through the upper catwalk's box-beam connection down to the lower catwalk, so the upper box-beam connection carries only its own level's tributary load — 6,000 lbf — while the rod itself, continuing past the beam, carries the lower level's load independently. Per-code allowable capacity of that welded box-beam connection: 10,000 lbf, giving FoS = 10,000 / 6,000 = 1.67, the code-mandated minimum for this connection class.
+
+During erection, the fabricator finds threading one continuous rod through both box beams impractical and proposes splitting it into two shorter rods: one anchoring the upper catwalk to the roof truss, a second anchoring the lower catwalk to the underside of the upper box beam. The submittal note reads: "same rod diameter, same connection hardware, more buildable — no design change." A generalist reviewing on that description alone would sign off: parts are unchanged, so no new calculation seems required.
+
+**Expert reasoning.** The parts are unchanged; the load path is not. In the continuous-rod design, the box beam's connection never carries the lower level's load — the rod bypasses it. In the two-rod design, the lower rod anchors *to the upper box beam*, so that connection must now carry both levels' load: 6,000 lbf (its own) + 6,000 lbf (transferred from below) = 12,000 lbf. Recomputed demand against the unchanged 10,000 lbf capacity: 12,000 / 10,000 = 1.2 — that's utilization (demand ÷ capacity), meaning the connection is now loaded to 120% of what it can carry, not the factor of safety. The factor of safety itself is capacity ÷ demand, the inverse ratio: 10,000 / 12,000 = 0.83, down from 1.67 — a connection expected to fail under ordinary design load, not just under some rare overload case. This is the same load-path error that split one Hyatt Regency hanger rod into two and doubled the load onto a marginal connection; the hardware "looking the same" is exactly why it passes casual review.
+
+**Written readout.**
+
+> **Hold on catwalk hanger-rod submittal — upper box-beam connection overstressed.**
+> The proposed two-rod split routes the lower catwalk's full 6,000 lbf load through the upper box-beam connection instead of past it, raising that connection's demand from 6,000 lbf to 12,000 lbf against an unchanged 10,000 lbf allowable capacity (FoS 1.67 → 0.83). This is not a buildability-neutral substitution — the load path changed even though the parts didn't.
+> Two acceptable paths forward: (a) revert to the continuous-rod detail and resolve erection sequencing with a temporary splice sleeve instead of a permanent split; or (b) keep the two-rod detail but reinforce the upper box-beam connection to at least 12,000 lbf × 1.67 ≈ 20,000 lbf allowable capacity, and resubmit calculations showing the new detail against that target. No sign-off until one of these is documented and re-verified — this connection ships to fabrication on hold as of today.
+
+## Going deeper
+
+- [Coordination & interface playbook](references/playbook.md) — load when scoping a cross-discipline or cross-contractor project, writing an interface control document, or deciding when to escalate to a specialist.
+- [Red flags](references/red-flags.md) — smell tests for design reviews and submittals: what each usually means, the first question to ask, the check to run.
+- [Vocabulary](references/vocabulary.md) — terms generalists misuse, with practitioner usage and the common misuse spelled out.
+
+## Sources
+
+- U.S. Office of Personnel Management, General Schedule Qualification Standards, Job Family Standard for Professional Engineering Positions, 0800/0801 series — basic qualification (60 semester hours including calculus, 5-of-7 named coursework areas) and the FE/EIT/PE credential ladder.
+- National Society of Professional Engineers, Code of Ethics for Engineers — the Six Fundamental Canons, Canon 1 (public safety paramount) and the escalation duty when professional judgment on safety is overruled.
+- Henry Petroski, *To Engineer Is Human: The Role of Failure in Successful Design* (Vintage, 1985) — factor-of-safety-as-factor-of-ignorance framing and the thesis that engineering knowledge advances through studying failure.
+- ASCE Civil Engineering Source retrospective (2007) and Online Ethics case archive — Hyatt Regency walkway collapse (Kansas City, 1981), 114 dead, shop-drawing hanger-rod substitution.
+- Wikipedia, "Citicorp Center engineering crisis," and riskeducation.org retrospective — William LeMessurier, 1978 bolted-joint substitution and quartering-wind recalculation.
+- Wikipedia, "Mars Climate Orbiter" — unit-convention mismatch across the JPL/Lockheed Martin interface, 1999.
+- James Trevelyan, *The Making of an Expert Engineer* (CRC Press, 2014) — field-study basis for the coordination-vs-calculation split cited as a heuristic above.
+- INCOSE Systems Engineering Handbook, 4th ed. (2015) — V-model, requirements-development and verification process areas.
+- Eng-Tips forum thread, "Specialists vs. Generalists" (eng-tips.com) — practitioner consensus on the competence-boundary and specialist-bench pattern, and the "useful for the lightest of problems" caution.

--- a/roles/general-engineer/references/playbook.md
+++ b/roles/general-engineer/references/playbook.md
@@ -1,0 +1,88 @@
+# General Engineer — Coordination & Interface Playbook
+
+## Interface Control Document (ICD) — filled example
+
+Handoff: pump-skid vendor (mechanical/electrical) to plant SCADA integrator, chilled-water loop retrofit.
+
+| Field | Vendor side (as-delivered) | Integrator side (as-assumed) | Resolved value | Owner |
+|---|---|---|---|---|
+| Flow signal type | 4–20 mA, 2-wire loop-powered | 0–10 V, 3-wire | **4–20 mA, 2-wire** — integrator adds isolator card | Integrator |
+| Flow units | GPM | L/min | **GPM** at the transmitter; PLC scales ×3.785 to L/min internally | Vendor states unit; Integrator owns conversion |
+| Pressure setpoint tolerance | ±2 psi at transmitter | ±0.5 psi assumed by control loop tuning | **±2 psi** — control loop retuned to vendor's actual tolerance | Integrator |
+| Comms protocol | Modbus RTU, 19200 baud | Modbus TCP expected | **RTU→TCP gateway required**, added to BOM | Vendor confirms RTU is fixed; Integrator supplies gateway |
+| Enclosure rating | NEMA 4 | NEMA 4X assumed (washdown area) | **NEMA 4X** — vendor to requote enclosure | Vendor |
+| Alarm on comms loss | Not specified by vendor | Assumed fail-safe (valve closes) | **Fail-closed within 5 s of comms loss**, written into vendor spec as a change order | Vendor, verified by Integrator FAT |
+
+**Process:**
+1. Pull the "as-assumed" column from each side's own design documents *before* the kickoff call — never from a verbal description of the other side's system.
+2. Any row where the two columns disagree is a defect found before integration, not during it; log it, don't just resolve it silently in conversation.
+3. Every resolved value gets a named owner — the party whose design changes to close the gap, not the party who happened to notice it.
+4. Re-issue the ICD after any vendor change order; a stale ICD is worse than none, since it reads as verified when it isn't.
+
+## Downstream-substitution re-verification checklist
+
+Run this whenever a fabricator, contractor, or vendor proposes a substitution described as "equivalent" or "no design change."
+
+1. **Identify what changed:** part, material, joint/connection type, unit convention, or routing/topology of the load or signal path.
+2. **Identify what didn't change:** the claim being made is usually "the unchanged part proves no re-verification is needed" — treat that claim as the thing to check, not evidence.
+3. **Re-trace the full path** (load, thermal, signal, or data) through the point of substitution, not just at the substituted component itself.
+4. **Recompute demand at every connection/interface the path crosses downstream of the substitution**, using the changed topology, not the original one.
+5. **Compare recomputed demand against the connection's original allowable/rated capacity** — a capacity number computed for the *old* topology does not update itself.
+6. **State the resulting margin explicitly** (see margin table below) before approving or rejecting.
+
+### Margin re-verification — filled example (two catwalk substitutions, same connection)
+
+| Scenario | Demand on upper box-beam connection | Allowable capacity | FoS | Verdict |
+|---|---|---|---|---|
+| Original: continuous rod bypasses connection | 6,000 lbf (own level only) | 10,000 lbf | 1.67 | Pass — meets code minimum |
+| Proposed: split rod, lower level now anchors to upper connection | 12,000 lbf (6,000 own + 6,000 transferred) | 10,000 lbf (unchanged) | 0.83 | **Fail — hold submittal** |
+| Reinforced-connection alternative | 12,000 lbf | 20,000 lbf (reinforced to 1.67× new demand) | 1.67 | Pass — resubmit with reinforcement calc |
+
+**Rule:** never accept a "meets code" verdict computed against the pre-substitution capacity number; recompute capacity at the same time as demand.
+
+## Specialist-routing decision table
+
+Route the moment a problem's governing physics sits outside these five (of the seven OPM 0801 threshold areas): statics/dynamics, strength of materials, fluid mechanics, thermodynamics, electrical fields/circuits.
+
+| Symptom in the problem statement | Governing discipline | Route to |
+|---|---|---|
+| "Will this crack/yield under repeated load" beyond simple static FoS | Fatigue / fracture mechanics | Mechanical/materials specialist |
+| "Will this resonate or amplify vibration" | Structural dynamics, modal analysis | Structural/vibrations specialist |
+| "Will this corrode / degrade chemically in service" | Materials/corrosion science | Materials engineer or metallurgist |
+| "Will this trip a breaker / meet an arc-flash rating" | Power systems, protective relaying | Electrical/power specialist |
+| "Will this meet a thermal-runaway or heat-rejection budget" beyond basic conduction/convection | Thermal systems design | Thermal/HVAC specialist |
+| "Will this meet a regulatory emissions/environmental limit" | Environmental engineering | Environmental specialist |
+| "Will this hold up under seismic/blast/dynamic extreme load" | Specialized structural dynamics | Structural specialist with that certification |
+
+**Handoff format to the specialist:** state (a) what's already been ruled out and why, (b) the specific governing question, (c) the margin/threshold that triggered the route — never "can you take a look at this," which re-derives the scoping work the generalist already did.
+
+## Systems-integration traceability table (V-model) — filled example
+
+Requirement-to-verification link for a subsystem integration (sensor package → data bus → control logic).
+
+| Requirement ID | Requirement (left leg) | Verification method (right leg) | Verification status | Owner |
+|---|---|---|---|---|
+| REQ-014 | Sensor reports flow rate accurate to ±1% of reading | Bench calibration against NIST-traceable reference, 5-point curve | Verified 2024-03-11 | Vendor test lab |
+| REQ-015 | Data bus delivers sensor reading to control logic within 200 ms | End-to-end latency test, 100-sample average | Verified, avg 142 ms, max 187 ms | Integrator |
+| REQ-016 | Control logic issues shutoff command within 500 ms of out-of-range reading | Fault-injection test, 20 trials | **Not yet verified** — test not scheduled | Integrator (flagged) |
+| REQ-017 | System fails safe (valve closes) on comms loss | Comms-interrupt test at FAT | Verified 2024-04-02 | Integrator |
+
+**Rule:** a requirement with no row in the right-hand column is not "probably fine" — it's an unverified requirement, and REQ-016 above blocks sign-off until scheduled and closed, regardless of how confident the design looks.
+
+## Escalation memo — filled example (NSPE Canon 1 duty triggered)
+
+Use when safety-relevant professional judgment has been overruled and informal escalation hasn't resolved it.
+
+> **To:** [Employer/client engineering director], cc: project file
+> **From:** [Engineer name, EIT/PE status]
+> **Re:** Formal notice — unresolved safety objection, catwalk hanger-rod submittal, Building 4
+>
+> On [date] I identified that the proposed two-rod hanger substitution drops the upper box-beam connection's factor of safety from 1.67 to 0.83 against its code-mandated minimum (see attached calculation). I raised this informally to [name] on [date] and recommended holding the submittal pending reinforcement or reversion to the continuous-rod detail.
+>
+> On [date] I was informed the submittal will proceed as-is due to schedule pressure, without the reinforcement calculation being completed. This is a documented professional-judgment override on a life-safety item.
+>
+> Per NSPE Code of Ethics Canon 1, I am notifying you formally that I cannot sign off on this submittal in its current state. If this is not resolved by [date], I am obligated to notify [the appropriate regulatory authority / building official] per the same Canon.
+>
+> Attached: load-path recalculation, original and proposed submittal drawings, informal-notice email thread.
+
+**Rule:** this memo is dated and attached to a calculation, never a verbal aside — the obligation is to make an unambiguous record, not to have privately raised a concern.

--- a/roles/general-engineer/references/red-flags.md
+++ b/roles/general-engineer/references/red-flags.md
@@ -1,0 +1,51 @@
+# General Engineer — Red Flags
+
+### Submittal or shop-drawing note reads "same capacity/hardware, just more buildable" with no re-derivation of the load path it touches
+- **Usually means:** the fabricator or contractor changed how a load or signal travels through the assembly (split a continuous member into two, rerouted a connection) while believing unchanged part specs mean unchanged behavior — the Hyatt Regency hanger-rod shape.
+- **First question:** "Trace this exact load from its source to its final support with the new detail — does any single connection now carry more than it did in the original design?"
+- **Data to pull:** the original design's load-path calculation next to the proposed submittal, redrawn with the new geometry.
+
+### Recomputed factor of safety lands within 10% of the code-mandated minimum and is presented as the sign-off basis
+- **Usually means:** the review stopped at "passes code" instead of asking what unmodeled load case (quartering wind, a field substitution, a construction-sequence load) could still exceed it — Petroski's factor-of-ignorance framing.
+- **First question:** "What load case does this code minimum not model, and does this design see it?"
+- **Data to pull:** the governing load case behind the code-minimum FoS and any deviation between that assumption and actual site/service conditions.
+
+### A load path, unit convention, or data format crosses a contractor/team boundary with no Interface Control Document in place before integration starts
+- **Usually means:** each side assumes the other is using the same convention because nobody was assigned to own the seam — the Mars Climate Orbiter shape (newton-seconds vs. pound-force-seconds, a 4.45x mismatch).
+- **First question:** "Who signed the ICD for this specific interface, and does it name the units, tolerances, and format explicitly rather than by reference to 'standard practice'?"
+- **Data to pull:** the ICD itself, or its absence, plus each side's independent spec sheet for the interface in question.
+
+### A downstream joint or connection-type substitution (bolted for welded, one material grade for another) is accepted on the basis that it's "the same category" as the original
+- **Usually means:** buildability or cost pressure is being treated as design-neutral without re-running the calculation the substitution actually touches — the Citicorp Center shape, where a bolted-joint swap was never re-checked against quartering winds (a 40% wind-load, 160% connection-load increase the original calc never covered).
+- **First question:** "What specific load case or wind direction does the original design assume this joint sees, and has the substituted joint been checked against that same case?"
+- **Data to pull:** the original connection calculation and the substitution's own capacity data under the same load case, not a generic allowable-stress table.
+
+### A problem sits outside the five-of-seven OPM core competency areas (statics/dynamics, strength of materials, fluid mechanics, thermodynamics, electrical fields/circuits, materials science, or a comparable area) and is being reasoned through by analogy instead of routed
+- **Usually means:** the generalist is pattern-matching to a discipline they know rather than admitting the problem needs one they don't — useful for the lightest problems, unreliable the moment a discipline-specific failure mode is in play.
+- **First question:** "Which of your five core areas does this actually fall under, and if none, who's the named specialist you're routing it to?"
+- **Data to pull:** the specialist bench list and whether this problem class has a named owner on it already.
+
+### Requirements traceability matrix has a requirement with an empty verification-or-validation column
+- **Usually means:** either the requirement is genuinely untested (a real gap) or it was never testable as written and should have been reclassified, not left dangling — the INCOSE V-model's left-leg-to-right-leg link broken.
+- **First question:** "Is this requirement unverifiable as stated, or verifiable but simply not yet tested?"
+- **Data to pull:** the traceability matrix and the requirement's original acceptance-criterion wording.
+
+### A safety-relevant professional disagreement is escalated verbally, with no dated written record
+- **Usually means:** the engineer raised the concern but didn't create the record NSPE Canon 1 actually requires — a verbal aside doesn't establish that the employer or client was formally notified before the decision proceeded.
+- **First question:** "Where's the timestamped memo or email that documents this notification, separate from the meeting where it was discussed?"
+- **Data to pull:** the written escalation record, or its absence, and the date it was sent relative to the decision it concerns.
+
+### A field retrofit or fix is executed without a documented update to the original governing calculation
+- **Usually means:** the fix was scoped to make the immediate symptom go away rather than to close the gap between the as-built condition and the design basis — the kind of unlogged night-time correction that leaves the next reviewer trusting a calculation that no longer matches the structure.
+- **First question:** "Does the design calculation on file reflect what's actually built now, or what was built before this retrofit?"
+- **Data to pull:** the as-built drawing set and the design calculation's revision history.
+
+### A design change is proposed after verification testing or analysis has already started, with no documented impact assessment
+- **Usually means:** schedule pressure is treating the change as small enough to fold in without asking which already-completed verification steps it invalidates.
+- **First question:** "Which specific verification or analysis activities does this change actually touch, and have those been rerun?"
+- **Data to pull:** the change-request record and the re-verification scope decision tied to it, if one was made.
+
+### An Interface Control Document exists but hasn't been re-issued after a vendor or contractor change order that touches it
+- **Usually means:** the ICD is being treated as a one-time artifact instead of a living document, so it now describes an interface that no longer matches either side's as-built state — worse than having no ICD, because it reads as current when it isn't.
+- **First question:** "What's the date of the most recent change order on either side of this interface, and does it postdate the ICD's last revision?"
+- **Data to pull:** the ICD's revision history next to each side's change-order log.

--- a/roles/general-engineer/references/vocabulary.md
+++ b/roles/general-engineer/references/vocabulary.md
@@ -1,0 +1,75 @@
+# Vocabulary
+
+Terms a cross-disciplinary generalist reaches for constantly and flattens together — each with the misuse that lets a marginal design or an unowned interface pass review.
+
+## Factor of safety vs. margin of safety
+
+**Factor of safety (FoS)** is a ratio: failure load ÷ maximum expected load (or allowable capacity ÷ demand). **Margin of safety (MoS)** is that same relationship expressed as MoS = FoS − 1, i.e. the fractional reserve capacity *beyond* the expected load. An FoS of 1.2 sounds comfortably above "passing" (1.0) but is only a 20% margin — thin enough that a single unmodeled load case can erase it.
+**In use:** "FoS 1.2 on that connection isn't a lot of headroom — that's 20% margin, not 120%."
+**Common misuse:** quoting the FoS number alone as if it were the margin, which overstates the actual reserve by a full 1.0 and hides how little slack an "acceptable" design really carries.
+
+## Load path vs. load case
+
+**Load path** is the physical route a force travels from where it's applied to where it's ultimately resisted (foundation, anchor, ground) — which members and connections carry it, in order. **Load case** is a specific defined combination of loads (dead + live + wind, dead + seismic, etc.) the structure or system is analyzed against. A substitution can leave every load case's magnitude unchanged while completely rerouting the load path through a different, unverified connection.
+**In use:** "The two-rod split didn't change any load case — it changed the load path. That upper connection now carries load it was never designed to see."
+**Common misuse:** treating "no load case changed" as proof nothing needs re-verification, when the failure mode lives in the path a load travels, not the magnitude tables.
+
+## Verification vs. validation
+
+**Verification** asks "did we build the thing right?" — does the deliverable meet its stated requirements/specification. **Validation** asks "did we build the right thing?" — does it meet the actual need in its intended use environment. A system can pass every verification test against its written spec and still fail validation if the spec itself was wrong or incomplete.
+**In use:** "This module verifies clean against every requirement in the ICD — but nobody's validated that the ICD's units convention matches what the other team's software actually expects."
+**Common misuse:** using "verified" and "validated" interchangeably, so a fully spec-compliant deliverable is assumed safe for its real-world use case without ever checking the spec against that use case.
+
+## Traceability
+
+The checkable link from a requirement to the specific test or inspection that confirms it was met (the V-model's left-leg-to-right-leg connection). No named verification method attached means it's a wish-list entry, not a requirement.
+**In use:** "No line in the verification matrix points back to this requirement — untraceable, so nobody's on the hook to confirm it."
+**Common misuse:** treating the requirements doc and the test plan as separately complete, without checking every requirement in the first has a named counterpart in the second.
+
+## Interface Control Document (ICD) vs. spec
+
+A **spec** describes what one component or subsystem must do on its own. An **ICD** describes the boundary between two components or teams specifically — units, tolerances, data formats, connector pinouts, timing — the things that only matter because two parties have to agree on them. A component can be perfectly spec-compliant and still fail at an interface if the ICD was never written or never enforced.
+**In use:** "Both sides met their own spec. Nobody wrote an ICD stating the units convention, so 'met spec' didn't stop a 4.45x unit mismatch at the handoff."
+**Common misuse:** assuming that if both sides of an interface separately meet their own specs, the interface between them is automatically sound — the ICD is a distinct deliverable, not a byproduct of two good specs.
+
+## Tolerance stack-up
+
+The cumulative dimensional or performance variation that results when several individually-toleranced parts or measurements are combined in series. Each part can be within its own individual tolerance and the assembly can still fail to fit or function because the tolerances stacked in the same direction.
+**In use:** "Each of these five shims is within its printed tolerance — but stack them worst-case and you're 0.4 mm outside the assembly's fit-up window."
+**Common misuse:** checking each component's tolerance in isolation and concluding the assembly is fine, without running the worst-case (or statistical) stack-up across the full chain of parts.
+
+## Derating
+
+Deliberately operating a component below its rated maximum (current, voltage, temperature, pressure) to extend its service life or absorb conditions the rating doesn't fully capture — a design choice, not evidence the original rating was wrong. A part run at its rated maximum continuously is not "meeting spec with margin," it's running at zero derating margin.
+**In use:** "We're derating this power supply to 70% of nameplate for continuous duty — the nameplate rating assumes intermittent load, and this application isn't intermittent."
+**Common misuse:** treating a component's nameplate/catalog rating as the safe continuous operating point in every application, rather than checking whether the rated duty cycle matches the actual use case and derating accordingly.
+
+## Single point of failure (SPOF)
+
+A single component, connection, or interface whose failure alone — with no other contributing fault — takes down the whole system or safety function. Redundancy only eliminates an SPOF if the redundant path is independent; two paths that share one unrecognized common element (one power feed, one control signal, one unowned interface) are not actually redundant.
+**In use:** "We've got two pumps, but they both draw from the same control signal — that signal is still a single point of failure for the whole redundant pair."
+**Common misuse:** counting a system as "redundant" because it has duplicate hardware, without tracing whether the duplicates share an unexamined common dependency that reintroduces the single point of failure.
+
+## Root cause vs. proximate cause
+
+**Proximate cause** is the immediate mechanical event that triggered a failure (the connection sheared). **Root cause** is the upstream process gap that let that event become possible (a substitution nobody re-verified). Fixing only the proximate cause reproduces the same failure with different hardware next time.
+**In use:** "Proximate cause: the sheared hanger rod. Root cause: shop-drawing substitutions don't route back through the engineer of record — fix that, or this repeats."
+**Common misuse:** closing an incident report at what broke, without tracing back to what let the unverified change through in the first place.
+
+## Design basis vs. design intent
+
+**Design basis** is the documented set of loads, codes, assumptions, and criteria a design was actually calculated against — a specific, checkable list. **Design intent** is the more general functional goal the design was meant to achieve. A substitution can still serve the design intent ("hold the catwalk up") while violating the design basis (the specific load path and connection capacity that calculation relied on).
+**In use:** "The fabricator's swap still serves the design intent — the catwalk still hangs. It violates the design basis, because that connection was never calculated for the load it now carries."
+**Common misuse:** approving a change because it doesn't obviously contradict the design intent, without checking it against the specific, documented design basis the original calculation used.
+
+## Boundary condition
+
+The stated assumption about how a component is supported, restrained, or connected at its edges, which the entire internal calculation depends on (fixed, pinned, free, continuous). Changing how a part is actually connected in the field — without updating the calculation's boundary condition — invalidates the calculation even if every other input stays the same.
+**In use:** "That beam was calculated as continuous over two supports. Field-splicing it there turns it into two simply-supported spans — the boundary condition changed, so the original moment calculation no longer applies."
+**Common misuse:** assuming a calculation still holds after a field change to how a part is physically connected, without checking whether that change altered the boundary condition the calculation assumed.
+
+## Competency boundary (five-of-seven / OPM 0801)
+
+The documented threshold — for a General Engineer, the OPM 0801 standard's five-of-seven core coursework areas (statics/dynamics, strength of materials, fluid mechanics, thermodynamics, electrical fields/circuits, materials science, or a comparable area) — past which a problem requires a named specialist rather than analogical reasoning. It is a scope boundary tied to a specific qualifying standard, not a general sense of "how confident I feel."
+**In use:** "This is a heat-transfer problem outside my five areas — I can scope it, but the calculation itself routes to a thermal specialist."
+**Common misuse:** treating "I've seen something like this before" as equivalent to formal competency in the area, instead of checking the problem against the specific credentialed boundary and routing it when it falls outside.


### PR DESCRIPTION
## Rubric score: 18/18

## Resolution rationale

None of the three supplied candidates (aerospace-engineer, agricultural-engineer, application-security-engineer) survive even the counterfactual test — their Decision frameworks, Tools & methods, and Worked examples are about aircraft certification/weight budgets, farm equipment, and app threat models respectively, none of which a Fuel Cell Engineer would ever consult; this isn't a granularity gap, it's a wrong-domain mismatch, so none is a reasonable parent among the given options. However O*NET correctly nests 17-2141.01 (Fuel Cell Engineers) under 17-2141.00 (Mechanical Engineers), and the repo already has a mechanical-engineer role (roles/mechanical-engineer/SKILL.md, onet_soc_code 17-2141.00) that the CLI's matcher missed. Applying the granularity test against that true parent: mechanical-engineer's core decisions (FEA/mesh convergence, Kt/Kf fatigue notch correction, factor-of-safety selection, DFM/tolerance stack-ups) are generic structural/mechanical judgment. A Fuel Cell Engineer's actual decisions — polarization-curve interpretation, membrane electrode assembly (MEA) design, catalyst loading/poisoning (CO, sulfur) tradeoffs, gas diffusion layer selection, water/thermal management across the stack, balance-of-plant (compressor, humidifier, coolant loop) sizing, degradation-rate diagnosis (voltage decay per 1000 h) — are electrochemical and thermodynamic, not structural, and mechanical-engineer's Decision framework and worked example would give no guidance (or misleading structural-only guidance) on any of them. That's a real content/failure-mode gap, not just "less detail," satisfying the practitioner-nod and non-derivability tests for a new leaf. Fuel cell engineering nonetheless shares the parent occupation's context (packaging fuel cell hardware into a mechanical system, structural/thermal integration of the stack) closely enough that mechanical-engineer is a sensible parent rather than requiring an entirely new top-level category — hence new_leaf, not new_parent. Proposed slug 'fuel-cell-engineer' follows the repo's flat kebab-case occupation-name convention (e.g. mechanical-engineer, energy-engineer, solar-energy-systems-engineer already exist as siblings/near-siblings in the engineering category).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two new engineering roles at spec-2: `fuel-cell-engineer` (leaf under `mechanical-engineer`) and `general-engineer` (O*NET “Engineers, All Other”), and updates docs and counts.

- **New Features**
  - Added `roles/fuel-cell-engineer/SKILL.md` with ASTs, torque sweeps, and degradation diagnosis, plus `references/playbook.md`, `references/red-flags.md`, `references/vocabulary.md`; mapped to O*NET `17-2141.01` with parent `mechanical-engineer` in `data/roles.json`.
  - Added `roles/general-engineer/SKILL.md` with coordination/ICD/red-flag guidance, plus matching references; mapped to O*NET `17-2199.00` in `data/roles.json`.
  - Updated `README.md` and `ROADMAP.md` counts and links: roles 536, O*NET 526, engineering 83, Architecture & Engineering 50/59.

<sup>Written for commit 674e4ce22ae1a4be58effd76871bcde76c61ea26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

