### PR TITLE
role: add mechatronics-engineer

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,12 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**536 roles drafted** (526 mapped to an O*NET occupation, 10 custom; 494 at spec 2, 42 awaiting upgrade), across 10 categories:
+**537 roles drafted** (527 mapped to an O*NET occupation, 10 custom; 495 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `██████████░░░░░░░░░░` 51.8% (526 / 1,016 occupations)
+**O\*NET coverage:** `██████████░░░░░░░░░░` 51.9% (527 / 1,016 occupations)
 
 - **design**: 12
-- **engineering**: 83
+- **engineering**: 84
 - **finance**: 31
 - **healthcare**: 58
 - **legal**: 21

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 526 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 527 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -182,7 +182,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>17 — Architecture and Engineering</strong> (50/59 drafted)</summary>
+<summary><strong>17 — Architecture and Engineering</strong> (51/59 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -219,7 +219,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 | ✅ | 17-2171.00 | Petroleum Engineers | [`petroleum-engineer`](./roles/petroleum-engineer/SKILL.md) |
 | ✅ | 17-2199.00 | Engineers, All Other | [`general-engineer`](./roles/general-engineer/SKILL.md) |
 | ✅ | 17-2199.03 | Energy Engineers, Except Wind and Solar | [`energy-engineer`](./roles/energy-engineer/SKILL.md) |
-|  | 17-2199.05 | Mechatronics Engineers |  |
+| ✅ | 17-2199.05 | Mechatronics Engineers | [`mechatronics-engineer`](./roles/mechatronics-engineer/SKILL.md) |
 |  | 17-2199.06 | Microsystems Engineers |  |
 | ✅ | 17-2199.07 | Photonics Engineers | [`photonics-engineer`](./roles/photonics-engineer/SKILL.md) |
 | ✅ | 17-2199.08 | Robotics Engineers | [`robotics-engineer`](./roles/robotics-engineer/SKILL.md) |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 536,
+  "count": 537,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -6580,6 +6580,27 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/mechanics-installers-supervisor/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "mechatronics-engineer",
+      "description": "Use when a task needs the judgment of a Mechatronics Engineer \u2014 designing a backlash-compensation or motion-control algorithm for an electromechanical assembly, choosing motor-side vs. load-side sensor placement, matching inertia ratio and gearing on a servo axis, specifying an EMC/grounding scheme for a mixed mechanical-electrical assembly, or diagnosing whether a field failure is mechanical, electrical, or firmware in origin.",
+      "category": "engineering",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "17-2199.05",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/mechatronics-engineer/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/roles/mechatronics-engineer/SKILL.md
+++ b/roles/mechatronics-engineer/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: mechatronics-engineer
+description: Use when a task needs the judgment of a Mechatronics Engineer — designing a backlash-compensation or motion-control algorithm for an electromechanical assembly, choosing motor-side vs. load-side sensor placement, matching inertia ratio and gearing on a servo axis, specifying an EMC/grounding scheme for a mixed mechanical-electrical assembly, or diagnosing whether a field failure is mechanical, electrical, or firmware in origin.
+metadata:
+  category: engineering
+  maturity: draft
+  spec: 2
+  onet_soc_code: "17-2199.05"
+status: active
+---
+
+# Mechatronics Engineer
+
+## Identity
+
+An engineer who owns the closed-loop behavior of a system where mechanical, electrical, control, and firmware design are inseparable — a robot joint, a printer mechanism, a servo axis — accountable for the assembly hitting its accuracy, throughput, and cost targets together, not for any one discipline's subsystem in isolation. The defining tension: the cheapest sensor and the cheapest gear train are usually chosen independently by different disciplines, and only the mechatronics engineer discovers, often late, that the two cheap choices interact to blow the tolerance budget — at which point the fix is a control algorithm, not a part swap.
+
+## First-principles core
+
+1. **The control loop doesn't position the load, it positions whatever the sensor measures.** A motor-shaft encoder reports motor position, not load position; every mechanism between the two — gear backlash, belt stretch, coupling compliance — is invisible to the loop and shows up as uncompensated error at the load. Choosing sensor location is choosing what the controller can and can't see.
+2. **A mechanical error becomes a controls problem the moment the sensor sits upstream of it.** Backlash, once accepted as a mechanical characteristic rather than eliminated, must be compensated in software (directional pre-load, reversal dither) or it reads directly into positioning error — there is no controller gain that removes it.
+3. **Disciplines designed in isolation and integrated at the end compromise cost and performance that concurrent design would have caught.** The V-model exists because a mechanical decision (gear ratio, mass) and an electrical decision (sensor resolution, drive current) bound each other's achievable tolerance and bandwidth; sequencing them hides the interaction until final assembly, when it's expensive to fix.
+4. **A symptom's domain and a defect's domain are often different.** Electrical-looking faults (intermittent warning lights, erratic motion) can have a chemical or mechanical root cause; conversely, plenty of "hardware" field complaints resolve with a firmware reflash. Isolating which domain actually owns the defect, before ordering a part or a fix, is the job.
+5. **Noise coupling is a geometry problem, not a wire-gauge problem.** Induced noise voltage scales with loop area times the rate of field change (V ≈ A·dB/dt) — minimizing conductor loop area and lead length does more than upgrading cable spec, and a mis-terminated shield defeats the shielding entirely regardless of cable quality.
+
+## Mental models & heuristics
+
+- **When sizing a coupled (geared/belted) servo axis, keep reflected load-to-rotor inertia ratio ≤5:1, and treat 10:1 as the acceptable ceiling** before tuning gets difficult and settling time degrades; direct-drive axes tolerate ratios orders of magnitude higher because there's no compliant coupling to excite. Above ceiling, default to adding a gear reducer — a reducer of ratio G divides reflected load inertia by G².
+- **When keeping a servo loop stable, default to structural resonance ≥3× the velocity-loop bandwidth and ≥6× the position-loop bandwidth**, not just "as high as it happens to be" — margins tighter than that get tuned around at commissioning and reappear as instability once seals, bearings, or joints loosen and damping drops in the field.
+- **When backlash or compliance sits between the sensor and the load, default to load-side (direct) sensing** unless the cost savings of motor-side sensing are paired with an explicit, calibrated compensation algorithm — motor-side sensing without compensation is a silent accuracy failure, not a cheaper equivalent.
+- **When scoping a system spanning mechanical, electrical, and firmware concurrently, decompose top-down (requirement → functional → logical → physical, per VDI 2206) and integrate bottom-up with verification at each level** — sequencing disciplines instead of running them concurrently is the named failure mode: cost and performance get compromised by decisions made without the other domain's constraints in view.
+- **When a cheaper sensor is proposed, price the calibration/compensation engineering it requires against the sensor cost delta** — moving to coarser or worse-placed sensing doesn't remove the error, it exports it to controls engineering as added algorithm and calibration cost.
+- **For EMC, bypass every IC's power pin locally with a 0.1 µF ceramic capacitor plus a bulk 10s–100s µF cap, terminate cable shields at one end only (the controller end) to avoid ground loops, and never pigtail a shield** — unbraiding a shield into a single twisted lead and landing it under a screw is the single most common EMC mistake and defeats the shield's purpose.
+- **When a field failure recurs across multiple builds of the same design, check firmware/calibration state before replacing hardware** — a hardware-presenting fault that clears on reflash across many units points at firmware or calibration, not a part.
+
+## Decision framework
+
+1. **Set functional and tolerance requirements across all domains concurrently** — position/velocity accuracy, cycle time, cost ceiling — as one requirement set, not separate mechanical and electrical specs handed off in sequence.
+2. **Run domain-specific concept design in parallel, and explicitly flag every cross-domain dependency** — where a mechanical choice (gear ratio, backlash spec) bounds what an electrical/control choice (sensor resolution, achievable bandwidth) can deliver.
+3. **Choose sensor/actuator topology by asking what error sources sit between sensor and load**, and size the drivetrain by inertia-ratio matching before locking in a gear ratio.
+4. **Model the closed loop — mechanical dynamics plus control law — before committing to hardware**, checking resonance margin against target loop bandwidths and backlash against the tolerance budget.
+5. **Integrate bottom-up per the V-model's verification leg**, treating EMC/grounding as a system-integration check, not a per-subsystem afterthought.
+6. **On a field failure, isolate the domain (mechanical wear, electrical/EMC, firmware/calibration) before ordering a hardware fix.**
+7. **Write the qualification test report tracing every measured result back to the originating requirement**, not just a pass/fail table.
+
+## Tools & methods
+
+- VDI 2206 V-model artifacts — requirement/functional/logical/physical (RFLP) decomposition documents driving concurrent domain design and staged integration verification.
+- SolidWorks/Creo for mechanical CAD; MATLAB/Simulink for control-law and closed-loop dynamic simulation before hardware commitment.
+- PLC and motion-controller programming environments; servo autotuning and frequency-response (Bode) analyzers to verify inertia ratio and bandwidth margin against the resonance heuristic.
+- Backlash and resolution calibration procedures, and qualification test reports that trace measured performance to requirement IDs — see `references/playbook.md` for filled templates.
+
+## Communication style
+
+With mechanical peers: tolerance budgets and backlash numbers, in millimeters and ratios, not gain values. With electrical/controls peers: sensor placement rationale, resolution/update-rate arithmetic, and shield-termination points. With firmware: encoder counts and servo-loop timing, since that's the language a compensation algorithm gets specified in. With leadership: reduce to pass/fail against the tolerance spec plus a risk register naming which domain owns each open risk — never a symptom description without an assigned domain, because an unassigned symptom is how integration bugs live past their prototype.
+
+## Common failure modes
+
+- **Treating backlash as a controls problem to tune away** instead of applying the compensation algorithm (First-principles #2) or relocating the sensor.
+- **Designing mechanical, electrical, and firmware in isolation and integrating only at final assembly**, discovering the cross-domain interaction only after tooling is committed (First-principles #3).
+- **Committing to a gear ratio without checking the reflected inertia ratio**, then discovering instability at commissioning and tuning around it aggressively instead of revisiting the ratio (see resonance-margin heuristic under Mental models for why the aggressive tune doesn't hold long-term).
+- **EMC as a checklist item instead of a geometry decision** — adding bypass caps and shielded cable without addressing loop area or shield termination, then treating the residual noise as unexplained.
+- **Overcorrection: assuming every field complaint is firmware** because a past batch resolved on reflash, missing a genuine hardware/materials-chemistry defect the next time.
+
+## Worked example
+
+**Setup.** An inkjet printer's service-station wiper mechanism must stop within ±0.5 mm of target. The gear train between motor and wiper carriage has 2.1 mm of measured backlash (`B_raw`, per the end-of-line measurement procedure in `references/playbook.md` §2). Cost drove the choice of a motor-shaft rotary encoder (upstream of the gear train) over a load-side linear encoder: 1000 counts/mm (load-equivalent scale), servo loop updating at 500 Hz.
+
+**Naive read.** "Encoder resolution is 1/1000 mm per count — three orders of magnitude finer than the ±0.5 mm target, so the spec is comfortably met."
+
+**Expert reasoning.** Resolution isn't accuracy when the sensor sits upstream of the error source: the motor-side encoder cannot see the 2.1 mm of gear backlash between it and the load, so any position the encoder reports as "on target" can correspond to a load position anywhere within that 2.1 mm slop band, depending on the direction of last motion. The 2.1 mm backlash band is 4.2× the ±0.5 mm tolerance window — uncompensated, the mechanism fails its spec by a wide margin despite the encoder being far finer than needed. The controller doesn't position the wiper; it positions the motor shaft, and the gap between the two is exactly the backlash. Fine resolution also bounds the smallest velocity change the loop can act on: at 1000 counts/mm and a 500 Hz update rate, minimum detectable velocity change is (1/1000 mm) ÷ (1/500 s) = 0.5 mm/s — the granularity available for a reversal-dither compensation move.
+
+**Resolution chosen.** Rather than retrofit a load-side encoder, add a backlash-compensation algorithm: on every direction reversal, drive an extra 2.2 mm — the measured 2.1 mm backlash plus a 0.1 mm process margin, never the measured value exactly, since undershoot leaves residual backlash error and overshoot re-opens backlash on the other side — before resuming normal position control, calibrated per-unit at test since backlash varies with gear wear and tolerance stack-up. This keeps the ±0.5 mm target achievable on the cheaper motor-side sensor.
+
+**Written deliverable (design memo excerpt).** "Motor-side encoding retained. Measured gear-train backlash is 2.1 mm, 4.2× the ±0.5 mm stopping-accuracy requirement, and is invisible to the motor-shaft sensor — uncompensated, expect ~2.1 mm worst-case stopping error on direction reversal. Recommend a reversal-dither compensation move of 2.2 mm (measured backlash plus a 0.1 mm process margin, ±0.2 mm tolerance on the compensation value itself, re-verified at 6-month PM intervals as gear wear increases backlash) rather than a load-side encoder retrofit, which would add $[sensor delta] per unit against a one-time algorithm cost. Servo update rate (500 Hz) and encoder resolution (1000 counts/mm) give 0.5 mm/s minimum velocity-command granularity, sufficient to execute the dither move without overshoot. Risk: backlash grows with gear wear; compensation value needs a service-interval recalibration step, tracked as an open item against the maintenance plan, not the initial qualification."
+
+## Going deeper
+
+- [Playbook](references/playbook.md) — filled V-model requirement-to-verification traceability example, backlash-compensation calibration procedure, and inertia-ratio/gearbox sizing worksheet.
+- [Red flags](references/red-flags.md) — smell tests for mechatronic system integration: what each usually means, the first question to ask, the data to pull.
+- [Vocabulary](references/vocabulary.md) — terms generalists misuse, with practitioner usage and the common misuse spelled out.
+
+## Sources
+
+- W. Bolton, *Mechatronics: Electronic Control Systems in Mechanical and Electrical Engineering*, 7th ed. (Pearson) — canonical framing of mechatronics as integrated design rather than bolted-together disciplines.
+- VDI 2206, "Design methodology for mechatronic systems" (Verein Deutscher Ingenieure, 2004; revised 2021) — source for the V-model and the 2021 RFLP (requirement-functional-logical-physical) decomposition.
+- Doug Harriman, "Five Tips for Mechatronic System Integration" — source for the inkjet wiper backlash/accuracy numbers, the resolution/update-rate arithmetic, the "the control system positions the encoder" framing, and the isolated-disciplines failure mode.
+- Motion Control & Motor Association / automate.org guidance on inertia mismatch, corroborated by servo-vendor engineering notes — source for the 5:1/10:1 inertia-ratio heuristic, the G² gearbox-reduction relationship, and the 3×/6× resonance-margin heuristic [heuristic — needs practitioner check on exact resonance multiplier, sources range 3–6×].
+- Northwestern Mechatronics Wiki, "Shielding, Grounding, Noise Suppression" (Hades group) and jj-lapp.com EMC guides — source for the 0.1 µF bypass-cap value, the V ≈ A·dB/dt noise-coupling relationship, the pigtail anti-pattern, and one-end shield grounding.
+- VW/Škoda DQ200 DSG "mechatronic unit" field-failure record (warranty-extension notices, multi-region TSB pattern) — source for the symptom-vs-defect-domain failure mode (solder/fluid chemistry root cause, firmware-reflash resolution pattern).
+- O*NET-SOC 17-2199.05 task list used as coverage skeleton only, not quoted.

--- a/roles/mechatronics-engineer/references/playbook.md
+++ b/roles/mechatronics-engineer/references/playbook.md
@@ -1,0 +1,70 @@
+# Mechatronics Playbook
+
+Operational templates with concrete steps, thresholds, and filled numbers. Defaults, not laws — deviate consciously and say why in the design file.
+
+## 1. V-model requirement-to-verification traceability (filled example)
+
+System: inkjet service-station wiper axis (the SKILL.md worked example). Every row starts as a requirement and ends as a measured, signed-off number — no row ships without both ends filled.
+
+| Req ID | Requirement (customer/system level) | Functional spec | Logical/physical implementation | Verification method | Measured result | Status |
+|---|---|---|---|---|---|---|
+| R-01 | Wiper stops within ±0.5 mm of target, both directions | Closed-loop position control, settle time ≤300 ms | Motor-side rotary encoder, 1000 counts/mm load-equivalent, 500 Hz servo loop, reversal-dither compensation | Repeat-position test, 50 cycles/direction, dial indicator | ±0.42 mm worst-case (n=100) | PASS |
+| R-02 | Gear-train backlash characterized and compensated | Compensation move = `B_raw` + 0.1 mm margin, capped ±0.2 mm | 2.2 mm reversal-dither (2.1 mm `B_raw` + 0.1 mm margin), calibrated per unit at final test | Backlash gauge measurement pre- and post-compensation | 2.1 mm `B_raw` measured, 2.2 mm programmed | PASS |
+| R-03 | Axis stable under full seal/bearing wear range (EOL condition) | Structural resonance ≥3× velocity-loop BW, ≥6× position-loop BW | Velocity loop 40 Hz BW, position loop 20 Hz BW, structural resonance measured 150 Hz | Bode sweep at build and at simulated EOL (loosened bearing preload) | 150 Hz new (3.75×/7.5× velocity/position margins), 128 Hz at EOL simulation (3.2×/6.4× velocity/position margins) | PASS |
+| R-04 | EMC: no false-trigger of home-sensor optocoupler from motor commutation noise | Shield termination at controller end only; 0.1 µF + 47 µF bypass at each driver IC | Twisted-pair shielded motor leads, single-point shield ground, local bypass caps per IC power pin | Radiated/conducted susceptibility bench test + 500-cycle home-sensor false-trigger count | 0 false triggers / 500 cycles | PASS |
+| R-05 | Field serviceability: compensation value re-verifiable without full teardown | Compensation value stored in accessible service register, re-calibration procedure ≤15 min | Non-volatile register + guided calibration routine in service menu | Bench timing of calibration routine by non-engineer technician | 11 min average (n=5 technicians) | PASS |
+
+**Rule:** a requirement without a verification row is not done, regardless of how confident the design review was. A verification result that fails gets a new row (R-01a, etc.) tracing the fix back to the same requirement — never silently overwritten.
+
+## 2. Backlash-compensation calibration procedure
+
+Applies whenever the sensor sits upstream (motor-side) of a compliant/backlash-bearing mechanism (gear train, belt, worm drive) and load-side resensing wasn't chosen.
+
+1. **Measure raw backlash per unit at end-of-line test**, not from the drawing tolerance. Drive the load against a hard stop in direction A, zero the reading, then drive in direction B until motion is first detected at the load (dial indicator or load-side reference encoder used only for this calibration step). Record as `B_raw`.
+   - Example: nominal drawing backlash 1.5–2.5 mm; measured unit `B_raw` = 2.1 mm.
+2. **Add a process margin, not a repeat of the measurement.** Compensation move = `B_raw` + 0.1 mm (approx. 5% margin, capped at ±0.2 mm tolerance band per R-02). Do not compensate to exactly `B_raw` — undershoot leaves residual backlash error, overshoot drives the load past target and re-opens backlash the other way.
+3. **Program the compensation as a directional pre-move**, executed only on a sensed direction reversal (compare commanded direction to the direction of the immediately preceding move): drive `B_raw` + margin at maximum safe velocity before resuming normal closed-loop position control toward the actual target.
+4. **Verify at three points across the travel range** (near-limit, mid-travel, opposite-limit), 20 reversal cycles each. Threshold: worst-case stopping error ≤ tolerance budget (here ±0.5 mm) at all three points, not just the average.
+5. **Store the calibrated value in non-volatile, per-unit memory** — never as a firmware-wide constant. Backlash varies unit-to-unit with gear tolerance stack-up (observed spread on this program: 1.6–2.6 mm across 40 units, a 1.0 mm range against a 2.0 mm nominal).
+6. **Set a re-verification interval tied to wear rate, not an arbitrary calendar date.** Default: re-check at the PM interval where bearing/gear wear is expected to add ≥25% of the original compensation value (on this program, 6 months / ~500k cycles, from accelerated life test data). Flag re-verification failures (measured drift beyond ±0.3 mm of the stored value) as a maintenance action, not a redesign trigger, unless drift recurs after two consecutive recalibrations — then escalate to gear-train wear-rate investigation.
+
+**Fallback order if compensation alone can't hold tolerance:** (1) tighten the dither margin and re-verify motor current headroom — larger dither moves need more torque margin near travel limits; (2) add a load-side reference sensor used only for periodic re-zeroing (cheaper than full load-side closed-loop); (3) full load-side encoder retrofit, only after 1–2 are shown insufficient on data, since it's the highest-cost option and was the one value-engineered out originally.
+
+## 3. Inertia-ratio and gearbox sizing worksheet
+
+Use before locking a gear ratio on a coupled servo axis.
+
+**Inputs (example axis — a pick-and-place rotary joint):**
+- Load inertia at the joint, `J_load` = 0.048 kg·m²
+- Candidate motor rotor inertia, `J_motor` = 0.0006 kg·m²
+- Candidate gearbox ratio, `G` = 20:1
+- Required peak acceleration at load = 40 rad/s²
+- Motor peak torque rating = 3.2 N·m
+
+**Step 1 — Reflect load inertia to the motor shaft.** A gear ratio of `G` divides reflected inertia by `G²`:
+
+`J_reflected = J_load / G² = 0.048 / 20² = 0.048 / 400 = 0.00012 kg·m²`
+
+**Step 2 — Compute inertia ratio.**
+
+`ratio = J_reflected / J_motor = 0.00012 / 0.0006 = 0.20 → 0.2:1`
+
+Result is well under the 5:1 default ceiling (10:1 acceptable-but-tune-carefully limit) — this ratio is servo-friendly; no rework needed. If the same axis used `G` = 5:1 instead: `J_reflected` = 0.048/25 = 0.00192 kg·m², ratio = 0.00192/0.0006 = 3.2:1 — still under 5:1, but closer to the ceiling, and the design margin against tolerance stack-up (bearing wear, coupling wind-up) shrinks accordingly.
+
+**Step 3 — Check torque headroom against required acceleration.**
+
+Required motor torque = (`J_motor` + `J_reflected`) × required accel at motor shaft, where motor-shaft accel = load accel × `G` = 40 × 20 = 800 rad/s².
+
+`T_required = (0.0006 + 0.00012) × 800 = 0.00072 × 800 = 0.576 N·m`
+
+Against 3.2 N·m peak rating: headroom = 3.2 / 0.576 ≈ 5.6× — comfortable margin for load variation, friction, and dynamic disturbances (target minimum: ≥2× at worst-case load condition, not nominal).
+
+**Step 4 — Decision table**
+
+| Reflected inertia ratio | Action |
+|---|---|
+| ≤5:1 | Proceed; standard autotuning expected to converge without gain scheduling |
+| >5:1 and ≤10:1 | Proceed with caution; plan for extended commissioning time, verify resonance margin (§ tools/methods) before sign-off, expect gain scheduling may be needed across the travel range |
+| >10:1 | Do not proceed on the current ratio — increase `G` (inertia drops with `G²`, so even a modest ratio bump helps disproportionately), or move to direct-drive/torque-motor topology if the mechanical package allows it |
+
+**Common sizing mistake:** picking `G` to hit the desired output speed/torque only, then discovering the inertia ratio afterward. Size `G` against both constraints simultaneously — output kinematics and inertia ratio — because a ratio chosen purely for speed frequently lands in the >10:1 band on lightweight rotary joints with small motors.

--- a/roles/mechatronics-engineer/references/red-flags.md
+++ b/roles/mechatronics-engineer/references/red-flags.md
@@ -1,0 +1,51 @@
+# Red Flags
+
+### Positioning error settles to a value close to measured gear/belt backlash, and flips sign with direction of approach
+- **Usually means:** motor-side (upstream) sensing with no reversal-dither or pre-load compensation — the loop is faithfully holding the motor shaft on target while the load sits anywhere within the backlash band.
+- **First question:** is the encoder or resolver mounted on the motor shaft or on the load, and is there a compensation move on direction reversal?
+- **Data to pull:** mechanism backlash measurement (mm or degrees), sensor location in the kinematic chain, and a position-error log tagged by direction of last motion.
+
+### Reflected load-to-rotor inertia ratio above 10:1 on a geared or belted axis
+- **Usually means:** the axis will be difficult or impossible to tune to target bandwidth without excessive gain reduction, and will re-excite compliance resonance as damping drops in the field.
+- **First question:** was the gear ratio chosen for torque/speed matching alone, or was reflected inertia checked against the servo's stable range?
+- **Data to pull:** motor rotor inertia, load inertia, gear ratio, and the vendor's stable inertia-ratio range for the selected drive/motor combination.
+
+### Structural resonance frequency less than 3x the velocity-loop bandwidth (or less than 6x the position-loop bandwidth)
+- **Usually means:** the loop is tuned close enough to the mechanical resonance that gain margin will erode as bearings wear or seals stiffen, producing field instability that didn't appear at commissioning.
+- **First question:** what is the measured (not modeled) first structural resonance from a Bode sweep, and what bandwidth was the loop actually tuned to?
+- **Data to pull:** frequency-response (Bode) plot from the servo autotuner, commissioning-time bandwidth setting, and any field reports of audible buzz or hunting.
+
+### Intermittent fault clears after a firmware reflash on more than one unit from the same build
+- **Usually means:** genuine firmware/calibration defect (state corruption, stale calibration table) rather than a hardware or wiring problem — but only if the pattern repeats across builds; a single-unit fix is weaker evidence.
+- **First question:** does the fault recur after reflash on the same unit, and does it appear on units from a different manufacturing lot or supplier batch?
+- **Data to pull:** field-return log cross-referencing serial number, build/lot date, firmware version at failure, and post-reflash recurrence rate.
+
+### EMC/noise complaint after a cable or connector redesign, with no change to loop area or shield termination
+- **Usually means:** the redesign changed conductor routing or loop area (even without changing cable spec), or a shield was pigtailed instead of terminated 360 degrees at one end.
+- **First question:** was the shield terminated at both ends (ground loop) or pigtailed into a single lead, and did the new routing increase the loop area between signal and return?
+- **Data to pull:** cable routing diagram before/after the redesign, shield termination photos or drawings, and an oscilloscope capture of the induced noise waveform correlated to a known switching event (e.g., motor commutation).
+
+### Bypass capacitor present on the schematic but supply rail still shows switching-frequency ripple at the IC pin
+- **Usually means:** the 0.1 uF ceramic cap is placed too far from the IC's power pin (trace inductance defeats it), or the bulk capacitor (10s-100s uF) is missing or undersized for the transient current.
+- **First question:** what is the physical trace length from the bypass cap to the IC power pin, and is there a separate bulk cap on the same rail?
+- **Data to pull:** PCB layout showing cap placement and trace length, and an oscilloscope measurement of rail ripple at the IC pin during a load transient.
+
+### Qualification test report shows pass/fail results with no traceability to a requirement ID
+- **Usually means:** the V-model's verification leg was skipped or done informally — measured results were never tied back to the RFLP decomposition, so a marginal pass can hide a requirement that was quietly loosened.
+- **First question:** can every measured result in the report be traced to a specific requirement ID in the RFLP documents?
+- **Data to pull:** the RFLP requirement-to-verification traceability matrix and the raw qualification test data (not just the pass/fail summary table).
+
+### A single mechanical or electrical subsystem redesign lands late in the program with no cross-domain sign-off
+- **Usually means:** disciplines were run sequentially instead of concurrently, and the late change (e.g., a gear ratio bump for torque margin) may have silently invalidated an electrical/control assumption (sensor resolution, achievable bandwidth) made earlier.
+- **First question:** which other domain's design assumptions (sensor resolution, drive current, control bandwidth) depend on the parameter that just changed?
+- **Data to pull:** the cross-domain dependency list from concept design and the change-request record showing who reviewed the late change.
+
+### Motor current or torque saturating during normal operation, not just at startup or fault
+- **Usually means:** either the reflected inertia is too high for the selected motor/drive (undersized for the load), or mechanical friction/binding is higher than modeled and is being masked by the controller commanding more torque to compensate.
+- **First question:** does current saturate during steady-state motion or only during acceleration, and does manually back-driving the mechanism (motor de-energized) reveal excess friction?
+- **Data to pull:** motor current/torque log time-aligned with the motion profile, and a manual back-drive torque measurement at the load.
+
+### Backlash-compensation value has not been recalibrated since initial qualification, and the unit has passed 500k duty cycles (or 6 months in service)
+- **Usually means:** gear wear has increased actual backlash beyond the calibrated compensation value, so the dither move under- or over-travels and positioning error creeps back in gradually rather than failing sharply.
+- **First question:** when was backlash last measured directly (not inferred from position error), and how many duty cycles or operating hours has the unit accumulated since?
+- **Data to pull:** the maintenance/PM log showing last recalibration date and duty-cycle count, plus a fresh direct backlash measurement for comparison against the compensation value on file.

--- a/roles/mechatronics-engineer/references/vocabulary.md
+++ b/roles/mechatronics-engineer/references/vocabulary.md
@@ -1,0 +1,107 @@
+# Vocabulary
+
+Terms of art generalists misuse — not terms they could resolve by looking up a definition, but terms whose textbook definition survives while the practitioner implication gets dropped.
+
+## Backlash
+
+**Definition.** The bounded range of load-side motion that produces zero change in motor/sensor-side reading, caused by clearance between mating gear teeth or other drivetrain elements — not wear, though wear increases it.
+
+**In use:** "Measured gear-train backlash is 2.1 mm — that's 4.2× the ±0.5 mm stopping-accuracy requirement, so it has to be compensated, not tuned around."
+
+**Misuse note.** Generalists treat backlash as a property the control loop can just "tune out" with gain (see First-principles #2 in `SKILL.md` for why it can't). The fix is an explicit compensation algorithm (e.g., reversal dither, `references/playbook.md` §2) or elimination via load-side sensing/mechanical preload — not a gain change.
+
+## Resolution
+
+**Definition.** The smallest position (or velocity) increment a sensor can report — a property of the sensor and its scaling, independent of what the sensor can actually see.
+
+**In use:** "1000 counts/mm resolution is three orders of magnitude finer than the ±0.5 mm target — but that's not the same claim as meeting the accuracy spec."
+
+**Misuse note.** Generalists equate fine resolution with accuracy. Resolution only bounds accuracy from below; a fine-resolution sensor placed upstream of an uncompensated error source (like backlash) still produces gross positioning error, because the sensor is precisely reporting the wrong thing.
+
+## Reflected inertia
+
+**Definition.** The load-side inertia as it appears to the motor through a gear reduction, scaled by 1/G² for a reducer of ratio G — not the raw load inertia.
+
+**In use:** "A 5:1 reducer divides reflected load inertia by 25, which is why gearing down is the standard fix when the inertia ratio blows the 10:1 ceiling."
+
+**Misuse note.** Generalists apply the gear ratio linearly to inertia (divide by G) instead of by the square of the ratio (divide by G²), which understates by how much a modest gear ratio change fixes an inertia-mismatch problem, or leads them to over-spec a gearbox when a smaller ratio would have sufficed.
+
+## Inertia ratio
+
+**Definition.** The ratio of reflected load inertia to motor (rotor) inertia at a coupled servo axis — the sizing quantity that predicts tuning difficulty and settling behavior, distinct from the mechanical gear ratio.
+
+**In use:** "Reflected inertia ratio comes in at 7:1 — inside the 10:1 ceiling, but past the 5:1 comfort line, so expect the tuning pass to take longer."
+
+**Misuse note.** Generalists conflate inertia ratio with gear ratio because both are expressed as "N:1." They're different physical quantities that happen to share notation — gear ratio is a kinematic choice; inertia ratio is its dynamic consequence and is what actually predicts control stability.
+
+## Load-side sensing / motor-side sensing
+
+**Definition.** Load-side (direct) sensing places the position sensor on the driven member itself, downstream of all drivetrain compliance; motor-side (indirect) sensing places it on the motor shaft, upstream of gear backlash, belt stretch, and coupling compliance.
+
+**In use:** "Motor-side encoding is retained for cost, but that means backlash between it and the load is invisible to the loop and has to be compensated explicitly."
+
+**Misuse note.** Generalists treat the sensor-location choice as interchangeable with a cost/precision tradeoff on the sensor part number alone. The real tradeoff is architectural: motor-side sensing doesn't just cost less, it structurally cannot see downstream mechanical error, which then has to be paid for as calibration/algorithm engineering.
+
+## Bandwidth (servo loop)
+
+**Definition.** The frequency up to which a control loop (velocity loop or position loop) can command and track motion with acceptable phase lag — a control-system property distinct from the sensor's sample/update rate, which only sets an upper bound on achievable bandwidth.
+
+**In use:** "Structural resonance needs to sit at least 3× the velocity-loop bandwidth, or the loop will excite the resonance while trying to close it fast."
+
+**Misuse note.** Generalists use "bandwidth" and "update rate" interchangeably. A 500 Hz servo update rate does not mean 500 Hz loop bandwidth — bandwidth is typically a fraction of the sample rate and is further constrained by structural resonance margin, not just by how fast the controller samples.
+
+## Structural resonance
+
+**Definition.** The natural mechanical frequency at which a coupled structure (bracket, coupling, drivetrain) amplifies excitation — a mechanical property that bounds how aggressively the control loop can be tuned before it excites instability.
+
+**In use:** "Resonance margin was 3× at commissioning; once bearing wear dropped damping in the field, the same gain setting rang the structure."
+
+**Misuse note.** Generalists treat resonance margin as a one-time commissioning check rather than a lifetime one — see the 3×/6× margin heuristic under Mental models in `SKILL.md` for the field-wear mechanism that erodes it after commissioning.
+
+## Shield termination (single-ended grounding)
+
+**Definition.** The practice of connecting a cable's shield to ground at exactly one end (the controller end, by convention) so the shield diverts induced noise without becoming a current path between two separated ground references.
+
+**In use:** "Terminate the shield at the controller end only — grounding both ends turns the shield into a ground-loop conductor instead of a noise diversion path."
+
+**Misuse note.** Generalists assume more grounding is always better shielding and connect the shield at both ends "for safety." That creates a ground loop between the two chassis ground potentials, which injects noise current through the shield rather than diverting it — the opposite of the intended effect.
+
+## Pigtail (shield termination)
+
+**Definition.** An unbraided shield gathered into a single twisted lead and landed under a screw terminal or connector pin, rather than terminated 360° around the connector backshell.
+
+**In use:** "The intermittent noise traced back to a pigtailed shield on the encoder cable — swap it for a 360° backshell termination before touching any filtering."
+
+**Misuse note.** Generalists treat "the shield is grounded" as sufficient and don't distinguish termination geometry. A pigtail adds inductance and creates a gap in shield coverage right at the connector, defeating the shield at the exact frequencies EMC problems tend to occur, regardless of how well-specified the cable itself is.
+
+## Loop area (EMC)
+
+**Definition.** The physical area enclosed by a current-carrying conductor and its return path — the geometric quantity that sets induced-noise coupling via V ≈ A·dB/dt, independent of wire gauge or shielding.
+
+**In use:** "The noise didn't drop after upgrading to heavier-gauge cable, because the fix needed was routing the return conductor tighter to the source, not a thicker wire."
+
+**Misuse note.** Generalists respond to EMC problems by upgrading cable spec (gauge, shielding rating) because that's the purchasable lever. Induced voltage scales with loop area times rate of field change, not wire gauge — a large loop area with premium cable still couples noise; a tight loop with modest cable often doesn't.
+
+## Concurrent (V-model / RFLP) design
+
+**Definition.** Per VDI 2206, decomposing a mechatronic system top-down (requirement → functional → logical → physical) with mechanical, electrical, and firmware domains run in parallel and cross-checked at each level, then integrating and verifying bottom-up — distinct from a sequential handoff between disciplines.
+
+**In use:** "Run the RFLP decomposition concurrently across domains and flag every point where a mechanical choice bounds an electrical one — don't finalize the gear ratio before controls has weighed in on achievable bandwidth."
+
+**Misuse note.** Generalists read "V-model" as just a project-phase diagram and implement it as a sequential handoff (mechanical finishes, then electrical starts, then firmware) — not a valid reading of it; see First-principles #3 in `SKILL.md` for why sequencing compromises cost and performance. The V-model's actual point is running domains concurrently with explicit cross-domain dependency flags.
+
+## Compliance (mechanical)
+
+**Definition.** The inverse of stiffness — how much a structure or coupling deflects under a given load — a property that, like backlash, sits between sensor and load and is invisible to a sensor placed upstream of it.
+
+**In use:** "Belt stretch is compliance, not backlash — it doesn't create a dead zone, but it does add a load-dependent position lag the motor-side encoder can't see."
+
+**Misuse note.** Generalists lump compliance in with backlash as "mechanical slop" and expect the same fix (dither/preload). Compliance produces a continuous, load-dependent error rather than a bounded dead zone, so it needs a different compensation approach (stiffness increase or load-side sensing), not a reversal-dither move.
+
+## Domain isolation (fault diagnosis)
+
+**Definition.** The diagnostic step of determining which discipline (mechanical, electrical/EMC, firmware/calibration, or materials/chemistry) actually owns a field defect before ordering a fix — distinct from noting which discipline the symptom presents in.
+
+**In use:** "The warning light is an electrical symptom, but domain isolation on the last three units traced it to solder/fluid chemistry, not the wiring harness."
+
+**Misuse note.** Generalists fix the domain the symptom looks like it belongs to (an electrical-looking fault gets an electrical fix) rather than isolating the domain that actually causes it. A symptom's presenting domain and its defect's owning domain are frequently different, and skipping isolation leads to swapping the wrong part.


### PR DESCRIPTION
## Rubric score

18/18

## Resolution rationale

Applied the granularity test to the three offered candidates. Mechatronics Engineer (17-2199.05) integrates computer-controlled mechanical/electrical/embedded-software systems (actuator/sensor/controller co-design, control-loop and firmware-hardware tradeoffs, system integration testing) — none of the candidates share its decision framework, tools, or failure modes: aerospace-engineer's core is weight-budget/margin-of-safety/certification-basis reasoning for airframes (14 CFR Part 25/23, FEA stress margins); agricultural-engineer's core is hydrologic/irrigation/grain-bin/nutrient design against NRCS/ASABE standards; application-security-engineer's core is SDLC vulnerability triage (IDOR, SAST/DAST/SCA, CVSS reachability). A practitioner doing mechatronics work (e.g., sizing a motor+encoder+controller loop for a computer-controlled machine, debugging a mechanical-electrical-software integration failure, choosing between analog and digital control architectures) would get zero usable guidance — wrong tools, wrong failure modes, wrong worked-example math — from any of these three, and none is a plausible parent for it. No reasonable parent exists among the offered candidates, so this is a new_parent case (note for the generation step: the existing `roles/robotics-engineer` role, not among the offered candidates, is the nearest sibling in the repo — robotics-engineer is scoped specifically to robotic manipulators/kinematics, while mechatronics-engineer is the broader computer-controlled-mechanical-systems discipline covering non-robot applications like automotive, consumer, and manufacturing-equipment mechatronics; worth a quick check during generation that the two skills don't end up overlapping/duplicating content, but they are distinct enough O*NET occupations to justify separate roles).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `mechatronics-engineer` role (O*NET 17-2199.05) focused on computer-controlled electromechanical systems. Updates counts and the O*NET checklist to reflect the addition.

- **New Features**
  - Added `roles/mechatronics-engineer/SKILL.md` with core principles, decision framework, tools, and a worked example.
  - Added references: `references/playbook.md`, `red-flags.md`, `vocabulary.md`.
  - Registered the role in `data/roles.json` (spec 2, `engineering`, active) and updated `README.md`/`ROADMAP.md` stats and checklist.

<sup>Written for commit fc59f85414a993918f208c83fcd85766b08921f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

