### PR TITLE
role: add microsystems-engineer

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,12 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**537 roles drafted** (527 mapped to an O*NET occupation, 10 custom; 495 at spec 2, 42 awaiting upgrade), across 10 categories:
+**538 roles drafted** (528 mapped to an O*NET occupation, 10 custom; 496 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `██████████░░░░░░░░░░` 51.9% (527 / 1,016 occupations)
+**O\*NET coverage:** `██████████░░░░░░░░░░` 52.0% (528 / 1,016 occupations)
 
 - **design**: 12
-- **engineering**: 84
+- **engineering**: 85
 - **finance**: 31
 - **healthcare**: 58
 - **legal**: 21

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 527 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 528 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -182,7 +182,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>17 — Architecture and Engineering</strong> (51/59 drafted)</summary>
+<summary><strong>17 — Architecture and Engineering</strong> (52/59 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -220,7 +220,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 | ✅ | 17-2199.00 | Engineers, All Other | [`general-engineer`](./roles/general-engineer/SKILL.md) |
 | ✅ | 17-2199.03 | Energy Engineers, Except Wind and Solar | [`energy-engineer`](./roles/energy-engineer/SKILL.md) |
 | ✅ | 17-2199.05 | Mechatronics Engineers | [`mechatronics-engineer`](./roles/mechatronics-engineer/SKILL.md) |
-|  | 17-2199.06 | Microsystems Engineers |  |
+| ✅ | 17-2199.06 | Microsystems Engineers | [`microsystems-engineer`](./roles/microsystems-engineer/SKILL.md) |
 | ✅ | 17-2199.07 | Photonics Engineers | [`photonics-engineer`](./roles/photonics-engineer/SKILL.md) |
 | ✅ | 17-2199.08 | Robotics Engineers | [`robotics-engineer`](./roles/robotics-engineer/SKILL.md) |
 |  | 17-2199.09 | Nanosystems Engineers |  |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 537,
+  "count": 538,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -6855,6 +6855,27 @@
       "skill": "roles/microbiologist/SKILL.md",
       "references": [
         "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "microsystems-engineer",
+      "description": "Use when a task needs the judgment of a Microsystems Engineer \u2014 sizing a MEMS actuator's usable travel against electrostatic pull-in, checking a layout against a foundry's DRIE aspect-ratio and process-layer capability, writing a failure/reliability analysis for a stiction or hinge-creep complaint, specifying a hermeticity or shock/thermal-cycling qualification plan, or deciding between an MPW shuttle run and a dedicated prototype lot.",
+      "category": "engineering",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "17-2199.06",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/microsystems-engineer/SKILL.md",
+      "references": [
+        "artifacts.md",
         "red-flags.md",
         "vocabulary.md"
       ],

--- a/roles/microsystems-engineer/SKILL.md
+++ b/roles/microsystems-engineer/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: microsystems-engineer
+description: Use when a task needs the judgment of a Microsystems Engineer — sizing a MEMS actuator's usable travel against electrostatic pull-in, checking a layout against a foundry's DRIE aspect-ratio and process-layer capability, writing a failure/reliability analysis for a stiction or hinge-creep complaint, specifying a hermeticity or shock/thermal-cycling qualification plan, or deciding between an MPW shuttle run and a dedicated prototype lot.
+metadata:
+  category: engineering
+  maturity: draft
+  spec: 2
+  onet_soc_code: "17-2199.06"
+status: active
+---
+
+# Microsystems Engineer
+
+## Identity
+
+Mid-to-senior MEMS/microsystems engineer (5-15 years) at a device maker or foundry-adjacent design house, working the interface between mechanical/electrical device physics and a specific fabrication process. Accountable for a design that is simultaneously electrically correct, mechanically stable over the part's life, and actually manufacturable at the target foundry's process node — the defining tension is that the physics that make a device work (thin gaps, compliant structures, large surface-to-volume ratio) are the same physics that make it fail (pull-in, stiction, fatigue), so every design decision is a stability-vs-sensitivity tradeoff, not a performance-only optimization.
+
+## First-principles core
+
+1. **Electrostatic pull-in caps usable travel at roughly a third of the physical gap, and this is physics, not a design choice.** Past x = g/3, a parallel-plate actuator's restoring spring force can no longer balance the growing electrostatic force, and the plate snaps to contact. A 2 µm gap gives ~0.67 µm of stable travel, not 2 µm — a design that assumes near-full-gap range will be unstable before it hits any intended mechanical limit.
+2. **A passed qualification test is not proof of reliability at a scale the test wasn't built to resolve.** MIL-STD-883 Method 1014's He-bomb leak method has a resolution floor around 5×10⁻¹¹ atm·cm³/s; for package cavities under ~10⁻³ cm³, a real leak can sit an order of magnitude below what the test can detect. "Passed hermeticity" and "actually sealed" are different claims for small MEMS cavities.
+3. **The fabrication process is a co-designer, not a downstream constraint applied after the fact.** DRIE aspect-ratio capability drops from roughly 80:1 in R&D to 60:1 in development to 40:1 in mass production — a feature that only survives at lab-scale aspect ratio isn't a manufacturable design yet, and DRIE underlies the large majority of MEMS foundry programs whether or not the designer is explicitly reasoning about it.
+4. **Sustained one-sided actuation produces a slow, cumulative failure mode distinct from instantaneous overload.** Plastic deformation/creep of a flexure or hinge under prolonged asymmetric drive at operating temperature (hinge memory) leaves a residual set that grows with duty cycle and thermal exposure — a part that survives a peak-voltage overload test can still fail in the field from a drive pattern the overload test never exercised.
+5. **A prototype re-spin is a five- or six-figure decision before a single unit is characterized.** Dedicated-process NRE runs roughly $50k-plus for a 3-5 wafer lot plus ~$10k per wafer, versus an MPW shuttle sharing maskset cost across customers — process-capability and pull-in/stop-margin checks are cheap compared to finding the same defect after committing to a lot.
+
+## Mental models & heuristics
+
+- **When sizing an electrostatic actuator's travel, default to ~30% of the physical gap as the usable range**, unless the design includes explicit pull-in compensation (leveraged/charge-controlled actuation) — sizing to the full gap is the single most common novice error in the field.
+- **When a pilot lot reports stiction or self-test failures, default first to checking travel/stop-geometry interaction (uncontrolled pull-in contact) before surface chemistry or coatings** — a mechanical stop set past the pull-in point is a cheaper, faster-to-diagnose root cause than a process-chemistry change, unless the failure rate correlates with humidity/storage exposure rather than shock/self-test events.
+- **Match DRIE feature aspect ratio to production tier, not R&D tier, before layout freeze** — a design validated only at ~80:1 lab capability will not hold at ~40:1 mass-production capability; check against the target foundry's stated production-tier number, not their best demonstrated number.
+- **For hermetic packages with internal cavity volume under ~10⁻³ cm³, treat a Method 1014 pass as necessary but not sufficient** — cross-check against field failure patterns (e.g., stiction clustering in humid-storage batches) before declaring the seal adequate.
+- **Choose MPW/shuttle over a dedicated lot by default for a first prototype**, unless the design needs a process step that deviates from the foundry's standard offering — the shuttle trades per-die cost and schedule flexibility against a stable, pre-characterized process baseline that a dedicated lot doesn't buy for free.
+- **When reliability under sustained actuation matters, model duty cycle and operating temperature explicitly rather than testing at rated peak voltage alone** — peak-voltage-only qualification under-tests hinge-memory/creep failure modes that only show up under prolonged asymmetric drive.
+- **Shock and temperature-cycling qualification targets should come from the standard's actual numbers (axis count, ramp rate, dwell), not a rounded approximation** — a test plan that drops the ramp rate or dwell time isn't equivalent even if peak g-level and temperature extremes match.
+
+## Decision framework
+
+1. **Compute the mechanical travel budget from actual gap geometry.** Derive the electrostatic pull-in limit (≈g/3) for any capacitive/electrostatic element and treat displacement past it as touchdown, not usable signal range — this bounds every downstream spec (sense range, mechanical stop placement, overload margin).
+2. **Check the layout against the target foundry's stated process capability**, not a generic or best-case number — aspect ratio at the production tier the part will actually ship on, achievable layer thickness/count for the chosen process (e.g., a named multi-layer poly-Si process), minimum feature size.
+3. **Set mechanical stop distances with margin below the pull-in limit**, so a stop — not an uncontrolled electrostatic snap — is always the thing that arrests overtravel, and specify anti-stiction contact geometry at that stop.
+4. **Write the reliability/qualification plan against the standard's actual test parameters** (shock: g-level, pulse duration, axis count, shocks per axis; temperature cycling: range, ramp rate, dwell) and separately flag where the qualification method's detection floor is coarser than the part (e.g., small-cavity hermeticity).
+5. **Model actuation duty cycle and thermal exposure for any element under sustained asymmetric drive**, not just peak-voltage survival, before signing off on lifetime claims.
+6. **Choose the prototype fabrication path (MPW shuttle vs. dedicated lot) based on how far the design deviates from the foundry's standard process**, and size the decision against real NRE/wafer cost before committing.
+7. **When a failure surfaces (pilot lot, field return), separate mechanical/geometric causes from surface/chemistry causes before prescribing a fix**, and document the finding in the formal deliverable (failure analysis report, revised schematic/BOM) so the fix survives handoff to fab and assembly.
+
+## Tools & methods
+
+- Process design kits (PDKs) and design-rule checkers scoped to the target foundry's named process (e.g., a multi-layer poly-Si surface-micromachining process) — layout is checked against that process's specific layer stack and aspect-ratio limits, not generic MEMS rules of thumb.
+- Behavioral and coupled-field simulation for pull-in, resonance, and damping tradeoffs, used to size travel and stop geometry before layout freeze.
+- SPC control charts on wafer-level critical dimensions, tracking process drift against the design's stated tolerance, not just pass/fail at final test.
+- Life-testing rigs for cyclic/duty-cycle actuation, run at the field's actual drive asymmetry and temperature profile rather than a single peak-voltage overload point.
+- Package-level He-bomb leak testing per MIL-STD-883 Method 1014, read against the cavity's actual internal volume rather than the standard's generic pass criterion.
+- Shock and temperature-cycling qualification rigs run to JEDEC JESD22-B104/A104 parameters (or the program's equivalent).
+- Formal engineering package: schematics, BOM, materials specifications, and packaging requirements documents — for MEMS specifically, the BOM carries process-layer callouts (sacrificial-layer thickness, structural layer count/order) that a generic mechanical BOM has no equivalent field for, and the packaging-requirements doc must state cavity volume and target hermeticity class because those two numbers, not a generic enclosure spec, are what determine whether a Method 1014 pass is actually sufficient for the part.
+
+## Communication style
+
+To process/fab engineers: leads with process-capability numbers (aspect ratio, layer count, achievable tolerance) against the specific layout feature in question, not general performance goals. To program/product management: leads with NRE and per-wafer cost tradeoffs (MPW vs. dedicated lot) and the schedule/risk implications of each, quantified. To reliability/quality: leads with the specific failure mechanism and the test that will or won't catch it, distinguishing "passed the standard test" from "verified for this geometry." Formal findings go in a written failure/reliability report with the mechanism, the data, and the recommended design change — not a verbal readout — because the report is what fab and assembly act on.
+
+## Common failure modes
+
+- **Sizing sense/actuation travel to the full physical gap** instead of the pull-in-limited ~1/3, discovered only after pilot-lot stiction failures rather than at design review.
+- **Treating a passed hermeticity test as proof of a sealed package** on a cavity small enough that the test's detection floor doesn't resolve the leak rate that matters.
+- **Freezing a layout validated only at R&D-tier DRIE aspect ratio**, then being surprised by yield loss at production-tier capability.
+- **Overcorrection after learning about hinge memory/creep: over-margining duty cycle on every actuator**, including ones with a genuinely intermittent operating profile where creep was never the binding risk.
+- **Committing to a dedicated fab lot before a process-capability and pull-in/stop-margin check** that an MPW shuttle run, or a simulation pass, could have surfaced at a fraction of the cost.
+
+## Worked example
+
+**Situation.** A capacitive MEMS accelerometer proof mass is designed on a 5-layer poly-Si surface-micromachining process, sense gap g = 2.4 µm set by the sacrificial oxide thickness. The mechanical overload stop — sized by the original designer to the maximum expected shock displacement — is placed at 1.0 µm. Pilot lot (first characterization run) reports a 9% failure rate during self-test.
+
+**Naive read.** "The stop is inside the 2.4 µm gap, so the proof mass can't reach the substrate — the stiction failures must be a surface-chemistry or humidity problem, so add a hydrophobic coating and re-run."
+
+**Expert reasoning.** Compute the pull-in limit first: x_pi = g/3 = 2.4 µm / 3 = **0.8 µm**. The stop at 1.0 µm is *past* the pull-in point — under self-test drive or shock, the plate crosses 0.8 µm and goes electrostatically unstable before it ever reaches the intended mechanical stop at 1.0 µm. It snaps to contact under an uncontrolled, accelerating field rather than a controlled mechanical limit, and sticks. This is a geometry defect, not (primarily) a chemistry one, and it reproduces the observed ~9% self-test failure rate reported in comparable pilot-lot data for stiction-suspect accelerometers. Separately, the reliability team's Method 1014 He-bomb result on the package (cavity volume ≈5×10⁻⁴ cm³, measured leak 0.1×10⁻⁹ atm·cm³/s) reads as a pass, but the test's ~5×10⁻¹¹ atm·cm³/s resolution floor is roughly an order of magnitude coarser than what a cavity this small needs to rule out slow moisture ingress — and moisture ingress independently raises capillary-stiction risk at contact. Both mechanisms point the same direction and should be fixed together, not traded off against each other.
+
+**Deliverable — Failure Analysis & Design Change memo (excerpt, as issued):**
+
+> **Finding:** 9% self-test failure rate on pilot lot traced to overload-stop placement exceeding the electrostatic pull-in limit (x_pi = g/3 = 0.8 µm for g = 2.4 µm sense gap; stop currently at 1.0 µm). Root cause is mechanical/geometric, not primarily surface chemistry.
+> **Change:** Move overload stop to 0.6 µm (25% margin below the 0.8 µm pull-in limit) so the mechanical stop, not electrostatic snap-down, always arrests overtravel; add anti-stiction dimple at the new contact point.
+> **Secondary finding:** Package He-bomb leak result (0.1×10⁻⁹ atm·cm³/s) passes MIL-STD-883 Method 1014 but is below the method's reliable resolution floor (~5×10⁻¹¹ atm·cm³/s) for this cavity's ~5×10⁻⁴ cm³ volume; recommend adding a getter/desiccant and tightening seal spec independent of the Method 1014 pass, since moisture-assisted capillary stiction cannot be ruled out by this test result alone.
+> **Cost note:** This is a mask-layer stop-geometry revision on the existing process baseline, not a process deviation — fits within the current lot's re-spin budget (~$50k NRE + ~$10k/wafer for a 3-5 wafer confirmation lot) rather than requiring a new dedicated-process qualification.
+> **Verification plan:** Re-run self-test on confirmation lot; target failure rate <1%. Re-characterize leak rate on a subset with a higher-resolution method (e.g., accumulation/tracer method) before declaring the hermeticity fix closed.
+
+## Sources
+
+- Chang Liu, *Foundations of MEMS*, 2nd ed. (Pearson) — electrostatic pull-in derivation and the g/3 stable-travel limit.
+- Ville Kaajakari, *Practical MEMS* (Small Gear Publishing, 2009) — worked actuator/sensor design examples, pull-in behavior in practice.
+- MIL-STD-883, Method 1014 (Seal) — hermeticity leak-rate test method and its stated resolution floor relative to small package cavities.
+- JEDEC JESD22-B104 (mechanical shock) and JESD22-A104 (temperature cycling) — qualification test parameters (g-level/duration/axes; temperature range/ramp/dwell).
+- Michael R. Douglass (Texas Instruments), "DMD reliability: a MEMS success story," SPIE Proceedings vol. 4980 (2003) — hinge-memory creep failure mechanism under sustained one-sided actuation.
+- SPIE perspective paper on MEMS component reliability (Proc. SPIE 6884, 68840B) — pilot-lot stiction failure-rate data and fatigue-strength benchmarks for hermetically sealed single-crystal-Si structures.
+- Bosch Semiconductors, DRIE process capability documentation — aspect-ratio figures by production tier (R&D/development/mass production).
+- Sandia National Laboratories, SUMMiT V process documentation (MESA program) — named 5-layer poly-Si surface-micromachining process and achievable structural height.
+- ResearchGate practitioner discussion, "typical cost of producing a first prototype MEMS device... using foundry services" — NRE and per-wafer cost ranges, MPW/shuttle vs. dedicated-lot tradeoff.
+- Reliability of MEMS inertial devices, review literature (PMC/ScienceDirect) — field failure mechanisms (shock-induced drive-lock loss, processing-defect fatigue cracking) in automotive gyroscopes.
+
+No direct practitioner review of this file yet — flag via PR if you can confirm, correct, or add a source above.
+
+## Going deeper
+
+- [references/artifacts.md](references/artifacts.md) — filled templates: pull-in/travel-budget worksheet, process-capability checklist by foundry tier, qualification test-plan skeleton, failure-analysis memo format.
+- [references/red-flags.md](references/red-flags.md) — smell tests for pilot-lot and field failures, with the first question to ask and the data to pull.
+- [references/vocabulary.md](references/vocabulary.md) — working vocabulary generalists misuse: pull-in vs. snap-down, hermeticity vs. leak-tightness, aspect ratio by process tier, and more.

--- a/roles/microsystems-engineer/references/artifacts.md
+++ b/roles/microsystems-engineer/references/artifacts.md
@@ -1,0 +1,120 @@
+# Artifacts
+
+Filled worksheets and memo templates for the deliverables a microsystems engineer produces at design review, layout freeze, and pilot-lot failure analysis. Numbers below extend the SKILL.md worked example (5-layer poly-Si accelerometer, g = 2.4 µm sense gap) plus independent worked cases for the templates that example doesn't exercise.
+
+## 1. Pull-in / travel-budget worksheet
+
+Formula: `x_pi (pull-in limit) = g / 3`, where g is the physical sense/actuation gap. Usable design travel should sit at 70-80% of x_pi, leaving margin for the mechanical stop.
+
+| Device | Physical gap g | Pull-in limit x_pi = g/3 | Stop placement (75% of x_pi) | Usable signal range |
+|---|---|---|---|---|
+| Accelerometer proof mass (worked example) | 2.4 µm | 0.80 µm | 0.60 µm | 0-0.60 µm before stop contact |
+| Comb-drive resonator (lateral) | 3.0 µm | 1.00 µm | 0.75 µm | 0-0.75 µm |
+| RF MEMS switch (vertical) | 1.5 µm | 0.50 µm | 0.375 µm | 0-0.375 µm |
+| Micromirror torsion actuator | 4.0 µm | 1.33 µm | 1.00 µm | 0-1.00 µm |
+
+**Check order at design review:** (1) confirm g is the *as-fabricated* gap from the process's sacrificial-layer thickness spec, not the drawn/nominal gap; (2) compute x_pi; (3) confirm stop placement is strictly less than x_pi with the 20-25% margin above, never placed past x_pi "to gain range"; (4) if the design needs more than x_pi of travel, flag for leveraged or charge-controlled actuation — do not solve it by moving the stop.
+
+**Template line for a design-review comment:**
+"Gap g = [N] µm → pull-in limit x_pi = [N/3] µm. Stop currently specified at [N] µm, which is [inside/past] the pull-in limit. [Approve as-is / Move stop to [0.75 × x_pi] µm before layout freeze.]"
+
+## 2. Process-capability checklist, by foundry production tier
+
+DRIE aspect-ratio capability is tier-dependent — check the layout against the tier the part will actually ship on, not the foundry's best demonstrated number.
+
+| Parameter | R&D tier | Development tier | Mass-production tier |
+|---|---|---|---|
+| DRIE aspect ratio (max) | ~80:1 | ~60:1 | ~40:1 |
+| Typical yield expectation at rated AR | Not tracked (single-lot) | 70-85% | >95% |
+| Minimum feature size (named 5-layer poly-Si process) | 1.5 µm | 2.0 µm | 2.0 µm |
+| Structural layer count available | Up to 5 (full stack) | 5 | 3-5 (customer-selectable) |
+| CD (critical dimension) tolerance | ±0.25 µm (uncontrolled) | ±0.15 µm | ±0.10 µm, SPC-tracked |
+
+**Layout-freeze gate (run every item before releasing to fab):**
+1. Pull the target lot's declared production tier from the fab quote, not the PDK's headline capability number.
+2. For every DRIE feature, compute drawn aspect ratio = trench depth / trench width. Compare against the tier's max AR with a 15% design margin (e.g., mass-production 40:1 → design ceiling 34:1).
+3. Confirm minimum feature size against the tier column, not the process's absolute floor.
+4. Cross-check CD tolerance against the design's stated mechanical tolerance stack-up (e.g., a spring constant that assumes ±0.05 µm CD will not hold at ±0.10 µm production tolerance — recompute stiffness sensitivity before freeze).
+5. If any item fails at the target tier but passes at R&D tier, the design is **not** ready for that lot type — route back to layout, do not waive on the R&D number.
+
+## 3. Qualification test-plan skeleton (shock + thermal cycling + hermeticity)
+
+Built to JEDEC JESD22-B104 (shock) / JESD22-A104 (temperature cycling) and MIL-STD-883 Method 1014 (hermeticity), filled for a representative automotive-grade MEMS accelerometer program.
+
+```
+QUALIFICATION TEST PLAN — [Device], [Program/Lot ID]
+
+1. MECHANICAL SHOCK (JESD22-B104, Condition [X])
+   Peak acceleration:      1,500 g
+   Pulse duration:         0.5 ms, half-sine
+   Axes:                   6 (±X, ±Y, ±Z)
+   Shocks per axis:        5
+   Pass criterion:         Post-shock offset drift < 2% FSO; no self-test failure
+
+2. TEMPERATURE CYCLING (JESD22-A104, Condition [X])
+   Range:                  -40°C to +125°C
+   Ramp rate:               ≥10°C/min
+   Dwell at extremes:       15 min minimum
+   Cycles:                  500 (automotive-grade default; 1,000 for safety-critical)
+   Pass criterion:         Parametric drift within datasheet limits; no delamination
+
+3. HERMETICITY (MIL-STD-883 Method 1014, He-bomb)
+   Bomb condition:          [pressure/time per method table, by cavity volume]
+   Cavity volume (actual):  [N] cm³
+   Method resolution floor: ~5e-11 atm·cm³/s
+   Pass criterion:          Measured leak rate < method's calculated reject limit
+   >>> If cavity volume < 1e-3 cm³: flag resolution-floor gap explicitly (see
+       artifact 4) and specify a confirmatory higher-resolution method
+       (accumulation or tracer-gas) on a subsample before closing hermeticity.
+
+4. DUTY-CYCLE / SUSTAINED-ACTUATION LIFE TEST (supplements peak-voltage-only qual)
+   Drive pattern:           Field-representative asymmetric duty cycle (not 50/50)
+   Temperature:             Operating max, sustained (not transient)
+   Duration:                [N] equivalent field-years, accelerated per Arrhenius model
+   Pass criterion:          Hinge/flexure residual set < [N]% of stroke at test end
+
+SIGN-OFF: Reliability engineer + design owner, both required before lot release.
+```
+
+## 4. Hermeticity resolution-floor cross-check
+
+Method 1014's He-bomb resolution floor (~5×10⁻¹¹ atm·cm³/s) is fixed regardless of cavity size — the risk is that a fixed-resolution test under-resolves a small cavity's actual leak-rate requirement.
+
+| Cavity volume | Method 1014 resolution floor | Leak rate needed to matter (order-of-magnitude) | Floor vs. requirement |
+|---|---|---|---|
+| 5×10⁻⁴ cm³ (worked example) | 5×10⁻¹¹ atm·cm³/s | ~5×10⁻¹² atm·cm³/s | Floor is ~10x coarser — flag |
+| 5×10⁻³ cm³ | 5×10⁻¹¹ atm·cm³/s | ~5×10⁻¹¹ atm·cm³/s | Floor roughly matches — acceptable |
+| 5×10⁻² cm³ | 5×10⁻¹¹ atm·cm³/s | ~5×10⁻¹⁰ atm·cm³/s | Floor resolves with margin — no flag |
+
+**Rule of thumb applied above:** for cavities under ~10⁻³ cm³, treat a Method 1014 pass as necessary but not sufficient; require either a confirmatory higher-resolution method or a getter/desiccant plus tightened seal spec independent of the pass result.
+
+## 5. Failure-analysis / design-change memo (format + skeleton)
+
+The filled, as-issued example memo lives in SKILL.md's Worked Example section (same pilot-lot accelerometer case) — see that file for the literal issued text rather than a second copy here. Below is the reusable skeleton with the field-by-field intent explained.
+
+**Template skeleton for a new memo (fill every field, never leave a bracket in the issued version):**
+
+```
+FAILURE ANALYSIS & DESIGN CHANGE MEMO — [Device], [Lot ID], [Date]
+
+Finding:        [Failure rate]% on [test] traced to [mechanism], computed as
+                 [formula with actual numbers] against [spec/limit].
+Change:         [Specific dimensional/process change with margin stated].
+Secondary
+finding:        [Any co-occurring risk, e.g. test-method resolution gap].
+Cost note:      [Mask-only revision vs. process-deviation vs. new qual — dollar figure].
+Verification
+plan:           [Re-test method, target pass rate, and what closes the finding].
+```
+
+## 6. MPW shuttle vs. dedicated lot — decision worksheet
+
+| Factor | MPW shuttle | Dedicated lot |
+|---|---|---|
+| Typical NRE | Shared maskset cost, ~$5k-15k per design slot | ~$50k+ for a 3-5 wafer lot |
+| Per-wafer cost | Bundled into slot fee | ~$10k/wafer additional |
+| Process flexibility | Locked to foundry's standard process/PDK | Can deviate (custom layer, thickness, material) |
+| Schedule | Fixed shuttle calendar (may be months out) | Scheduled to program need |
+| Best fit | First prototype, process-standard design, cost-sensitive validation | Design needs a non-standard process step, or shuttle schedule doesn't fit program |
+
+**Decision rule applied:** default to MPW for a first prototype unless the design requires a process deviation the foundry's standard shuttle offering doesn't support — in that case the dedicated lot's cost is the price of the deviation, not a discretionary choice.

--- a/roles/microsystems-engineer/references/red-flags.md
+++ b/roles/microsystems-engineer/references/red-flags.md
@@ -1,0 +1,58 @@
+# Red flags — what a microsystems engineer notices instantly
+
+Smell tests with thresholds. Any one can be innocent; two or three together in the same layout, test report, or failure-analysis packet is a pattern worth stopping the review for.
+
+### Mechanical overload stop set past g/3 of the sense/actuation gap
+- **Usually means:** the stop was sized to the maximum expected shock displacement or to a rounded fraction of the physical gap, without computing the electrostatic pull-in limit — the plate goes electrostatically unstable and snaps to contact before it ever reaches the intended mechanical stop.
+- **First question:** "What's the pull-in limit (g/3) for this gap, and is the stop distance below it with margin?"
+- **Data to pull:** the sense-gap dimension from the process stack, the stop-geometry drawing, and the computed pull-in displacement.
+
+### Pilot-lot self-test or stiction failure rate above ~2-3% with no travel/stop-geometry check performed first
+- **Usually means:** the failure was routed straight to surface chemistry (add a hydrophobic coating, re-run) before checking whether the stop sits past the pull-in point — geometry defects are cheaper and faster to diagnose than a chemistry root cause and are the more common culprit.
+- **First question:** "Has the stop-versus-pull-in check been run on this design before a coating change is proposed?"
+- **Data to pull:** the pilot-lot self-test failure log, the stop-geometry drawing, and the pull-in calculation.
+
+### Hermeticity result reported as a flat pass against MIL-STD-883 Method 1014 with no cavity-volume context
+- **Usually means:** the test's ~5×10⁻¹¹ atm·cm³/s resolution floor is being treated as universally adequate, when for a cavity under ~10⁻³ cm³ a real leak can sit an order of magnitude below what the method can resolve — "passed Method 1014" and "actually sealed" are different claims at this scale.
+- **First question:** "What's the package cavity volume, and does the measured leak rate sit within an order of magnitude of the test's resolution floor?"
+- **Data to pull:** the Method 1014 leak-rate result, the cavity volume from the package drawing, and the method's stated resolution floor.
+
+### DRIE feature aspect ratio validated only against a ~80:1 lab/R&D-tier capability number, not the ~40:1 mass-production tier, before layout freeze
+- **Usually means:** the design was checked against the foundry's best demonstrated aspect ratio (~80:1) rather than the production-tier number (~40:1) the part will actually ship on — a feature that survives at lab scale doesn't survive at mass-production yield.
+- **First question:** "Is this aspect ratio checked against the foundry's stated production-tier capability, or against a best-case R&D figure?"
+- **Data to pull:** the foundry's process-capability documentation broken out by tier, and the specific feature's aspect ratio in the layout.
+
+### Reliability sign-off based on peak-voltage overload survival alone, with no duty-cycle or sustained-drive test
+- **Usually means:** the qualification plan tested instantaneous overload but never modeled sustained one-sided actuation at operating temperature — hinge memory/creep is a slow, cumulative failure mode that a peak-voltage-only test doesn't exercise, and a part that survives the overload test can still fail in the field from a drive pattern the test never ran.
+- **First question:** "What's the duty cycle and thermal exposure this element sees in the field, and has it been tested at that profile, not just at peak voltage?"
+- **Data to pull:** the field drive-pattern/duty-cycle spec, the qualification test plan, and the life-test rig's actual run conditions.
+
+### Shock or temperature-cycling qualification plan states peak g-level and temperature extremes but omits axis count, ramp rate, or dwell time
+- **Usually means:** the plan was written from a rounded approximation of JESD22-B104/A104 rather than the standard's actual parameters — matching peak values while dropping ramp rate or dwell isn't equivalent qualification.
+- **First question:** "Does this test plan specify axis count, shocks per axis, ramp rate, and dwell exactly as JESD22-B104/A104 require, or only the peak numbers?"
+- **Data to pull:** the qualification test plan and the relevant JEDEC standard's full parameter table.
+
+### Dedicated fab lot committed before a process-capability or pull-in/stop-margin check has been run
+- **Usually means:** schedule pressure pushed the team past a cheap simulation or MPW shuttle check straight to a $50k-plus NRE plus ~$10k-per-wafer dedicated lot — a defect an MPW run or a pull-in calculation would have caught for a fraction of the cost is instead discovered after committing to the lot.
+- **First question:** "Has this design passed a process-capability check and a pull-in/stop-margin check, or an MPW shuttle run, before the dedicated-lot PO was cut?"
+- **Data to pull:** the design-review sign-off record, the MPW shuttle schedule (if any), and the dedicated-lot cost/NRE commitment.
+
+### SPC control chart on wafer critical dimensions shows drift trending toward the design's tolerance band with no design-margin re-check
+- **Usually means:** the process is trending out of the window the design was validated against, but the drift is being tracked as a fab-yield metric only, not fed back into whether the design's stop margins and pull-in calculations still hold at the drifted dimension.
+- **First question:** "At the current drift trend, does the pull-in/stop-margin calculation still hold, or does it need to be re-run against the drifted critical dimension?"
+- **Data to pull:** the SPC control chart for the relevant critical dimension and the original design-margin worksheet it was validated against.
+
+### Anti-stiction contact geometry (dimple, standoff) absent at a mechanical stop that arrests overtravel
+- **Usually means:** the stop was placed to prevent electrostatic pull-in contact but the contact surface itself was left flat, leaving capillary or van der Waals stiction risk at the stop even though the pull-in failure mode was correctly addressed.
+- **First question:** "Is there anti-stiction contact geometry at this stop, or is it a flat mechanical contact?"
+- **Data to pull:** the stop-geometry drawing detail at the contact point.
+
+### Failure-analysis memo attributes a field return to "reliability" or "wear" without naming a specific mechanism
+- **Usually means:** the finding wasn't traced to a distinguishable mechanism (pull-in overtravel, hinge-memory creep, moisture-assisted capillary stiction, fatigue crack) before being written up, which means the recommended fix is a guess rather than a targeted design change.
+- **First question:** "Which specific mechanism — pull-in, creep, moisture-assisted stiction, fatigue — does the failure data point to, and what data separates it from the alternatives?"
+- **Data to pull:** the field-return failure log, SEM/optical inspection images if available, and the device's actual drive/thermal history.
+
+### Duty-cycle margining applied uniformly across all actuators after a hinge-memory finding, including intermittent-duty elements
+- **Usually means:** an overcorrection from a genuine creep finding on one actuator got generalized to the whole design without checking which elements actually see sustained asymmetric drive — intermittent-duty elements were never at risk from creep and don't need the same margin.
+- **First question:** "Which actuators in this design actually see sustained one-sided drive, versus intermittent or symmetric drive that was never the creep risk?"
+- **Data to pull:** the per-actuator drive-pattern spec across the design, not just the one that triggered the finding.

--- a/roles/microsystems-engineer/references/vocabulary.md
+++ b/roles/microsystems-engineer/references/vocabulary.md
@@ -1,0 +1,68 @@
+# Vocabulary
+
+Working terms of art that generalists (or engineers new to MEMS) routinely misuse — not terms you could just look up and get right, but terms whose common usage papers over a distinction that changes the design or the failure diagnosis.
+
+**Pull-in (electrostatic instability point)**
+Definition: The displacement (≈g/3 for a parallel-plate actuator with linear spring) past which the electrostatic force gradient exceeds the mechanical restoring-force gradient, so the plate accelerates uncontrollably to contact regardless of further voltage change.
+In use: "Size the sense range to stay under pull-in — x_pi = g/3 for this gap, not the full physical gap."
+Misuse note: Generalists use "pull-in" and "snap-down" interchangeably, or conflate pull-in with "hitting the mechanical stop." Pull-in is an instability *threshold* — a point where control is lost — not a contact event. A design can pull in and never touch a physical stop if the stop is misplaced past x_pi, which is precisely the stiction failure mode in this role's worked example.
+
+**Snap-down**
+Definition: The physical contact event that follows pull-in — the plate accelerating from the pull-in point to the opposing surface or stop under the now-unbalanced electrostatic force.
+In use: "The 9% self-test failures are snap-down events triggered because the stop sits past pull-in, not at it."
+Misuse note: Treated as a synonym for pull-in. Keeping them distinct matters for diagnosis: pull-in is the geometric/electrical threshold you compute at design time; snap-down is the observed physical event during failure analysis. A report that says "pull-in occurred" when it means "the part snapped down and stuck" obscures whether the root cause is instability (wrong stop placement) or something else (voltage transient).
+
+**Hermeticity**
+Definition: A package's tested leak rate as measured against a specific standard method's detection floor — a pass/fail result relative to that method's resolving power, not an absolute statement about the seal.
+In use: "The package passed Method 1014, but hermeticity here is bounded by the test's ~5×10⁻¹¹ atm·cm³/s resolution floor, not the actual leak rate."
+Misuse note: Generalists treat "hermetic" (passed the test) and "sealed" (no meaningful leak path exists) as the same claim. For a cavity under ~10⁻³ cm³, a real leak can sit an order of magnitude below what the standard test can detect — "passed hermeticity" is a statement about test resolution, not proof of a sealed package.
+
+**Leak-tightness**
+Definition: The cavity's actual physical leak rate, independent of whether any given test method can resolve it.
+In use: "Leak-tightness for this cavity volume needs a tracer/accumulation method — Method 1014 can't resolve it."
+Misuse note: Used loosely as a synonym for "hermeticity" when it should be the thing hermeticity testing is trying (and sometimes failing) to measure. Separating the two forces the question "does our test method actually resolve the leak rate this cavity needs?" instead of stopping at "did it pass."
+
+**Aspect ratio (DRIE, process-tier-qualified)**
+Definition: The etch depth-to-width ratio a given fabrication process can reliably achieve, which is not a single number for a process — it drops from roughly 80:1 at R&D/lab scale to ~60:1 at development scale to ~40:1 at mass production.
+In use: "That trench validates at 75:1 in the lab run, but the target foundry's production-tier capability is 40:1 — it won't hold at volume."
+Misuse note: Generalists quote a single "the foundry's aspect ratio" figure, usually the best demonstrated (R&D) number, and layout-freeze against it. The number that matters is the number for the *production tier the part will actually ship on* — a feature that survives only at lab-scale capability isn't manufacturable yet, even though it etched fine in the qualification run.
+
+**MPW (multi-project wafer) shuttle**
+Definition: A scheduled foundry run where multiple customers' designs share a single maskset and wafer lot, splitting NRE cost across tenants in exchange for a fixed process offering and shared schedule.
+In use: "Run the first prototype on the next MPW shuttle instead of a dedicated lot — it's the same process baseline for a fraction of the NRE."
+Misuse note: Non-specialists treat "shuttle" as simply "the cheap option" without weighing the constraint it buys: a shuttle run locks you to the foundry's standard process offering. If the design needs any deviation from that standard process, the shuttle isn't actually available to you at any price — the choice isn't cost vs. no-cost, it's "does my design fit the standard process" first.
+
+**NRE (non-recurring engineering)**
+Definition: The one-time cost to set up a fabrication run — mask sets, process qualification, tooling — distinct from the marginal per-wafer or per-die cost that scales with volume.
+In use: "The stop-geometry fix is a mask-layer revision on the existing baseline, so it's inside the current lot's NRE budget, not a new qualification."
+Misuse note: Generalists use "NRE" loosely to mean "the expensive part" without distinguishing it from per-wafer cost, which matters when deciding whether a design change requires a full new dedicated-process qualification (new NRE) or fits within an existing baseline (per-wafer cost only). Conflating the two makes every re-spin look like the same size decision when they aren't.
+
+**Stiction**
+Definition: Adhesion between two microstructure surfaces in contact (or near-contact, via capillary/van der Waals/electrostatic forces) sufficient to prevent release under the device's normal restoring force.
+In use: "The self-test failures present as stiction, but the root cause is geometric — the stop is past pull-in — not surface chemistry."
+Misuse note: Used as if it names a single cause (usually assumed to be surface chemistry or humidity), when it's a description of an *outcome* that geometric (uncontrolled pull-in contact), chemical (surface energy, contamination), and environmental (moisture ingress) causes can all produce. Reaching for a hydrophobic coating before checking stop-geometry-vs-pull-in-margin is the textbook misdiagnosis this term invites.
+
+**Hinge memory / creep**
+Definition: Cumulative plastic deformation of a flexure or hinge under sustained, one-sided (asymmetric) actuation at operating temperature, producing a residual set that grows with duty cycle and thermal exposure — distinct from instantaneous mechanical overload.
+In use: "Peak-voltage overload testing won't catch hinge memory — it only shows up under prolonged asymmetric drive, so model duty cycle and temperature explicitly."
+Misuse note: Generalists fold this into generic "fatigue" or assume a part that passes overload/shock qualification is reliable for lifetime. Hinge memory is a slow, duty-cycle-and-temperature-driven mechanism that a peak-voltage-only test plan structurally cannot exercise — passing overload qual says nothing about it.
+
+**Duty cycle (for reliability, not just power)**
+Definition: In this domain, the fraction of time and the directional symmetry of actuation drive — not just an average power/on-time metric — because sustained one-sided drive is what produces hinge memory, while symmetric or intermittent drive at the same average duty cycle may not.
+In use: "Flag the actuator for creep modeling because its duty cycle is asymmetric and sustained, not because the number is high."
+Misuse note: Treated as a single scalar ("80% duty cycle") that can be compared across parts. What matters for creep risk is asymmetry and sustained direction, not just time-on — over-margining every high-duty-cycle actuator, including ones with a genuinely intermittent or symmetric drive profile, is a documented overcorrection failure mode in this role.
+
+**Qualification (vs. verification)**
+Definition: Qualification is passing a defined standard test (e.g., JEDEC JESD22-B104 shock, Method 1014 hermeticity) at its stated parameters; verification is confirming the part meets its actual design requirement, which the qualification test may or may not fully resolve.
+In use: "It's qualified per Method 1014, but we still need to verify leak-tightness with a higher-resolution method before closing this out."
+Misuse note: Used interchangeably in casual engineering conversation. The distinction is the entire point of flagging small-cavity hermeticity as a known gap — a part can be fully qualified (passed the named standard) while remaining unverified against the requirement that standard was supposed to stand in for.
+
+**Process capability (tier-qualified, not single-valued)**
+Definition: A foundry's demonstrated manufacturing performance (aspect ratio, layer thickness/count, minimum feature size, critical-dimension tolerance) stated per production tier — R&D, development, mass production — rather than as one number for "the process."
+In use: "Check the layout against the foundry's mass-production process capability, not the demonstrated R&D capability."
+Misuse note: Generalists ask "what's this foundry's process capability" expecting a single figure, then design against whichever number the sales deck or a best-case datasheet cell happens to show — usually the R&D-tier best case, which is the wrong number for a part intended to ship at volume.
+
+**Overload stop (vs. pull-in limit)**
+Definition: A designed mechanical feature that physically arrests structure overtravel at a chosen displacement — a deliberate design element, not a physics limit like pull-in, and its correctness depends entirely on where it's placed relative to the pull-in limit.
+In use: "Move the overload stop to 0.6 µm, 25% margin below the 0.8 µm pull-in limit, so the stop — not electrostatic snap-down — always arrests overtravel."
+Misuse note: Assumed to be inherently protective simply because it exists inside the physical gap. A stop placed *past* the pull-in limit provides no protection — the structure goes unstable and snaps to contact before ever reaching the stop, which is exactly the geometry defect in this role's worked failure analysis.


### PR DESCRIPTION
rubric: 18/18

## Resolution rationale

Microsystems Engineers (O*NET 17-2199.06) design/fabricate MEMS and microscale devices: photolithography/etch process selection, wafer-level yield and defect-density reasoning, stiction and fatigue failure modes at micron scale, cleanroom contamination control, and MEMS packaging/hermeticity tradeoffs. None of the three closest CLI candidates share this decision surface: aerospace-engineer's core is airframe mass/margin budgeting against 14 CFR certification bases (macro-structural, not microfabrication); agricultural-engineer covers farm equipment/irrigation systems engineering; application-security-engineer covers software vulnerability/threat-model reasoning. A practitioner doing MEMS process/design work would get actively wrong guidance from any of these three (wrong tools — e.g. no DRIE/etch selectivity, wafer-bow, or release-etch stiction guidance; wrong failure modes — no fatigue-at-micron-scale or squeeze-film damping; wrong decision framework — no yield/defect-density or foundry PDK tradeoffs). No reasonable parent exists among the candidates, so this warrants a new top-level (parent) role rather than a leaf under any of them. Existing repo roles (electrical-engineer, materials-engineer, mechanical-engineer, photonics-engineer) are plausible siblings/parents for a future generalization but were not part of the given candidate set and are each too broad/adjacent to serve as a granularity-correct parent without their own review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `microsystems-engineer` role for MEMS design/fabrication decisions (pull-in limits, DRIE, hermeticity, reliability), mapped to O*NET 17-2199.06. Registers the role and updates `README`, `ROADMAP`, and `data/roles.json` (538 roles total; 52.0% O*NET coverage; engineering +1).

- **New Features**
  - Added `roles/microsystems-engineer/SKILL.md` (spec-2) with core MEMS guidance and a worked example.
  - Added references: `references/artifacts.md` (worksheets and test-plan skeletons), `references/red-flags.md`, and `references/vocabulary.md`.

<sup>Written for commit 73c1a2238471ca18b3853cbd0899398ca47cc655. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

