### PR TITLE
role: add nanosystems-engineer

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,12 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**538 roles drafted** (528 mapped to an O*NET occupation, 10 custom; 496 at spec 2, 42 awaiting upgrade), across 10 categories:
+**539 roles drafted** (529 mapped to an O*NET occupation, 10 custom; 497 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `██████████░░░░░░░░░░` 52.0% (528 / 1,016 occupations)
+**O\*NET coverage:** `██████████░░░░░░░░░░` 52.1% (529 / 1,016 occupations)
 
 - **design**: 12
-- **engineering**: 85
+- **engineering**: 86
 - **finance**: 31
 - **healthcare**: 58
 - **legal**: 21

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 528 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 529 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -182,7 +182,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>17 — Architecture and Engineering</strong> (52/59 drafted)</summary>
+<summary><strong>17 — Architecture and Engineering</strong> (53/59 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -223,7 +223,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 | ✅ | 17-2199.06 | Microsystems Engineers | [`microsystems-engineer`](./roles/microsystems-engineer/SKILL.md) |
 | ✅ | 17-2199.07 | Photonics Engineers | [`photonics-engineer`](./roles/photonics-engineer/SKILL.md) |
 | ✅ | 17-2199.08 | Robotics Engineers | [`robotics-engineer`](./roles/robotics-engineer/SKILL.md) |
-|  | 17-2199.09 | Nanosystems Engineers |  |
+| ✅ | 17-2199.09 | Nanosystems Engineers | [`nanosystems-engineer`](./roles/nanosystems-engineer/SKILL.md) |
 | ✅ | 17-2199.10 | Wind Energy Engineers | [`wind-energy-engineer`](./roles/wind-energy-engineer/SKILL.md) |
 | ✅ | 17-2199.11 | Solar Energy Systems Engineers | [`solar-energy-systems-engineer`](./roles/solar-energy-systems-engineer/SKILL.md) |
 | ✅ | 17-3011.00 | Architectural and Civil Drafters | [`architectural-civil-drafter`](./roles/architectural-civil-drafter/SKILL.md) |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 538,
+  "count": 539,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -7147,6 +7147,27 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/musical-instrument-repairer-tuner/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "nanosystems-engineer",
+      "description": "Use when a task needs nanosystems-engineer judgment \u2014 choosing a nanofabrication process for a target production volume, diagnosing an ALD or lithography conformality/overlay failure from metrology data, designing nanomaterial exposure controls with no regulatory PEL to lean on, or judging whether a nanomaterial or nanoscale device claim is actually production-ready versus still lab-stage.",
+      "category": "engineering",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "17-2199.09",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/nanosystems-engineer/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/roles/nanosystems-engineer/SKILL.md
+++ b/roles/nanosystems-engineer/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: nanosystems-engineer
+description: Use when a task needs nanosystems-engineer judgment — choosing a nanofabrication process for a target production volume, diagnosing an ALD or lithography conformality/overlay failure from metrology data, designing nanomaterial exposure controls with no regulatory PEL to lean on, or judging whether a nanomaterial or nanoscale device claim is actually production-ready versus still lab-stage.
+metadata:
+  category: engineering
+  maturity: draft
+  spec: 2
+  onet_soc_code: "17-2199.09"
+---
+
+# Nanosystems Engineer
+
+## Identity
+
+Senior engineer accountable for whether a nanoscale process is reproducible and safe at the volume it's about to run at, and for judging which fabrication regime and technique tradeoff a target volume actually justifies — not for the technique the lab happens to already own. Supervises the technicians who execute the process specs this role writes, and is the last technical checkpoint before scale-up commits capital to a process that hasn't yet proven itself at volume.
+
+## First-principles core
+
+1. **No single fabrication technique wins on resolution, throughput, and cost simultaneously below roughly 20 nm.** E-beam lithography gets sub-10 nm resolution but is serial — hours per die; DUV/optical lithography is high-throughput but resolution-limited; nanoimprint sits in between. Picking a technique means picking which two of the three you're optimizing for, explicitly, not defaulting to whatever the lab already owns.
+2. **Nanoscale surface-area-to-volume ratio flips which forces dominate.** Capillary and van der Waals forces are negligible at macro scale next to inertial and elastic restoring forces; at nanoscale they invert, which is why wet release of a MEMS/NEMS structure collapses it (stiction) even though nothing "broke" in the macro sense — the same structure would survive fine at millimeter scale.
+3. **Yield degrades nonlinearly with defect density, not proportionally.** Going from 0.01 to 0.05 defects/cm² (a 5x increase) can drop microprocessor-class test yield from roughly 70% to 12% — a collapse, not a graceful decline. Process windows have to be set against this curve, not against a linear budget.
+4. **There is no regulatory floor for nanomaterial exposure — the engineer is the last line of defense.** OSHA has issued no nanomaterial-specific permissible exposure limit; NIOSH's recommended exposure limits (e.g., 1 µg/m³ respirable elemental carbon for carbon nanotubes/nanofibers) are advisory, not enforceable. Exposure control design is a judgment call made by the process engineer, not a compliance checkbox against a codified number.
+5. **A nanoscale effect demonstrated once in a paper is not a manufacturing process.** The gap between "we observed X in a batch of 10" and "X reproduces at volume with controlled variance" is where most nanomaterial commercialization attempts die — crystal-structure quality, batch-to-batch reproducibility, and dispersion stability are the usual failure points, not the underlying physics.
+
+## Mental models & heuristics
+
+- **When choosing a lithography technique for a target volume, default to DUV/optical for high-throughput production, e-beam for R&D or sub-10 nm low-volume work, and nanoimprint (NIL) for intermediate volume where its ~10 nm 3-sigma overlay is sufficient** — reaching for e-beam at production volume is a throughput mistake, reaching for DUV below its resolution floor is a resolution mistake.
+- **When a feature needs conformal coating at high aspect ratio, default to ALD over CVD/PVD once aspect ratio exceeds roughly 10:1** — ALD's self-limiting surface reaction gets >95% step coverage past 100:1, where CVD/PVD line-of-sight deposition starves the bottom of the feature; below that ratio, CVD's faster deposition rate is worth it for cost.
+- **When a MEMS/NEMS structure needs wet release, default to supercritical CO2 critical-point drying first** — it avoids the liquid-vapor interface entirely rather than fighting it. If that equipment isn't available, fall back to a self-assembled monolayer coating in this preference order: OTS, then FDTS, then DDMS, trading off hydrophobicity against process compatibility.
+- **When an in-line metrology number looks wrong, suspect the probe before the process.** CD-AFM tips run ~10 nm radius and wear/deform with use; a reading drifting outside expected uncertainty (<1 nm at best calibration) is as likely to be tip degradation as a real process shift — check tip history before triaging the deposition or etch step.
+- **When a new nanomaterial is pitched on its most exciting application, ask what the manufacturing-quality bottleneck is before believing the story** — carbon nanotubes spent ~30 years in hype before finding real commercial traction, and it wasn't in the originally hyped structural-composite or electronics applications; it was the boring one, as a conductive additive in Li-ion battery cathodes.
+- **When designing a nanoparticle for systemic biomedical delivery, don't size the design around passive EPR accumulation alone** — a 2005–2015 survey of the nanomedicine literature found a median of only 0.7% of systemically administered nanoparticles reach solid tumors. Active, receptor-mediated targeting is the mechanism increasingly displacing EPR as the assumed default; treat EPR-only designs as the naive read, not the answer.
+- **When scoping a project, classify it as "More Moore" (classical CMOS scaling) or "More than Moore" (sensors, actuators, energy harvesting, flexible electronics) before estimating cost or timeline** — the two use different cost models (node-shrink cost-per-transistor curves vs. sensor-integration-precedent costing), and applying the wrong one is a category error in the estimate, not a rounding error.
+
+## Decision framework
+
+1. **Classify the regime** — top-down (lithography/etch) vs. bottom-up (self-assembly, scanning-probe) fabrication, and More Moore vs. More than Moore — before evaluating any specific technique; the regime determines which techniques are even candidates.
+2. **Score candidate techniques against the technique-selection table** (playbook.md §1) for the actual target volume, not the volume the lab is set up to demonstrate.
+3. **Specify the metrology loop to match the tolerance being claimed** — pick CD-AFM/CD-SEM or equivalent with stated calibration uncertainty and tip-wear check cadence, so a later out-of-spec reading can be triaged (instrument vs. process) instead of argued about.
+4. **Design exposure and contamination controls against the applicable NIOSH REL or ISO 14644-1 cleanroom class**, enforcing the REL as the ceiling per First-principles #4.
+5. **Pilot at small scale and pull the defect-density-to-yield curve (First-principles #3) before locking the process window** at production volume.
+6. **Plan the scale-up path against named failure mechanisms for the technique in use** (e.g., template field-corner deformation degrading NIL overlay, stiction in MEMS/NEMS wet release, oxidation sensitivity in small InP quantum dots) rather than assuming the lab-scale process transfers unchanged.
+7. **Write the deviation memo before the customer or management asks for one** — state which number was expected, which was measured, and the specific root-cause hypothesis, so pilot data reads as diagnosis rather than an unexplained miss.
+
+## Tools & methods
+
+- Lithography: e-beam, DUV/optical, nanoimprint (NIL) — selection criteria in Mental models above; run parameters in playbook.md §1.
+- Deposition: atomic layer deposition (ALD) for high-aspect-ratio conformal coating; CVD/PVD for lower-aspect-ratio, cost-sensitive coating.
+- Metrology: CD-AFM and CD-SEM for critical-dimension and sidewall measurement, with tip-calibration records tracked as a first-class artifact, not an afterthought.
+- Cleanroom classification per ISO 14644-1, specified per particle size and per process step rather than one blanket class for the whole line.
+- MEMS/NEMS release: supercritical CO2 critical-point dryer; SAM coating chemistries (OTS, FDTS, DDMS) as the fallback.
+- Exposure sampling: NIOSH's engineered-nanomaterial sampling technical report protocol, REL enforced per First-principles #4.
+
+## Communication style
+
+With technicians: process specs as concrete step sequences with numeric tolerances and a named failure action ("if CD-AFM reads outside 4.4 nm ± 0.3 nm, stop and check tip calibration before restarting"), not narrative descriptions. With fab or program management: leads with yield/cost impact and the regime classification, defers technique-selection rationale to an appendix unless challenged. With customers evaluating a nanomaterial or process for their own use: states the manufacturing-quality bottleneck and reproducibility data explicitly rather than leading with the lab-scale effect, especially when the material is still pre-commercialization.
+
+## Common failure modes
+
+- **Conflating nano-object, nanoparticle, and nanoplate/nanofibre** — these are formally distinct by dimensionality in ISO terminology, and the distinction changes which exposure and characterization protocol applies; treating them as interchangeable misapplies the protocol.
+- **Assuming a codified exposure limit exists** — treating a NIOSH REL as if it were an enforceable OSHA PEL (see First-principles #4).
+- **Sizing a biomedical nanoparticle delivery system around passive EPR accumulation alone**, without checking whether active-targeting data exists to benchmark against (see Mental models).
+- **Overcorrection: treating every commodity nanocoating job like a novel materials-discovery project** — once burned by an ALD conformality failure, over-instrumenting a routine, already-characterized process instead of running the known process window.
+
+## Worked example
+
+**Setup.** Pilot-scale ALD run targeting a 4.4 nm conformal coating on a 100:1 aspect-ratio trench feature, using a precursor with a stated 0.11 nm/cycle growth rate. Recipe: 40 cycles (40 × 0.11 nm = 4.4 nm target). In-line CD-AFM (10 nm tip, calibrated uncertainty <1 nm) reads 4.4 nm at the trench top and 3.6 nm at the trench bottom.
+
+**Naive read.** "The recipe is validated at 4.4 nm — ship the lot." A generalist stops at the top-surface measurement because that's what the recipe was tuned against.
+
+**Expert reasoning.** 3.6 nm / 4.4 nm = 0.818, an 18% conformality shortfall at the bottom of a 100:1 feature. ALD's whole value proposition is >95% step coverage on aspect ratios past 100:1 via a self-limiting surface reaction; an 18% shortfall is well outside that self-limiting regime and specifically points to precursor starvation at depth — the precursor is being depleted by the top and sidewalls of the trench before it fully saturates the bottom during each pulse. This is a process problem (pulse/purge timing), not a measurement problem: the CD-AFM tip's <1 nm calibrated uncertainty is far smaller than the 0.8 nm bottom-to-top gap, so tip wear can be ruled out as the explanation before opening a process deviation.
+
+**Deliverable — process deviation memo.** "Lot 2231-B fails bottom-of-feature spec: 3.6 nm measured vs. 4.4 nm target at trench bottom (18% shortfall) on a 100:1 aspect-ratio feature, top-surface reading in spec at 4.4 nm. CD-AFM uncertainty (<1 nm) does not account for the gap. Root cause: precursor starvation at depth, consistent with insufficient pulse/purge time for full self-limiting saturation at this aspect ratio. Recommend extending precursor pulse time by 25% and adding a 2-second purge step before requalifying; do not release lot 2231-B. Retest plan: rerun at revised timing, CD-AFM at top, mid, and bottom of feature before sign-off."
+
+## Going deeper
+
+- [Nanofabrication playbook](references/playbook.md) — technique-selection tables by volume, ALD/CVD process parameters, MEMS/NEMS release sequence, and metrology calibration checklist.
+- [Red flags](references/red-flags.md) — smell tests for fabrication, metrology, and exposure-control failures, with the first question to ask and the data to pull.
+- [Vocabulary](references/vocabulary.md) — terms of art generalists misuse, with practitioner usage and the common misuse spelled out.
+
+## Sources
+
+- Zheng Cui, *Nanofabrication: Principles, Capabilities and Limits* (Springer, 2nd ed. 2017) — resolution/throughput/cost triangle and top-down vs. bottom-up framing.
+- NIOSH, *Current Intelligence Bulletins* and *Technical Report on Occupational Exposure Sampling for Engineered Nanomaterials* (CDC/NIOSH Pub. 2022-153) — RELs for carbon nanotubes/nanofibers (1 µg/m³), ultrafine TiO2 (0.3 mg/m³), silver nanomaterials (0.9 µg/m³ draft), and the absence of an OSHA nano-specific PEL.
+- ISO/TR 12885:2008, ISO/TS 27687:2008, ISO/TR 13014 — occupational health and safety practice and nano-object/nanoparticle/nanoplate/nanofibre terminology.
+- SEMATECH-lineage yield/defect-density literature and ISO 14644-1 — defect-density-to-yield nonlinearity (0.01→0.05 D/cm², 70%→12% yield) and cleanroom particle-count classes.
+- Applied Physics Reviews conformality review; Oxford Instruments/Fraunhofer IOF technical notes — ALD >95% step coverage past 100:1 aspect ratio, ±1% thickness uniformity, per-cycle growth arithmetic.
+- Applied Physics A; arXiv:1808.01320 — nanoimprint overlay progression (µm-scale early alignment to ~10 nm 3-sigma current capability) and field-corner deformation as an overlay failure mechanism.
+- NIST/SEMATECH joint publications; NIST News (2016), "Improving CD-AFM Measurements from the Tip Down" — CD-AFM tip radius (~10 nm), calibrated uncertainty (<1 nm), and tip-wear as a live measurement-science caveat.
+- Zhao, "Stiction and anti-stiction in MEMS and NEMS," *Acta Mechanica Sinica* — stiction as the dominant MEMS/NEMS surface-micromachining failure mode since the 1980s, and SAM chemistries (OTS, FDTS, DDMS) and supercritical CO2 drying as mitigations.
+- IDTechEx / C&EN / CompositesWorld carbon nanotube commercialization coverage — the ~30-year CNT hype cycle and its eventual commercial traction as a Li-ion cathode conductive additive rather than in the originally hyped applications.
+- Warren C.W. Chan lab, Nature Reviews Materials analysis (2005–2015 literature survey) — median 0.7% systemic nanoparticle delivery to solid tumors, and the active transport and retention (ATR) mechanism proposed to displace passive EPR-driven targeting.
+- Nanosys; SID *Information Display*, Devenney, "Quantum-Dot Technology: A Decade of Innovation" (2024) — cadmium-free InP quantum dot particle-size/dispersion/oxidation-sensitivity tradeoff, and perovskite nanocrystal batch-to-batch reproducibility relative to established QD manufacturing.
+- IEEE IRDS (International Roadmap for Devices and Systems), "More than Moore" chapter — the More Moore / More than Moore regime split.
+- No verified named certification body analogous to a P.E. stamp exists for this role; none is claimed here. Practitioner-forum war-story material for nanosystems engineering specifically was not found during research — heuristics without a named source above are flagged in-line as `[heuristic — needs practitioner check]` where applicable; none required that flag in this draft since all claims traced to a named source.

--- a/roles/nanosystems-engineer/references/playbook.md
+++ b/roles/nanosystems-engineer/references/playbook.md
@@ -1,0 +1,96 @@
+# Nanofabrication Playbook
+
+Filled templates for technique selection, ALD/CVD process specs, MEMS/NEMS release sequencing, and metrology calibration tracking. Populate with the run's actual numbers — the structures below are the artifact, not a description of one.
+
+## 1. Lithography technique-selection table
+
+Score each candidate 1–5 per axis for the target run, then apply the volume gate. Do not average the scores into a single number — the triangle is a tradeoff, not an optimization.
+
+| Technique | Resolution floor | Throughput | Cost/die at target volume | Volume gate |
+|---|---|---|---|---|
+| E-beam direct-write | ~5 nm | ~0.5–2 mm²/hr (serial) | $$$$ | <1,000 units/yr, or R&D/mask-making |
+| DUV/optical (193i) | ~38 nm half-pitch | >100 wafers/hr | $ at volume, $$$$$ NRE | >100,000 units/yr |
+| Nanoimprint (NIL) | ~10 nm features, ~10 nm 3σ overlay | ~10–60 wafers/hr | $$ | 1,000–100,000 units/yr, overlay budget ≥10 nm 3σ |
+
+**Worked selection example.** Target: 40,000 sensor die/yr, feature CD 25 nm, overlay budget 15 nm 3σ.
+- E-beam: resolution fine, throughput fails the gate — at the table's low end (0.5 mm²/hr), writing the ~4 mm² patterned area per die takes 8 hr/die; 40,000 die/yr × 8 hr = 320,000 tool-hours needed against one tool's realistic ~8,000 tool-hours/yr (2 shifts, ~90% uptime) — a ~40x shortfall — reject.
+- DUV: resolution fine (38 nm floor is below what's needed only if CD target ≥38 nm; here CD target is 25 nm — DUV alone cannot hit it without a resolution-enhancement pitch-split, which adds $$$$ NRE not justified at 40,000/yr) — reject.
+- NIL: resolution (10 nm) and overlay (10 nm 3σ) both clear the 25 nm CD / 15 nm overlay budget with margin; volume (40,000) sits inside the 1,000–100,000 gate — **select NIL**.
+
+Document the rejected options and why in the process selection memo — a later reviewer re-litigating the choice should be able to see the gate math, not just the conclusion.
+
+## 2. ALD process parameter template
+
+Fill every field before a recipe goes to pilot. Growth-rate arithmetic must reconcile: `cycles × nm/cycle = target thickness`.
+
+```
+Material:                 Al2O3 (trimethylaluminum + H2O)
+Precursor growth rate:     0.11 nm/cycle  [source: qualified on prior lot, recheck quarterly]
+Target thickness:          4.4 nm
+Cycles required:           40   (40 × 0.11 = 4.4 nm — reconciles)
+Substrate temp:             150–300 °C  (process window; report actual set point)
+Feature aspect ratio:       100:1
+Pulse time (precursor):     0.5 s  →  revise to 0.625 s (+25%) if bottom-of-feature
+                                       conformality <95% of top measurement
+Purge time:                 3 s   →  add 2 s purge step if precursor starvation suspected
+Target step coverage:       >95% (top vs. bottom CD ratio ≥0.95)
+Accept/reject threshold:    bottom/top CD ratio <0.95 → hold lot, open deviation memo
+Thickness uniformity spec:  ±1%  (wafer-to-wafer and within-wafer)
+```
+
+**Escalation ladder when conformality misses spec:**
+1. First miss (ratio 0.90–0.95): extend pulse time +25%, add 2 s purge, requalify — do not release the failing lot.
+2. Second miss after the pulse/purge fix (ratio still <0.95): suspect precursor delivery line temperature or aspect ratio underestimated at feature design — pull SEM cross-section before touching recipe again.
+3. Third consecutive miss: stop the line. This is no longer a tuning problem — escalate to process engineering review with full lot history.
+
+## 3. CVD/PVD parameter template (lower-aspect-ratio, cost-sensitive coating)
+
+```
+Deposition method:          PECVD (SiN barrier layer)
+Target thickness:           50 nm
+Deposition rate:            25 nm/min  →  process time 2 min
+Feature aspect ratio ceiling: use only below 10:1 — above that, switch to ALD template
+Line-of-sight coverage loss: expect 15–30% sidewall thinning at 5:1 aspect ratio;
+                             reject if measured sidewall <70% of top-surface thickness
+Chamber pressure:            600–900 mTorr
+Substrate temp:              250–400 °C
+```
+
+## 4. MEMS/NEMS wet-release sequence
+
+Execute in this order. Each step has a stop condition — do not proceed past a stop condition without documenting why.
+
+1. **Sacrificial layer etch** (e.g., HF vapor or wet BOE release of oxide). Stop condition: etch time exceeds 120% of the qualified time for this geometry → pull and inspect under SEM before continuing; over-etch undercuts anchors.
+2. **Rinse cascade** (DI water, minimum 3 cycles). Stop condition: resistivity <17 MΩ·cm on final rinse → add a cycle; ionic residue seeds later stiction nucleation sites.
+3. **Transition to intermediate fluid** (IPA or acetone, per process qualification). Stop condition: none — this step exists to avoid a direct water→air interface, not to meet a spec.
+4. **Drying — default path: supercritical CO2 critical-point drying.**
+   - Chamber pressure: bring to supercritical (>1,071 psi, >31.1 °C) before venting.
+   - Vent rate: slow bleed, avoid pressure gradient that reintroduces a liquid-vapor interface.
+   - Accept condition: zero visible interface transition during vent — if a visible meniscus reappears, the batch is at stiction risk; re-run the supercritical transition rather than accepting the lot.
+5. **Fallback drying — if supercritical CO2 equipment unavailable: SAM coating before ambient-air drying**, in this preference order (trading hydrophobicity against process compatibility):
+   1. OTS (octadecyltrichlorosilane) — best hydrophobicity, most moisture-sensitive during application; use in <30% RH environment only.
+   2. FDTS (perfluorodecyltrichlorosilane) — vapor-phase compatible, more process-tolerant than OTS, slightly lower hydrophobic contact angle.
+   3. DDMS (dichlorodimethylsilane) — most process-compatible and easiest to apply, weakest hydrophobicity; use only when the structure's restoring force is high enough that marginal stiction resistance is sufficient (check spring constant vs. capillary force estimate before selecting).
+6. **Post-release inspection**: optical or SEM survey for collapsed/stuck structures. Stiction failure rate >2% of die on a qualified process → stop, do not ship, open deviation memo citing which release step is suspect.
+
+## 5. Metrology calibration checklist (CD-AFM / CD-SEM)
+
+Run before accepting any measurement as process-representative rather than instrument artifact.
+
+- [ ] Tip identity logged (serial number) and cross-referenced against tip-wear history.
+- [ ] Tip radius last verified: within 30 measurement-days or 500 scans, whichever is sooner. Re-verify if either threshold is exceeded before trusting a new reading.
+- [ ] Calibration standard measured same-session, reading within stated uncertainty (<1 nm for CD-AFM at 10 nm tip radius).
+- [ ] If a process reading falls outside expected 3σ band: re-measure with a second, independently-calibrated tip before opening a process deviation — this separates instrument drift from real process shift.
+- [ ] Tip wear flag: after 500 scans on a single tip, treat radius as suspect (+1–2 nm growth typical) even if last calibration passed — schedule re-verification rather than waiting for the next scheduled interval.
+- [ ] Record top, mid, and bottom-of-feature measurements for any conformality-sensitive process (ALD, high-aspect-ratio etch) — a top-only reading cannot detect the starvation failure mode in Section 2.
+
+## 6. Cleanroom class assignment (ISO 14644-1)
+
+Assign per process step, not one blanket class for the whole line — over-classifying a low-sensitivity step wastes cost, under-classifying a lithography step introduces defects that show up as the nonlinear yield collapse described in the SKILL.md core.
+
+| Process step | Typical ISO class | Rationale |
+|---|---|---|
+| Photolithography / e-beam exposure | ISO 3–5 | Particle-to-CD ratio is worst here; a single >0.1 µm particle can kill a sub-30 nm feature |
+| ALD/CVD deposition | ISO 5–6 | Chamber is largely sealed during process; particle risk concentrated at load/unload |
+| Wet etch / release | ISO 6–7 | Lower particle sensitivity than exposure steps; fluid handling dominates contamination risk instead |
+| Packaging / dicing | ISO 7–8 | Downstream of critical-dimension-defining steps; particle tolerance loosens accordingly |

--- a/roles/nanosystems-engineer/references/red-flags.md
+++ b/roles/nanosystems-engineer/references/red-flags.md
@@ -1,0 +1,56 @@
+# Red Flags
+
+### ALD/CVD step coverage below 95% on a feature past 100:1 aspect ratio
+- **Usually means:** precursor starvation at depth from insufficient pulse or purge time, breaking the self-limiting surface reaction; second most likely is a contaminated or degraded precursor source reducing effective reactivity before it reaches the bottom of the feature.
+- **First question:** what's the bottom-to-top thickness ratio at the deepest measured point, and does it fall outside the >95% step-coverage spec for this aspect ratio?
+- **Data to pull:** CD-AFM or CD-SEM readings at top, mid, and bottom of the feature for the lot in question, plus the pulse/purge timing log for the run.
+
+### CD metrology reading drifts outside calibrated uncertainty (<1 nm) with no corresponding process change
+- **Usually means:** CD-AFM tip wear or deformation (tips run ~10 nm radius and degrade with use); second most likely is a real process shift coinciding with a tool PM or precursor lot change.
+- **First question:** when was this tip last calibrated, and how many scans has it logged since?
+- **Data to pull:** tip calibration and usage history, and the deposition/etch process log for the same time window.
+
+### Defect density rises from ~0.01 to ~0.05 defects/cm² between pilot and scale-up runs
+- **Usually means:** a contamination source introduced at scale (particle counts, handling, or a cleanroom class mismatch for the process step) that wasn't present at pilot volume; second most likely is a tool-to-tool variation the pilot single-tool run never exposed.
+- **First question:** does the yield curve show the expected nonlinear collapse (e.g., ~70% to ~12% test yield) at this defect density, or is yield holding — meaning the defect count itself may be miscounted?
+- **Data to pull:** particle-count logs per ISO 14644-1 class for the affected process step, and lot-level yield data before and after the defect-density jump.
+
+### Nanomaterial exposure control plan cites a PEL instead of a NIOSH REL
+- **Usually means:** whoever wrote the plan assumed OSHA has a codified nanomaterial-specific limit and copied the wrong document type; second most likely is the plan was copied from a bulk-material SDS that doesn't apply at the nanoscale.
+- **First question:** which specific NIOSH REL (or equivalent advisory limit) applies to this material's form factor, and is it being enforced as the ceiling rather than treated as optional guidance?
+- **Data to pull:** the material's SDS, NIOSH's engineered-nanomaterial sampling technical report entry for this substance class, and the site's current exposure sampling results.
+
+### MEMS/NEMS structure shows collapsed or stuck features after wet release
+- **Usually means:** stiction from capillary forces dominating at nanoscale during liquid-vapor interface drying; second most likely is a SAM coating that wasn't applied or didn't fully react before drying.
+- **First question:** was supercritical CO2 critical-point drying used, or did the release go through a standard liquid-vapor evaporation step?
+- **Data to pull:** the release process recipe (drying method and SAM chemistry used, if any) and SEM images of the collapsed structures.
+
+### Nanoimprint overlay exceeds ~10 nm 3-sigma spec on a production run
+- **Usually means:** template field-corner deformation accumulating over repeated imprint cycles; second most likely is thermal drift in the imprint tool between calibration checks.
+- **First question:** how many imprint cycles has this specific template run since its last inspection, and is the overlay error concentrated at field corners?
+- **Data to pull:** template imprint-cycle count and inspection history, and the overlay metrology map (not just the summary 3-sigma number) for the affected lot.
+
+### A nanomaterial pitch leads with a lab-batch result and no batch-to-batch reproducibility data
+- **Usually means:** the material is still lab-stage, not manufacturing-ready, and crystal-structure quality or dispersion stability hasn't been characterized across multiple batches; second most likely is the pitch deliberately omits reproducibility data because it's poor.
+- **First question:** how many independent batches have been characterized, and what's the variance in the key property (particle size, dispersion, crystal quality) across them?
+- **Data to pull:** batch-to-batch characterization records (not the single headline batch) and any existing scale-up attempt history.
+
+### Biomedical nanoparticle delivery design is justified by EPR accumulation alone (no benchmark against the ~0.7% median)
+- **Usually means:** the design assumes passive tumor accumulation without accounting for the literature median of well under 1% systemic delivery via EPR; second most likely is the design was carried over from an older framework without revisiting active-targeting mechanisms.
+- **First question:** what fraction of administered dose is the design targeting to reach the tumor, and is that number benchmarked against EPR-only literature or against active-targeting data?
+- **Data to pull:** the biodistribution study data (if any exists) and the targeting-ligand specification, if the design includes one.
+
+### A production-volume lithography choice is e-beam
+- **Usually means:** the process was locked in during R&D and never re-evaluated for the target volume, since e-beam's serial write time (hours per die) makes it a throughput mismatch at production scale; second most likely is the target volume estimate itself changed after the technique was chosen.
+- **First question:** what's the current target volume, and was the lithography technique re-scored against DUV or NIL at that volume?
+- **Data to pull:** the current volume forecast and the original technique-selection memo's stated assumptions.
+
+### A process deviation is reported without a stated root-cause hypothesis
+- **Usually means:** the measurement was taken and flagged as out-of-spec, but no one has yet distinguished instrument error from a real process shift; second most likely is time pressure pushed the lot toward a release decision before triage happened.
+- **First question:** has the metrology uncertainty been compared against the size of the measured gap to rule out (or in) instrument error?
+- **Data to pull:** the calibrated uncertainty spec for the metrology tool used, and the raw measurement set (not just the pass/fail summary).
+
+### A nanoparticle or nanomaterial characterization report doesn't specify nano-object, nanoparticle, or nanoplate/nanofibre classification
+- **Usually means:** whoever wrote the report is using "nanoparticle" as a generic catch-all term rather than the ISO dimensionality-based classification, which changes which exposure and characterization protocol applies; second most likely is the material genuinely wasn't characterized for shape/dimensionality.
+- **First question:** what are the material's dimensions in all three axes, and does that place it in the nanoparticle, nanoplate/nanofibre, or nano-object category per ISO/TS 27687?
+- **Data to pull:** TEM or SEM images with dimensional measurements across all three axes.

--- a/roles/nanosystems-engineer/references/vocabulary.md
+++ b/roles/nanosystems-engineer/references/vocabulary.md
@@ -1,0 +1,107 @@
+# Vocabulary
+
+Terms of art generalists misuse — not terms they could just look up. Each entry gives the practitioner definition, an in-use example, and the specific way it gets misapplied.
+
+## Conformality / step coverage
+
+**Definition.** The ratio of coating thickness at the bottom (or sidewall) of a feature to the thickness at the top, expressed as a percentage or fraction — a measure of how uniformly a deposition process coats a non-planar surface, not how thick the coating is.
+
+**In use:** "Bottom-of-feature reading is 3.6 nm against a 4.4 nm target — that's 82% conformality, well outside the >95% self-limiting regime ALD is supposed to deliver at this aspect ratio."
+
+**Misuse note.** Generalists treat a passing top-surface measurement as proof the process is "conformal." Conformality is a top-to-bottom ratio; a recipe can be dead-on at the trench opening and starved at depth, and reporting only the top number silently drops the number that actually defines the term.
+
+## Self-limiting (surface reaction)
+
+**Definition.** A reaction mechanism, central to ALD, where the precursor saturates the available surface sites and then stops reacting regardless of further exposure — growth per cycle is fixed by surface chemistry, not by how long or how much precursor is dosed.
+
+**In use:** "Extending the pulse time by 25% isn't overdosing the film — we're still inside the self-limiting window, just giving the precursor enough time to reach saturation at the bottom of a 100:1 feature."
+
+**Misuse note.** Generalists assume "self-limiting" means the process is insensitive to timing, so a conformality failure gets diagnosed as a hardware or chemistry problem instead of the correct read: at high aspect ratio, insufficient pulse/purge time can prevent the reaction from ever reaching its self-limiting saturation point at depth, even though the mechanism itself is self-limiting.
+
+## Stiction
+
+**Definition.** Permanent adhesion of a released MEMS/NEMS structure to an adjacent surface, caused by capillary force during the liquid-vapor interface of wet release (or by van der Waals/electrostatic forces after drying) — not friction, and not a fabrication defect in the structure itself.
+
+**In use:** "The cantilever didn't break during etch — it survived release and then stiction pulled it flat against the substrate as the rinse solvent evaporated."
+
+**Misuse note.** Non-specialists read "stiction" as a portmanteau of "stuck friction" and assume it's a mechanical wear phenomenon. It's a surface-force failure mode specific to nanoscale surface-area-to-volume ratios, and the fix is process-side (supercritical CO2 drying, SAM coating) — not a material or geometry redesign.
+
+## Aspect ratio (in deposition context)
+
+**Definition.** The ratio of a feature's depth to its width, used to predict whether a deposition technique can reach the bottom of the feature — not a generic shape descriptor.
+
+**In use:** "Past roughly 10:1 aspect ratio, CVD's line-of-sight deposition starts starving the bottom of the trench; that's the threshold where switching to ALD is worth its slower deposition rate."
+
+**Misuse note.** Generalists use "high aspect ratio" loosely to mean "deep" or "narrow" without tying it to a specific technique's known crossover point. In this domain the number is a decision threshold (roughly 10:1 CVD/PVD-to-ALD, >100:1 for ALD's >95% step-coverage claim to hold) — stating aspect ratio without stating which regime it falls in leaves the actionable part out.
+
+## Critical dimension (CD)
+
+**Definition.** The smallest feature width or spacing on a fabricated pattern that a process is specified to hold within tolerance — the number a lithography or etch process is qualified against, measured by CD-AFM or CD-SEM.
+
+**In use:** "If CD-AFM reads outside 4.4 nm ± 0.3 nm, stop and check tip calibration before restarting — don't requalify the process off a single out-of-spec CD reading."
+
+**Misuse note.** Generalists use "CD" as a synonym for "resolution" or "smallest feature the tool can make." CD is a spec number tied to a specific measured feature on a specific process, with a stated tolerance and measurement uncertainty — conflating it with the tool's theoretical resolution limit skips the tolerance-and-uncertainty framing that makes the number actionable.
+
+## Overlay
+
+**Definition.** The alignment accuracy between two successive lithography layers, typically reported as a 3-sigma value — a registration metric, distinct from resolution (the smallest feature a single layer can print).
+
+**In use:** "Nanoimprint's ~10 nm 3-sigma overlay is fine for this device, even though its resolution is coarser than e-beam's — overlay and resolution are different specs and this design is overlay-limited, not resolution-limited."
+
+**Misuse note.** Generalists use "overlay" and "resolution" interchangeably as both being about "how small/precise the pattern is." A process can have excellent resolution and poor overlay (or vice versa), and which one is the binding constraint determines the technique choice — collapsing the two terms collapses a real decision axis.
+
+## Defect density (yield context)
+
+**Definition.** Defects per unit area used as the input to a yield model — related to yield nonlinearly (via a model like the Poisson or negative-binomial yield equation), not proportionally.
+
+**In use:** "Going from 0.01 to 0.05 defects/cm² is a 5x increase in defect density but can drop yield from ~70% to ~12% — don't budget the process window as if yield degrades linearly with defect count."
+
+**Misuse note.** Generalists treat "5x more defects" and "5x worse yield" as roughly the same statement. The relationship is nonlinear and the collapse can be much steeper than the defect-density increase suggests — a process window set against a linear mental model will look fine at pilot scale and fail at production scale.
+
+## REL vs. PEL
+
+**Definition.** PEL (permissible exposure limit) is an OSHA-enforceable legal ceiling; REL (recommended exposure limit) is a NIOSH-published advisory guideline with no independent legal force. For engineered nanomaterials, no OSHA nano-specific PEL exists — only RELs.
+
+**In use:** "There's no PEL for carbon nanotubes — the 1 µg/m³ NIOSH REL is the number we've chosen to enforce internally, and that's a judgment call, not a compliance requirement we're satisfying."
+
+**Misuse note.** Generalists treat any published exposure number as equally binding and say things like "we're within the PEL" when citing a REL. The distinction matters because meeting a REL isn't a regulatory safe harbor — the engineer, not the regulator, is accountable for the exposure control design.
+
+## Nano-object / nanoparticle / nanoplate / nanofibre
+
+**Definition.** ISO/TS 27687 terms distinguished by dimensionality: a nano-object is the umbrella term (any of the three below); a nanoparticle has all three external dimensions in the nanoscale; a nanoplate has one dimension in the nanoscale; a nanofibre has two dimensions in the nanoscale. Not interchangeable synonyms for "small particle."
+
+**In use:** "This is a nanoplate, not a nanoparticle — only one dimension is under 100 nm — so the applicable characterization and exposure protocol is different from the isotropic-nanoparticle case."
+
+**Misuse note.** Generalists use "nanoparticle" as a catch-all for anything nanoscale. Because the ISO terms are dimensionality-specific and different protocols attach to each, calling a nanofibre a "nanoparticle" in a report or exposure plan misapplies the protocol that's supposed to follow from the classification.
+
+## EPR (enhanced permeability and retention)
+
+**Definition.** A passive tumor-accumulation mechanism relying on leaky tumor vasculature and poor lymphatic drainage to trap circulating nanoparticles — one candidate delivery mechanism among several, with a documented median systemic-delivery efficiency under 1% in a large literature survey, not a reliable design default.
+
+**In use:** "Don't size the delivery system around EPR alone — the survey data puts median tumor delivery at 0.7%, so active receptor-mediated targeting needs to be the primary mechanism, with EPR as a secondary contributor at best."
+
+**Misuse note.** Generalists who've encountered EPR in an intro-level source treat it as the mechanism nanomedicine delivery is built on. Citing EPR as if it were sufficient justification for a delivery design, without the reproducibility/efficiency data, is exactly the naive read the field has since moved past.
+
+## More Moore vs. More than Moore
+
+**Definition.** Two distinct roadmap regimes from the IEEE IRDS: "More Moore" is classical CMOS dimensional/density scaling; "More than Moore" covers non-scaling functional diversification — sensors, actuators, energy harvesting, flexible electronics — with different economics and failure modes than density scaling.
+
+**In use:** "This is a More than Moore program — a MEMS pressure sensor — so cost and timeline should be modeled against sensor-integration precedents, not against a logic-node scaling curve."
+
+**Misuse note.** Generalists apply CMOS-scaling cost/timeline intuition (cost-per-transistor curves, node-shrink cadence) to projects that are actually in the More than Moore regime, where those economics don't hold — the classification isn't just labeling, it's the input to which cost model applies.
+
+## Pilot scale
+
+**Definition.** A production run at reduced volume/throughput used specifically to characterize the defect-density-to-yield curve and failure mechanisms before committing to full production volume — not simply "a smaller batch" or "a test run" in the generic sense.
+
+**In use:** "The pilot run's job is to map where the yield curve starts collapsing, not just to confirm the process works at small scale — a process window that looks clean at pilot's low defect density can still fail once scaled."
+
+**Misuse note.** Generalists treat a successful pilot as evidence the process is ready for production, because it demonstrated the effect at some volume. Given yield's nonlinear relationship to defect density, a pilot that looks fine is only informative about the part of the curve it sampled — it doesn't validate the process at production-scale defect rates unless that's explicitly what was measured.
+
+## Self-assembled monolayer (SAM)
+
+**Definition.** A single-molecule-thick coating that spontaneously organizes on a surface via a headgroup-substrate chemical bond, used in this domain as an anti-stiction surface treatment (e.g., OTS, FDTS, DDMS) — a surface-chemistry fix, not a bulk material coating.
+
+**In use:** "If the supercritical CO2 dryer isn't available, fall back to an OTS SAM coating — it changes the surface energy enough to prevent stiction during a conventional wet release."
+
+**Misuse note.** Generalists reach for "coating" language and assume thicker or more coating is more protective. A SAM is deliberately monomolecular; its function is to change surface energy, not to add bulk thickness, and the fallback order (OTS, then FDTS, then DDMS) trades hydrophobicity against process compatibility — treating them as interchangeable "extra coating" options skips that tradeoff.


### PR DESCRIPTION
Rubric score: 18/18

## Resolution rationale

None of the three candidates share Nanosystems Engineers' (17-2199.09) domain. Aerospace-engineer's decision framework (certification basis, V-n diagrams, margin of safety, weight budgets), tools (FEA, flutter analysis, DER coordination), and worked example (fuel-burn sensitivity, spar cap MS) are aircraft/spacecraft-structure specific and would actively mislead someone doing nanofabrication process design, cleanroom/yield tradeoffs, nanoscale characterization (AFM/SEM/TEM), or quantum-confinement/surface-effect reasoning. Project-management-specialist and education-administrator-other are process/operations roles with no technical overlap at all (EVM/RAID vs. program completion metrics) — clearly wrong guidance for engineering decisions like process integration tradeoffs, contamination control, or scale-up failure modes unique to nanoscale systems. No existing role in this candidate set is a plausible parent (e.g., a materials-engineer or semiconductor-process-engineer role, if one existed, would be a better parent, but none was surfaced). Propose a new top-level leaf: nanosystems-engineer, covering nanoscale materials/device/system design, nanofabrication process selection, characterization methodology, and scale-up/yield decision-making — distinct first-principles core (surface-area-to-volume dominance, quantum confinement effects, process-induced defect propagation) and worked examples (e.g., reconciling a nanofabrication process yield/throughput tradeoff, or a nanomaterial property specification against a device performance requirement) that a generalist or the three candidates above cannot supply.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new spec-2 `nanosystems-engineer` role (O*NET 17-2199.09) with practical guidance for nanoscale design, fabrication, metrology, and scale-up. Registers the role and updates README/roadmap counts and links to reflect expanded engineering coverage.

- **New Features**
  - Added `roles/nanosystems-engineer/` with `SKILL.md` and references: `references/playbook.md`, `references/red-flags.md`, `references/vocabulary.md`.
  - Registered in `data/roles.json` (`spec: 2`, `category: engineering`, `status: active`, `onet_soc_code: "17-2199.09"`, `jurisdictions: ["us"]`).
  - Updated `README.md` and `ROADMAP.md`: roles 539; O*NET coverage 529/1016 (52.1%); engineering roles 86; roadmap progress 529/1016 and Architecture & Engineering 53/59; link to `nanosystems-engineer`.

<sup>Written for commit 7c86d96681125469fcfae1959835283171a7955e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

