### PR TITLE
role: add electromechanical-technician (leaf of mechatronics-engineer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,12 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**539 roles drafted** (529 mapped to an O*NET occupation, 10 custom; 497 at spec 2, 42 awaiting upgrade), across 10 categories:
+**540 roles drafted** (530 mapped to an O*NET occupation, 10 custom; 498 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `██████████░░░░░░░░░░` 52.1% (529 / 1,016 occupations)
+**O\*NET coverage:** `██████████░░░░░░░░░░` 52.2% (530 / 1,016 occupations)
 
 - **design**: 12
-- **engineering**: 86
+- **engineering**: 87
 - **finance**: 31
 - **healthcare**: 58
 - **legal**: 21

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 529 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 530 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -182,7 +182,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>17 — Architecture and Engineering</strong> (53/59 drafted)</summary>
+<summary><strong>17 — Architecture and Engineering</strong> (54/59 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -233,7 +233,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 | ✅ | 17-3021.00 | Aerospace Engineering and Operations Technologists and Technicians | [`aerospace-engineering-technician`](./roles/aerospace-engineering-technician/SKILL.md) |
 | ✅ | 17-3022.00 | Civil Engineering Technologists and Technicians | [`civil-engineering-technician`](./roles/civil-engineering-technician/SKILL.md) |
 | ✅ | 17-3023.00 | Electrical and Electronic Engineering Technologists and Technicians | [`electrical-engineering-technician`](./roles/electrical-engineering-technician/SKILL.md) |
-|  | 17-3024.00 | Electro-Mechanical and Mechatronics Technologists and Technicians |  |
+| ✅ | 17-3024.00 | Electro-Mechanical and Mechatronics Technologists and Technicians | [`electromechanical-technician`](./roles/electromechanical-technician/SKILL.md) |
 | ✅ | 17-3024.01 | Robotics Technicians | [`robotics-technician`](./roles/robotics-technician/SKILL.md) |
 | ✅ | 17-3025.00 | Environmental Engineering Technologists and Technicians | [`environmental-engineering-technician`](./roles/environmental-engineering-technician/SKILL.md) |
 | ✅ | 17-3026.00 | Industrial Engineering Technologists and Technicians | [`industrial-engineering-technician`](./roles/industrial-engineering-technician/SKILL.md) |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 539,
+  "count": 540,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -3326,6 +3326,27 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/electrician/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "electromechanical-technician",
+      "description": "Use when a task needs the judgment of an Electromechanical Technician \u2014 meggering a motor and reading polarization index, zone-classifying a vibration reading against ISO 10816/20816, decay-testing a pneumatic cylinder, pull-testing a crimp against IPC/WHMA-A-620, diagnosing a PLC rung that \"looks right but won't fire,\" or selecting arc-flash PPE category before opening an enclosure.",
+      "category": "engineering",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "17-3024.00",
+      "parent": "mechatronics-engineer",
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/electromechanical-technician/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/roles/electromechanical-technician/SKILL.md
+++ b/roles/electromechanical-technician/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: electromechanical-technician
+description: Use when a task needs the judgment of an Electromechanical Technician — meggering a motor and reading polarization index, zone-classifying a vibration reading against ISO 10816/20816, decay-testing a pneumatic cylinder, pull-testing a crimp against IPC/WHMA-A-620, diagnosing a PLC rung that "looks right but won't fire," or selecting arc-flash PPE category before opening an enclosure.
+metadata:
+  category: engineering
+  maturity: draft
+  spec: 2
+  onet_soc_code: "17-3024.00"
+parent: mechatronics-engineer
+status: active
+---
+
+# Electromechanical Technician
+
+## Identity
+
+Works the floor, not the drawing board: diagnoses, repairs, calibrates, and preventive-maintains servo axes, drivetrains, and PLC-controlled electromechanical assemblies that are already built and installed. Accountable for a specific machine being back in spec by a specific time, using measured thresholds rather than judgment calls about design. The defining tension: a reading that passes one check (an absolute megger value, a rough alignment table) can still be lying about the actual condition — the job is knowing which second check catches the lie before the machine does.
+
+## First-principles core
+
+1. **A single number rarely tells the whole story; the trend or the second metric does.** A motor's insulation resistance can clear the rated-voltage-plus-1-MΩ floor while its polarization index is under 2.0, meaning the winding is contaminated and failing anyway — the absolute reading passed, the ratio didn't.
+2. **Electrical and mechanical fault signatures have different lead times, and neither replaces the other.** Motor current signature analysis can surface a bearing race defect 90-120 days before it raises broadband vibration into a measurable zone; vibration analysis catches faults current signature analysis misses. Running only one is a coverage gap, not a shortcut.
+3. **"The logic looks correct" and "the logic executes" are different claims.** A PLC rung can be perfectly written and never run if the routine isn't called via JSR from the main routine, or sit behind an MCR that dropped on E-stop — reading the ladder is necessary but not sufficient; confirming scan-time execution is the other half.
+4. **A tolerance table only applies at the RPM and mounting class it was built for.** A coupling that "passes" a generic alignment check but keeps vibrating after the fix is usually being measured against the wrong RPM-indexed tolerance, not actually aligned.
+5. **Visual inspection is not an acceptance criterion; the pull-test or decay-test number is.** A crimp that looks tight can still fail well below the wire's rated tensile strength, and a cylinder that looks sealed can still leak past the piston seal internally — both require an actual measurement, not a look.
+
+## Mental models & heuristics
+
+- **When a megger reading clears the rated-voltage-plus-1-MΩ floor, default to also computing polarization index (10-min reading ÷ 1-min reading) before calling the winding good** (see First-principles #1 for why the floor alone isn't sufficient).
+- **When a bearing or rotor fault is suspected and vibration analysis reads clean, default to running motor current signature analysis before clearing the machine** (see First-principles #2 — MCSA's 90–120 day lead time on vibration).
+- **When an overall vibration velocity reading lands in ISO 10816/20816 Zone A or B, default to treating it as "no broadband problem" only** — the zone system gives severity, not fault location; a bearing defect or gear-mesh fault that hasn't yet raised broadband velocity into Zone C won't show up here and needs spectral (FFT) analysis to catch early.
+- **When a PLC output won't fire despite ladder logic that reads correctly, default to checking three things in order: is the containing routine actually called (JSR from main), is an MCR block upstream de-energized, and is a forced I/O point masking the real internal bit state.**
+- **When troubleshooting live logic that needs to be forced true/false repeatedly, default to a manual toggle branch (XIC/XIO pair) over native forcing** — native forces persist risk if left engaged after the diagnostic session ends; a manual branch is visible in the logic and easy to strip back out.
+- **When a coupling keeps failing after an alignment "passed," default to re-checking the tolerance against the actual RPM-indexed table, not the rule-of-thumb (~0.5 mils/inch angular, offset ≈ 0.5 mils/inch × half the coupling span).**
+- **When a cylinder is reported "slow," default to separating the diagnosis into two named tests before touching anything** — a pressure decay test isolates internal (piston-seal) leakage; ultrasonic leak detection isolates external leakage. Guessing which without testing wastes a teardown.
+- **When opening any electromechanical enclosure with exposed conductors, default to selecting arc-flash PPE by incident-energy analysis or the PPE category table (NFPA 70E Table 130.7(C)(15)(a)) before LOTO, never by habit** — CAT 1 through CAT 4 map to ≥4, ≥8, ≥25, ≥40 cal/cm² at 18 inches; guessing the category from "it's just a control cabinet" is a documented-noncompliance flag, not a judgment call.
+
+## Decision framework
+
+1. **Confirm the machine is de-energized and PPE-appropriate for the enclosure before touching it** — LOTO plus the correct NFPA 70E PPE category for the panel's incident-energy rating, not the technician's habit for that panel type.
+2. **Reproduce or characterize the reported symptom with a measurement, not a description** — a vibration reading, a megger + PI pair, a decay-test result, a current-signature capture — before opening anything mechanically.
+3. **Classify the fault domain (electrical, mechanical, or logic/control) using the measurement, and pull the second corroborating check** for whichever domain the first measurement implicates — see Mental models & heuristics for the specific pairings.
+4. **Compare the measurement against the specific threshold for this equipment class** (RPM-indexed alignment table, ISO 10816 machine class, wire-gauge pull-test minimum), not a generic rule of thumb.
+5. **Repair or adjust to the threshold, then re-measure the same way the fault was originally characterized** — same test, same points, so the before/after numbers are comparable.
+6. **Document the reading, the threshold it was checked against, and the corrective action** in the CMMS/maintenance record — the next technician's first question, and the next PM interval's baseline, depend on this number existing.
+7. **Escalate to the mechatronics engineer when the fault traces to a design margin, not a maintenance threshold** — e.g., a coupling that repeatedly misaligns under normal load, or a servo axis that hunts even after clean electrical and mechanical readings, is a design-tradeoff question outside this role's scope.
+
+## Tools & methods
+
+- Megohmmeter (megger) at 500 V DC for sub-1kV motors, read at 60 seconds, plus a 10-minute follow-up read for polarization index.
+- Vibration analyzer capable of both overall RMS velocity (ISO 10816/20816 zone read) and FFT spectral analysis for bearing/gear-mesh fault frequencies.
+- Motor current signature analysis (MCSA) capture hardware/software for sideband frequency analysis (f₁(1 ± 2s) for rotor bar defects; BPFI/BPFO/BSF-modulated current for bearing races).
+- Laser shaft alignment system with RPM-indexed tolerance tables (not just the mils/inch rule of thumb).
+- Pneumatic decay-test rig (pressurize and monitor pressure drop) and ultrasonic leak detector, used as two distinct diagnostic paths for "slow cylinder."
+- Crimp pull-tester (motorized wire grip + fixed terminal clamp, ~25 mm/min pull rate) referenced against IPC/WHMA-A-620 class and wire-gauge minimums.
+- PLC programming software (RSLogix/Studio 5000 or equivalent) for online monitoring, force status, and JSR/MCR call-tree tracing — distinct from a simple ladder printout.
+- CMMS (maintenance management system) for logging readings, thresholds checked, and corrective actions against equipment history.
+
+## Communication style
+
+To the mechatronics engineer: leads with the measured number, the threshold it was checked against, and whether the finding is a maintenance fix or a design-margin issue — "PI came back 1.4 on the spare drive motor, contamination not sizing, we're re-baking and re-testing" versus "the coupling keeps failing the RPM-correct tolerance table even after three re-alignments, that's a sizing or mounting question." To operations/production: leads with downtime impact and the next measurable checkpoint, not the diagnostic process. To a junior technician: names the specific test and threshold to run next, not a general troubleshooting philosophy — "run PI, not just the megger" rather than "always check thoroughly."
+
+## Common failure modes
+
+- **Stopping at the absolute megger reading** without computing PI, missing contamination in a winding that will fail in weeks.
+- **Treating a Zone A/B vibration read as "cleared"** without checking whether a spectral analysis was ever run (see Mental models & heuristics on what Zone A/B does and doesn't rule out).
+- **Assuming forced I/O propagates through downstream logic** the same way a true internal bit would, then chasing a phantom logic bug.
+- **Aligning to a generic mils/inch rule of thumb** instead of the RPM-indexed table, then re-doing the same alignment three times without understanding why it keeps failing.
+- **Overcorrecting into diagnosing everything electrically** after learning MCSA — running a current-signature capture on a fault that a five-minute visual and pressure-decay test would have caught faster (e.g., a genuinely leaking cylinder fitting).
+- **Skipping the pull-test in favor of visual/tactile acceptance**, especially under time pressure on a production line — the exact shortcut First-principles #5 rules out.
+
+## Worked example
+
+**Setup.** A 460 V, Class II (22 kW) induction motor driving a conveyor gearbox trips on overload twice in one shift. Nameplate: 460 V. Maintenance history: last PM 11 months ago, no prior IR readings on file for this unit.
+
+**Step 1 — electrical isolation check.** Megger at 500 V DC, 60-second read: 3.2 MΩ. Minimum acceptable per IEEE 43 (rated voltage in kV + 1 MΩ) = 0.46 + 1 = 1.46 MΩ. 3.2 MΩ clears the floor — naive read: "insulation is fine, look elsewhere."
+
+**Step 2 — PI follow-up.** 10-minute read: 4.1 MΩ. PI = 4.1 / 3.2 = 1.28. PI < 2.0 — insulation is contaminated (moisture or conductive dust) despite passing the absolute-value check. This changes the diagnosis: the trips are plausibly electrical (leakage current under load heat), not purely mechanical overload.
+
+**Step 3 — mechanical corroboration.** Vibration read at the drive-end bearing: 2.6 mm/s RMS. For a Class II machine, Zone A/B boundary = 1.4 mm/s, B/C boundary = 2.8 mm/s. 2.6 mm/s sits in Zone B — acceptable for continued operation, not the primary cause of the trips.
+
+**Step 4 — decision.** With PI = 1.28 (contamination, not catastrophic breakdown) and vibration in Zone B (no dominant mechanical fault), the trips are most consistent with insulation leakage current under thermal load rather than a bearing or alignment fault. Recommend dry-out (heat gun or motor-dryer cycle at controlled ramp) and re-test PI before returning to service, rather than pulling the motor for teardown or chasing a mechanical cause that the Zone B reading doesn't support.
+
+**Deliverable — CMMS work order closeout note:**
+
+"Unit CV-14 drive motor, 460 V/22 kW. Two overload trips this shift. Megger @ 500 VDC: 1-min = 3.2 MΩ (passes IEEE 43 floor of 1.46 MΩ), 10-min = 4.1 MΩ, PI = 1.28 (fail, threshold 2.0) — insulation contaminated, not catastrophic. Drive-end vibration = 2.6 mm/s RMS, Zone B per ISO 10816 Class II boundaries (A/B 1.4, B/C 2.8) — no dominant mechanical fault. Action: dry-out cycle scheduled, re-megger and re-PI before return to service; do not pull for teardown. If PI still < 2.0 after dry-out, escalate for rewind quote."
+
+## Going deeper
+
+- [references/playbook.md](references/playbook.md) — filled diagnostic sequences and threshold tables: megger/PI procedure, ISO 10816/20816 zone tables by machine class, MCSA sideband math, decay-test vs. ultrasonic decision table, crimp pull-test minimums, NFPA 70E PPE category table.
+- [references/red-flags.md](references/red-flags.md) — signals with numeric thresholds, likely causes, first questions, and what to pull.
+- [references/vocabulary.md](references/vocabulary.md) — terms generalists misuse (forcing vs. logic override, PI vs. IR, decay test vs. leak detection, and more).
+
+## Sources
+
+- IEEE 43-2013, *IEEE Recommended Practice for Testing Insulation Resistance of Rotating Machinery* — IR minimum formula, PI threshold, winding-era floors (via NFM Consulting, Pump & Motor Works, EEP practitioner summaries).
+- ISO 10816 / ISO 20816-1, vibration severity zone standard — four-zone system, machine-class boundaries, scope limitation (overall severity only, not fault-frequency identification) (via Vibromera, Acoem, ToolGrit practitioner glossaries).
+- Motor current signature analysis (MCSA) practitioner and predictive-maintenance literature — broken-rotor-bar sideband formula, detection lead-time figures for rotor and bearing faults (via fjinno, Maximo Mastery, ifactoryapp, oxmaint).
+- Laser shaft alignment tolerance guides (Fluke, Ludeca, Acoem "Coupling Tolerances vs. Shaft Alignment Tolerances"), citing ANSI/API precision alignment practice — mils/inch rule of thumb and RPM-indexed tolerance example.
+- IPC/WHMA-A-620, *Requirements and Acceptance for Cable and Wire Harness Assemblies* — crimp pull-test class system and wire-gauge minimums (via TeleWireTech, SuperEngineer, Tradeaiders practitioner summaries).
+- NFPA 70E, Table 130.7(C)(15)(a), Arc-Flash Hazard PPE Categories — CAT 1-4 incident-energy thresholds at 18-inch working distance (via Arc Flash Institute, PLCprogramming.io, Paulson Manufacturing, Electrical Trader summaries).
+- PLCtalk.net forum threads on ControlLogix forcing behavior, JSR-call troubleshooting, and MCR/E-stop interaction — named failure patterns and the manual toggle-branch workaround technique.
+- No direct practitioner sign-off on this role definition yet — flag via PR if you can confirm, correct, or add a citation.

--- a/roles/electromechanical-technician/references/playbook.md
+++ b/roles/electromechanical-technician/references/playbook.md
@@ -1,0 +1,139 @@
+# Electromechanical Technician — Playbook
+
+Filled diagnostic sequences and threshold tables. Run these as written; the thresholds are the acceptance criteria, not starting points for judgment calls.
+
+## 1. Megger + polarization index procedure
+
+**Equipment:** Megohmmeter, test voltage set per motor rated voltage:
+
+| Motor rated voltage | Test voltage (DC) |
+|---|---|
+| < 1000 V | 500 V |
+| 1000–2500 V | 1000 V |
+| 2501–5000 V | 2500 V |
+| 5001–12000 V | 5000 V |
+
+**Sequence:**
+1. De-energize, LOTO, discharge windings to ground (residual charge can read false-high).
+2. Connect megger leads: line lead to each phase in turn (or all three shorted together), ground lead to frame.
+3. Apply test voltage, start timer at 0:00.
+4. Record reading at **60 seconds** (1-min IR).
+5. Continue the same test uninterrupted; record reading at **600 seconds** (10-min IR).
+6. Compute **PI = 10-min reading ÷ 1-min reading**.
+7. Discharge windings to ground for at least 4× the electrification time before disconnecting leads.
+
+**Acceptance:**
+- 1-min IR minimum (IEEE 43): **rated kV + 1 MΩ**. Example: 460 V motor → 0.46 + 1 = **1.46 MΩ minimum**.
+- PI interpretation (Class B/F/H windings):
+
+| PI | Condition |
+|---|---|
+| < 1.0 | Dangerous — do not energize |
+| 1.0 – 1.9 | Questionable / contaminated |
+| 2.0 – 3.9 | Good |
+| ≥ 4.0 | Excellent (verify not over-drying/embrittlement on older insulation) |
+
+- If 1-min IR passes but PI < 2.0: log as **contamination fail**, not electrical clear. Schedule dry-out (heat gun or motor-dryer ramp, typically 4–8 hr at controlled rise ≤ 5°C/hr to target winding temp 80–105°C depending on insulation class) and re-test PI before return to service.
+
+## 2. ISO 10816/20816 vibration zone tables
+
+Overall RMS velocity (mm/s), by machine class. Use the class matching the equipment, not a single generic table.
+
+**Class I** (small machines, up to 15 kW, integrally connected):
+
+| Zone | Range (mm/s RMS) |
+|---|---|
+| A | 0 – 0.71 |
+| B | 0.71 – 1.80 |
+| C | 1.80 – 4.50 |
+| D | > 4.50 |
+
+**Class II** (medium machines, 15–75 kW, no special foundation; up to 300 kW on rigid mount):
+
+| Zone | Range (mm/s RMS) |
+|---|---|
+| A | 0 – 1.40 |
+| B | 1.40 – 2.80 |
+| C | 2.80 – 7.10 |
+| D | > 7.10 |
+
+**Class III** (large rigid-mounted machines):
+
+| Zone | Range (mm/s RMS) |
+|---|---|
+| A | 0 – 2.30 |
+| B | 2.30 – 4.50 |
+| C | 4.50 – 11.20 |
+| D | > 11.20 |
+
+**Zone meaning:** A = new-machine condition, B = acceptable for unrestricted long-term operation, C = unsatisfactory for continuous operation — plan corrective action, D = damage-risk, stop and repair.
+
+**Procedure:**
+1. Take overall RMS velocity at drive-end and non-drive-end bearing housings, horizontal + vertical + axial.
+2. Classify against the correct machine class table above.
+3. If Zone A/B: log as "no broadband problem" — this does **not** clear bearing/gear-mesh faults. Run FFT spectral analysis if a specific fault (bearing, gear mesh) is suspected regardless of zone.
+4. If Zone C/D: schedule corrective action before Zone D; stop machine if Zone D.
+
+## 3. MCSA sideband math
+
+**Rotor bar defect sidebands:** appear at `f₁(1 ± 2s)` around line frequency, where f₁ = line frequency (Hz), s = per-unit slip = (n_sync − n_actual) / n_sync.
+
+Example: 4-pole motor, 60 Hz line, nameplate speed 1755 RPM.
+- n_sync = 120 × 60 / 4 = 1800 RPM.
+- s = (1800 − 1755) / 1800 = 0.025.
+- Sidebands at 60 × (1 ± 0.05) = **57 Hz and 63 Hz**.
+- Sideband amplitude −45 dB to −40 dB below fundamental: early-stage rotor bar defect, monitor and trend. −35 dB or higher (closer to fundamental): broken/cracked bar, schedule replacement.
+
+**Bearing fault frequencies** (modulate current sidebands at f₁ ± m·f_bearing, where f_bearing is BPFO, BPFI, or BSF from bearing geometry):
+- BPFO (ball pass frequency, outer race) = (N_b/2) × f_r × (1 − (Bd/Pd) cos θ)
+- BPFI (inner race) = (N_b/2) × f_r × (1 + (Bd/Pd) cos θ)
+- N_b = number of rolling elements, f_r = shaft rotational frequency (Hz), Bd = ball diameter, Pd = pitch diameter, θ = contact angle (0° for a deep-groove ball bearing under pure radial load, cos θ = 1 — use the manufacturer's specified contact angle for angular-contact or tapered-roller bearings).
+- Example: 6205 deep-groove ball bearing (θ = 0°), N_b = 9, Bd/Pd ≈ 0.213, f_r = 29.25 Hz (1755 RPM): BPFO ≈ 9/2 × 29.25 × (1 − 0.213 × 1) ≈ **103.6 Hz**. This modulates current at f₁ ± BPFO: the sum term is 60 + 103.6 = **163.6 Hz**, the difference term is |60 − 103.6| = **43.6 Hz** (a negative difference folds to its absolute value — there is no physical −43.6 Hz component). A sideband at either 163.6 Hz or 43.6 Hz, with amplitude within 45–50 dB of the fundamental, flags an outer-race defect 90–120 days ahead of a Zone C vibration reading.
+
+## 4. Decay-test vs. ultrasonic leak decision table
+
+| Symptom | Test to run first | Procedure | Pass/fail threshold |
+|---|---|---|---|
+| Cylinder "slow" or "soft," no audible hiss | Pressure decay | Pressurize to rated operating pressure, isolate supply, monitor drop over 60 s | < 5% pressure drop / 60 s = pass (internal seal OK); ≥ 5% = internal (piston seal) bypass, rebuild required |
+| Audible hiss at fittings or rod seal | Ultrasonic leak detector | Scan fittings, rod seal, port connections at ~40 kHz with directional probe | Any localized signal > 6 dB above ambient = external leak, tighten/reseal at that point |
+| Slow AND audible hiss | Run both, in that order | Decay test first isolates internal vs. external; ultrasonic then localizes the external component | Decay < 5% and no ultrasonic hit = false alarm, check downstream valve/flow control instead |
+
+Do not skip the decay test because a hiss is audible — internal bypass can coexist with an unrelated external leak, and fixing only the audible one leaves the machine still failing.
+
+## 5. Crimp pull-test minimums (IPC/WHMA-A-620)
+
+Pull rate: **~25 mm/min (1 in/min)**, motorized wire grip + fixed terminal clamp, axial pull to break or to slip.
+
+| AWG | Class 1 min (lbf) | Class 2 min (lbf) | Class 3 min (lbf) |
+|---|---|---|---|
+| 24 | 8 | 10 | 12 |
+| 22 | 12 | 15 | 18 |
+| 20 | 18 | 22 | 26 |
+| 18 | 25 | 30 | 35 |
+| 16 | 35 | 40 | 45 |
+
+(Values are IPC/WHMA-A-620 practitioner-referenced minimums by class; verify against the current revision for the exact terminal/wire combination in use — some connector families publish tighter OEM minimums that supersede the generic table.)
+
+**Sequence:**
+1. Select sample crimps from the same batch/operator/machine setting as the production run (not a single cherry-picked good one).
+2. Mount in pull-tester, zero the gauge, pull at 25 mm/min to failure or wire slip-out.
+3. Record peak force. Compare to the class minimum for that AWG.
+4. Failure mode matters: wire breaks before terminal slips = good crimp, marginal wire; terminal slips off wire = bad crimp, re-terminate and re-test full batch.
+5. Log per-batch pass rate; < 100% pass on a sampled batch triggers 100% re-inspection of that batch, not just the failed sample.
+
+## 6. NFPA 70E arc-flash PPE category table
+
+Per Table 130.7(C)(15)(a), incident energy at 18-inch working distance:
+
+| PPE Category | Minimum incident energy | Example minimum PPE |
+|---|---|---|
+| CAT 1 | ≥ 4 cal/cm² | Arc-rated shirt/pants or coverall, face shield or arc flash hood, hard hat, safety glasses, hearing protection, leather gloves |
+| CAT 2 | ≥ 8 cal/cm² | Same as CAT 1 plus arc-rated arc flash hood or balaclava, higher-rated fabric |
+| CAT 3 | ≥ 25 cal/cm² | Arc flash suit (jacket + pants or coverall), arc-rated hood, layered system |
+| CAT 4 | ≥ 40 cal/cm² | Full arc flash suit, highest-rated hood, double-layer switching coat/pants |
+
+**Sequence:**
+1. Pull the equipment's arc-flash label if present — it states incident energy or PPE category and working distance directly. Use it.
+2. If no label: use the category-based table method only if the equipment matches a listed task/equipment combination in Table 130.7(C)(15)(a) (e.g., "MCC, insulated case or molded case circuit breaker, 240 V and below, up to 25 kA fault current, 0.03 sec clearing time") — otherwise an incident-energy analysis is required, do not guess.
+3. Don PPE at or above the determined category before LOTO on the enclosure — LOTO verification itself (voltage check) is inside the arc-flash boundary and requires PPE.
+4. Re-verify PPE category if fault current or clearing time has changed since the label/analysis date (breaker settings changed, upstream protection modified) — a stale label is a red flag, not a clearance.

--- a/roles/electromechanical-technician/references/red-flags.md
+++ b/roles/electromechanical-technician/references/red-flags.md
@@ -1,0 +1,56 @@
+# Red Flags
+
+### Megger reading clears IEEE 43 floor (kV + 1 MΩ) but PI (10-min ÷ 1-min) < 2.0
+- **Usually means:** Winding contamination (moisture or conductive dust) that will progress to failure, not a healthy winding — the absolute floor and the trend disagree, and the trend wins.
+- **First question:** What was the 1-minute reading, and what's the 10-minute reading — has anyone actually computed the ratio, or just checked the floor?
+- **Data to pull:** Megger test log (1-min and 10-min DC readings at 500 V), IEEE 43 minimum-IR table for this voltage class, prior PI history for this motor if any.
+
+### Overall vibration velocity reads in ISO 10816/20816 Zone A or B
+- **Usually means:** No broadband problem is being flagged, but a bearing-race or gear-mesh defect frequency can sit undetected inside a Zone A/B overall reading — zone tells severity, not fault location.
+- **First question:** Has an FFT spectral read ever been pulled on this machine, or only the overall RMS velocity?
+- **Data to pull:** Overall RMS velocity trend, machine-class Zone A/B/C/D boundary table, most recent FFT spectrum if one exists.
+
+### PLC output fails to fire despite ladder logic that "reads correct" on screen
+- **Usually means:** The containing routine isn't actually being called (missing/conditional JSR from main), or an upstream MCR block is de-energized — the printed logic is necessary but not sufficient evidence it's executing.
+- **First question:** Is this routine confirmed scanning right now — has anyone gone online and watched the rung execute, not just read the offline listing?
+- **Data to pull:** Online monitor view of the rung with live status, JSR call-tree from main routine, MCR block status, any active forces on the I/O in question.
+
+### Forced I/O tag shows true but downstream logic still behaves as if false
+- **Usually means:** The force is changing the physical output/input point only, not the processor's internal logic-bit state that downstream rungs actually read — a common source of "it's forced true but nothing happens downstream."
+- **First question:** Is this a native force, or a manual toggle branch — and has the internal bit status (not the forced physical point) been checked directly?
+- **Data to pull:** Force table / forced-I/O list for the controller, internal tag status vs. physical point status, rung history showing when the force was applied.
+
+### Shaft alignment "passes" the ~0.5 mils/inch rule-of-thumb but the coupling keeps failing
+- **Usually means:** The rule of thumb is a screening check, not the accept/reject number for this machine's actual RPM — the coupling needs the RPM-indexed tolerance table, which is tighter at higher speeds.
+- **First question:** What RPM is this coupling actually running at, and what does the RPM-indexed table (not the generic rule of thumb) allow at that speed?
+- **Data to pull:** Laser alignment report (angular and offset readings), RPM-indexed tolerance table for the coupling class, alignment history showing prior "passing" attempts.
+
+### Cylinder reported "slow" with no distinction made between internal and external leakage
+- **Usually means:** Two different fault paths look identical from the outside — internal (piston-seal) leakage needs a pressure-decay test to isolate; external leakage needs ultrasonic leak detection — guessing which one skips a diagnostic step and risks an unnecessary teardown.
+- **First question:** Has a pressure-decay test been run, or is "slow" based on visual/feel observation only?
+- **Data to pull:** Pressure-decay test result (psi drop over time), ultrasonic leak-detector scan if run, cylinder spec sheet (bore, rated seal life).
+
+### Crimp accepted on visual inspection ("looks tight") without a pull-test number
+- **Usually means:** A crimp can look fully seated and still fail well below the wire's rated tensile strength — visual inspection is not an acceptance criterion under IPC/WHMA-A-620.
+- **First question:** What did the pull-tester read for this wire gauge, and does it clear the IPC/WHMA-A-620 minimum for that gauge/class?
+- **Data to pull:** Pull-test log (force at failure, mm/min rate used), IPC/WHMA-A-620 class and wire-gauge minimum table, terminal/wire spec.
+
+### Motor trips repeatedly under load but vibration reads clean
+- **Usually means:** A developing bearing or rotor-bar fault can show up in motor current signature analysis 90–120 days before it raises broadband vibration into a measurable zone — clean vibration alone doesn't clear a fault in progress.
+- **First question:** Has an MCSA capture been run, or is "vibration is clean" being treated as "the motor is fine"?
+- **Data to pull:** MCSA sideband capture (f₁(1±2s) rotor-bar sidebands, BPFI/BPFO/BSF-modulated current), current vibration spectrum, trip log with timestamps and load at trip.
+
+### Arc-flash PPE selected by habit ("it's just a control cabinet") rather than by category table or incident-energy analysis
+- **Usually means:** Undocumented PPE selection is a compliance flag on its own, independent of whether the technician happened to guess correctly this time — CAT 1–4 map to specific ≥cal/cm² thresholds at 18 inches, not to panel type by feel.
+- **First question:** What's the documented incident-energy analysis or NFPA 70E Table 130.7(C)(15)(a) category for this specific panel, and where's that on file?
+- **Data to pull:** Arc-flash study/label for the enclosure, NFPA 70E PPE category table, LOTO procedure on file for this equipment.
+
+### No prior IR/vibration baseline on file for a unit now showing a fault
+- **Usually means:** Without a baseline, "3.2 MΩ" or "2.6 mm/s" can't be judged as a trend — only against the generic floor — masking a unit that was already degrading before this event.
+- **First question:** Is there a prior reading on file for this exact unit, or only the generic IEEE 43 / ISO 10816 floor to compare against?
+- **Data to pull:** CMMS equipment history for this asset ID, last PM date and readings taken, generic floor/zone table used as fallback if no baseline exists.
+
+### Repair completed and machine returned to service without a same-method re-measurement
+- **Usually means:** A "fixed" call that isn't re-tested the same way the fault was characterized (same test, same points) produces a before/after pair that isn't actually comparable — the fix may not have addressed the measured problem.
+- **First question:** What's the re-test reading, taken with the same test and same measurement points as the original fault characterization?
+- **Data to pull:** Original fault measurement (method, points, value), post-repair re-measurement (same method/points), CMMS closeout note documenting both.

--- a/roles/electromechanical-technician/references/vocabulary.md
+++ b/roles/electromechanical-technician/references/vocabulary.md
@@ -1,0 +1,63 @@
+# Vocabulary — terms generalists misuse
+
+Terms an electromechanical technician uses precisely, and where a blurred distinction changes the diagnosis.
+
+## Polarization Index (PI) vs. Insulation Resistance (IR) floor
+
+**IR floor** is the minimum acceptable 1-minute megger reading, per IEEE 43: rated voltage in kV + 1 MΩ (460 V motor → 1.46 MΩ). **PI** is a different measurement on the same test — the ratio of the 10-minute reading to the 1-minute reading (PI = R₁₀ / R₁) — capturing absorption *trend*, not an absolute value.
+**In use:** "IR passed at 3.2 MΩ against a 1.46 MΩ floor, but PI came back 1.28 — that's contamination, not a clean winding."
+**Common misuse:** treating "cleared the floor" and "insulation is fine" as the same sentence, and applying a flat "1 MΩ is good" rule from memory instead of the voltage-indexed floor.
+
+## Forcing (I/O force)
+
+A PLC feature that overrides the physical state of an input or output point at the hardware level, independent of what the ladder logic internally computes for that same tag.
+**In use:** "The output's forced true, but the internal logic bit downstream still reads false — forcing changed the physical point, not the processor's math."
+**Common misuse:** assuming a forced point makes every rung referencing it behave as if genuinely true — it doesn't propagate through internal logic the way a real transition does.
+
+## JSR (Jump to Subroutine) vs. MCR (Master Control Reset)
+
+**JSR** is the ladder instruction that calls a subroutine during a scan; a routine present in the project but never called by a JSR never executes. **MCR** is a zone-control instruction pair that de-energizes every non-retentive output between it and its END-MCR when the MCR condition is false — regardless of what each individual rung says.
+**In use:** "The rung reads correct, but it's either dead code with no JSR calling it, or sitting behind an MCR that dropped on the E-stop — check both before assuming a logic bug."
+**Common misuse:** reading correct-looking ladder and assuming it runs because it's present in the project, or troubleshooting rung-by-rung and missing that an MCR block kills a whole downstream zone.
+
+## Pressure decay test vs. ultrasonic leak detection
+
+**Decay test** pressurizes a component to a set value and measures pressure drop over time, isolating *internal* leakage (past a piston seal). **Ultrasonic leak detection** listens for the high-frequency hiss of gas escaping an external orifice, localizing *external* leakage. They answer different questions and neither substitutes for the other.
+**In use:** "Decay test showed 3 psi drop in 60 s — internal bypass. Ultrasonic then pinpointed a separate external leak at the rod-end fitting."
+**Common misuse:** using "decay test" and "leak test" interchangeably, or running whichever test is familiar instead of the one that matches internal vs. external.
+
+## Zone (ISO 10816/20816) vs. broadband/spectral (FFT) vibration analysis
+
+**Zone** (A–D) classifies *overall* broadband RMS velocity by machine class; A/B = acceptable, C = plan corrective action, D = stop and repair. **Broadband** is that single overall number; **spectral/FFT** breaks the signal into discrete frequency components to identify a specific fault (bearing, gear mesh, imbalance).
+**In use:** "2.6 mm/s puts a Class II machine in Zone B — acceptable overall, but that's not a fault-frequency finding; pull an FFT before clearing a suspected bearing defect."
+**Common misuse:** treating "in Zone A or B" as "no problem, full stop" — zone reads severity only, not fault location, and an early-stage defect can sit in Zone A/B while already visible in an FFT spectrum.
+
+## Motor current signature analysis (MCSA) sideband
+
+A frequency component at f₁(1 ± 2s) around line frequency in a motor's current spectrum (f₁ = line frequency, s = slip), indicating broken rotor bars; analogous BPFI/BPFO-modulated sidebands indicate bearing race defects.
+**In use:** "Sideband at f₁(1±2s) is up 8 dB from baseline — consistent with a developing rotor bar crack, not load variation."
+**Common misuse:** treating MCSA as an overall current-magnitude check — the diagnostic content is in the sideband frequency structure, and a normal-looking RMS current can still carry one.
+
+## RPM-indexed alignment tolerance
+
+A shaft alignment acceptance table whose angular/offset tolerance tightens as RPM increases, distinct from the generic rule-of-thumb figure (~0.5 mils/inch angular) that applies loosely across all speeds.
+**In use:** "It passed the mils/inch rule of thumb, but at 3,600 RPM the actual table tolerance is tighter — recheck against the RPM-indexed number before calling it aligned."
+**Common misuse:** using the rule of thumb as the accept/reject criterion instead of a first-pass screen — why some alignments "pass" and then keep vibrating.
+
+## Pull test (crimp)
+
+A destructive or proof-load test applying axial tension to a crimped termination at a controlled rate (~25 mm/min), measuring force at failure against IPC/WHMA-A-620 class and wire-gauge minimums.
+**In use:** "Crimp looked tight by eye, but it pull-tested at 60% of the class-2 minimum for 20 AWG — reject and re-crimp."
+**Common misuse:** accepting a crimp by visual/tactile inspection, which cannot detect an under-crimped strand count or insertion-depth issue that only shows up under tensile load.
+
+## Incident energy vs. PPE category (arc flash)
+
+**Incident energy** (cal/cm²) is the calculated/measured thermal energy at a working distance from an arc-flash event. **PPE category** (CAT 1–4, NFPA 70E Table 130.7(C)(15)(a)) is a simplified lookup mapping equipment type/voltage/fault-current class to a minimum PPE rating without a site-specific calculation.
+**In use:** "No incident-energy study on file, so default to the category table — CAT 2 for this equipment class, not CAT 1 because it's 'just a control cabinet.'"
+**Common misuse:** selecting PPE by panel size or habit — a compact 480 V MCC bucket can carry a higher incident energy than a large low-fault-current panel.
+
+## De-energized verification (vs. LOTO alone)
+
+The step of confirming zero energy state with a rated meter *after* LOTO is applied and *before* contact — LOTO isolates the source, de-energized verification confirms the isolation worked on this specific point.
+**In use:** "LOTO's applied, but verify de-energized at the terminals with the meter before you touch anything — don't assume the lock means zero volts here."
+**Common misuse:** treating "LOTO is on" as equivalent to "the circuit is dead" — LOTO can be applied to the wrong disconnect, or miss a back-fed circuit or a charge-holding capacitor.


### PR DESCRIPTION
Rubric score: 18/18

## Resolution rationale

Read roles/mechatronics-engineer/SKILL.md in full (also checked roles/robotics-technician/SKILL.md and confirmed roles/aerospace-engineering-technician and roles/gis-technologist are off-domain, ruled out immediately). O*NET 17-3024.00 is a hands-on technician occupation: assembling, testing, calibrating, troubleshooting, and repairing electromechanical/mechatronic equipment already designed by an engineer — general-purpose (sensors, actuators, control circuits, servomechanisms across industries), not limited to industrial robot arms. mechatronics-engineer's Decision framework (concurrent RFLP requirement-setting, sensor/actuator topology selection, closed-loop dynamic modeling before hardware commitment, gear-ratio/inertia sizing) and Tools & methods (SolidWorks/Creo, MATLAB/Simulink, VDI 2206 V-model artifacts) are all design-time engineering decisions a technician doing 17-3024.00 work never makes — they receive the design as a given and instead need calibration/troubleshooting procedures, meter/oscilloscope-based fault isolation, and assembly/test work instructions. That is a decisions-and-tools difference, not just a detail difference, so it fails the granularity test against mechatronics-engineer and warrants a new leaf. It also fails against robotics-technician (17-3024.01, sibling-not-candidate but checked for completeness): that role's entire framework — joint mastering/pulse-count verification, TCP calibration, robot-cell LOTO — is scoped specifically to industrial robot arms, whereas 17-3024.00 covers electromechanical equipment broadly (not necessarily robotic), so robots-technician is too narrow a target too. mechatronics-engineer is the correct parent by domain (design engineer whose output this technician installs/calibrates/troubleshoots), matching the existing robotics-engineer/robotics-technician pairing pattern already in the repo. Proposed slug 'electromechanical-technician' is free (no existing roles/electromechanical-technician or roles/mechatronics-technician directory) and follows the repo's '<noun>-technician' naming convention used by mechanical-engineering-technician, electrical-engineering-technician, aerospace-engineering-technician, and robotics-technician.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the new `electromechanical-technician` role (O*NET 17-3024.00) as a leaf of `mechatronics-engineer`, focused on hands-on maintenance and troubleshooting. Updates the role registry and docs to reflect the new role and counts.

- **New Features**
  - Added `roles/electromechanical-technician` with SKILL and references covering megger + PI, ISO 10816/20816 zones, PLC JSR/MCR and forces, arc‑flash PPE selection, pneumatic decay tests, and crimp pull-tests.
  - Registered in `data/roles.json` (parent `mechatronics-engineer`) and linked in README/ROADMAP; updated counts to 540 drafted (530 O*NET; spec‑2 498), engineering now 87, O*NET coverage 52.2%.

<sup>Written for commit 10a0f32a9dc700f8a4559b6a9b19270d31a5e7be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

