### PR TITLE
role: add nanotechnology-engineering-technician

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,12 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**540 roles drafted** (530 mapped to an O*NET occupation, 10 custom; 498 at spec 2, 42 awaiting upgrade), across 10 categories:
+**541 roles drafted** (531 mapped to an O*NET occupation, 10 custom; 499 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `██████████░░░░░░░░░░` 52.2% (530 / 1,016 occupations)
+**O\*NET coverage:** `██████████░░░░░░░░░░` 52.3% (531 / 1,016 occupations)
 
 - **design**: 12
-- **engineering**: 87
+- **engineering**: 88
 - **finance**: 31
 - **healthcare**: 58
 - **legal**: 21

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 530 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 531 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -182,7 +182,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>17 — Architecture and Engineering</strong> (54/59 drafted)</summary>
+<summary><strong>17 — Architecture and Engineering</strong> (55/59 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -237,7 +237,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 | ✅ | 17-3024.01 | Robotics Technicians | [`robotics-technician`](./roles/robotics-technician/SKILL.md) |
 | ✅ | 17-3025.00 | Environmental Engineering Technologists and Technicians | [`environmental-engineering-technician`](./roles/environmental-engineering-technician/SKILL.md) |
 | ✅ | 17-3026.00 | Industrial Engineering Technologists and Technicians | [`industrial-engineering-technician`](./roles/industrial-engineering-technician/SKILL.md) |
-|  | 17-3026.01 | Nanotechnology Engineering Technologists and Technicians |  |
+| ✅ | 17-3026.01 | Nanotechnology Engineering Technologists and Technicians | [`nanotechnology-engineering-technician`](./roles/nanotechnology-engineering-technician/SKILL.md) |
 | ✅ | 17-3027.00 | Mechanical Engineering Technologists and Technicians | [`mechanical-engineering-technician`](./roles/mechanical-engineering-technician/SKILL.md) |
 |  | 17-3027.01 | Automotive Engineering Technicians |  |
 | ✅ | 17-3028.00 | Calibration Technologists and Technicians | [`calibration-technician`](./roles/calibration-technician/SKILL.md) |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 540,
+  "count": 541,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -7189,6 +7189,27 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/nanosystems-engineer/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "nanotechnology-engineering-technician",
+      "description": "Use when a task needs the judgment of a Nanotechnology Engineering Technician \u2014 running or qualifying an RCA wet-clean sequence, diagnosing atomic layer deposition growth-per-cycle drift mid-run, sampling cleanroom air for engineered-nanomaterial exposure against NIOSH RELs, troubleshooting AFM probe wear or image-resolution loss, or verifying ISO 14644-1 cleanroom classification and ESD/gowning compliance before a fab run.",
+      "category": "engineering",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "17-3026.01",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/nanotechnology-engineering-technician/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/roles/nanotechnology-engineering-technician/SKILL.md
+++ b/roles/nanotechnology-engineering-technician/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: nanotechnology-engineering-technician
+description: Use when a task needs the judgment of a Nanotechnology Engineering Technician — running or qualifying an RCA wet-clean sequence, diagnosing atomic layer deposition growth-per-cycle drift mid-run, sampling cleanroom air for engineered-nanomaterial exposure against NIOSH RELs, troubleshooting AFM probe wear or image-resolution loss, or verifying ISO 14644-1 cleanroom classification and ESD/gowning compliance before a fab run.
+metadata:
+  category: engineering
+  maturity: draft
+  spec: 2
+  onet_soc_code: "17-3026.01"
+---
+
+# Nanotechnology Engineering Technician
+
+## Identity
+
+Distinct from the process engineer, who owns recipe design and disposition of an excursion: the technician's leverage is entirely in whether the run was executed to spec and whether a drift signal got caught and escalated before it compounded into scrapped material. The defining tension: at nanoscale, the exposure limits, static-discharge thresholds, and process tolerances the job runs against are frequently at or past the edge of what current measurement or regulation can pin down — the technician works inside real gaps (no OSHA PEL for engineered nanomaterials, a REL set by instrument capability rather than biology, a self-limiting deposition dose that only reveals its own health through cycle-to-cycle drift) and has to make defensible calls anyway.
+
+## First-principles core
+
+1. **A NIOSH REL is not proof of safety — for carbon nanotubes/nanofibers it's set at the floor of what air sampling can currently measure, not at a toxicologically derived safe level.** The REL of 1 µg/m³ respirable elemental carbon (8-hr TWA) is an instrument-limited number; meeting it demonstrates the sample was clean to the sensitivity of the method, not that exposure was biologically safe. There is currently no OSHA-enforceable PEL for engineered nanomaterials generally, so the REL is the best available ceiling, not a regulatory floor with margin baked in.
+2. **Particle size alone can move an exposure limit by an order of magnitude on the same chemical.** NIOSH's REL for ultrafine/nanoscale TiO2 is 0.3 mg/m³ versus 2.4 mg/m³ for fine-particle TiO2 — 8x stricter for the identical compound, purely from surface-area-driven reactivity at nanoscale. Chemical identity on a label doesn't tell a technician the hazard class; particle size does.
+3. **ESD damage thresholds shrink with feature size, so a gowning/grounding protocol that was adequate at one node is not automatically adequate at the next.** Less charge is needed to damage a device or photomask as geometries shrink, which makes wrist straps, dissipative touch points, and correctly woven (dissipative-thread) gowning fabric a first-order yield lever rather than a compliance formality — and a gowning fabric that isn't dissipative-thread woven can itself generate the static it's meant to suppress.
+4. **A wet-chemistry recipe's ratios and temperature band are the process, not a suggested starting point.** SC1 (NH4OH:H2O2:H2O = 1:4:20 at 80°C) etches silicon oxide and organics at a rate and selectivity that shifts with both ratio and temperature; the tighter 55–75°C control band used for controlled etch exposures over 60 minutes exists because the reaction is temperature-sensitive enough that "close to 80°C" and "80°C" give measurably different results.
+5. **In atomic layer deposition, growth-per-cycle is a self-limiting dose, and its cycle-to-cycle stability — not the single-point thickness reading — is the process-health signal.** ALD gets sub-angstrom control (observed GPCs from ~0.65 Å/cycle for SiN to ~1.6 Å/cycle for saturated Ga2O3) because each cycle deposits a bounded, self-limiting amount; a GPC that drifts from its qualified value mid-run means the delivery mechanism (precursor supply, valve, purge) is degrading, not that the target thickness merely needs a few more cycles bolted on.
+
+## Mental models & heuristics
+
+- **When a carbon-nanotube or nanofiber air sample comes back under the 1 µg/m³ REL, default to treating that as "sampling didn't detect a problem," not "no problem exists"** — the REL is set at the measurement floor (First-principles core #1), so a clean sample at that limit is weaker evidence of safety than a clean sample well under a toxicologically derived limit would be.
+- **When provisioning or inspecting cleanroom garments, default to verifying dissipative-thread construction rather than assuming any bunny suit suppresses static** — non-dissipative fabric is a documented failure mode that generates the charge it's meant to prevent (First-principles core #3).
+- **When AFM image resolution degrades gradually across a run, default to checking tip radius before blaming the sample or process.** A ScanAsyst probe starts around 2 nm radius (spec max 8 nm) and wears wider with use; resolution loss that tracks with probe hours, not with sample changes, is a consumable swap, not a process excursion.
+- **When running SC1 for a controlled etch, default to the tighter 55–75°C band for exposures over 60 minutes rather than the nominal 80°C spec point** — the process is controllable across a temperature range, and holding at the tight end of that range gives more consistent etch behavior for long, sensitive exposures.
+- **When an ALD run's in-line metrology shows a GPC that has moved from its qualified value, default to pausing and diagnosing the delivery system (precursor level, valve, purge line) before recalculating remaining cycles off the new single-point rate** — a rate that's drifted once may still be drifting, so re-running a short verification sub-sequence beats trusting either the nominal or the one new measurement (First-principles core #5).
+- **When no OSHA PEL exists for a material in use, default to the NIOSH REL or the vendor SDS's stated limit as the working ceiling, and document that the limit used is a recommendation, not an enforceable standard** [heuristic — needs practitioner check: the regulatory gap is confirmed, but the "always use REL/SDS as ceiling" response pattern is inferred, not sourced to a named procedure].
+- **When feature size on a job is smaller than what a prior gowning/ESD protocol was qualified for, default to re-verifying the protocol against the new node's ESD sensitivity rather than assuming the old protocol still covers it**, since the energy needed to cause damage keeps dropping as geometries shrink (First-principles core #3).
+
+## Decision framework
+
+1. **Confirm tool and process qualification before touching a run** — badge/training status for the specific tool, PPE and ESD-grounding check, and that the recipe on file matches the spec sheet version being run.
+2. **Verify recipe parameters against the written spec before mixing chemistry or starting deposition** — ratios, temperature band, exposure/cycle count — rather than relying on memory of "how it's usually done."
+3. **Execute the process step, logging real-time readings (bath temperature, chamber pressure, in-line metrology) against the tolerance band as the run proceeds**, not only at the end.
+4. **When a reading falls outside tolerance, isolate whether the cause is tool health, delivery/consumable degradation, or a genuine process shift before taking corrective action** — a single out-of-band reading gets a verification check, not an immediate large correction.
+5. **Recompute the remaining process plan (cycles, etch time, exposure) from the verified current rate, not the original nominal rate**, once a drift is confirmed rather than a one-off blip.
+6. **Escalate to the process engineer of record when the finding crosses a qualification boundary** — a drift whose root cause implicates the recipe itself, the tool's fitness for the spec, or exposure limits, rather than a routine consumable swap.
+7. **Log the deviation, the diagnostic path, and the corrective action taken** so the next technician or the engineer reviewing yield can trace what happened without re-deriving it.
+
+## Tools & methods
+
+- **Nanofabrication pattern-transfer tools** — electron-beam lithography (highest resolution, serial write, lowest throughput — hours per die), optical lithography (wavelength-limited resolution, highest throughput, cheapest per die), nanoimprint lithography (throughput near optical once a master exists, but replicates the master's defects into every part), focused ion beam milling (direct-write flexibility, slowest of the four, and the gallium-ion beam itself implants and damages the milled surface) — each with its own qualification requirements per tool.
+- **Wet-chemistry clean stations** running RCA-standard sequences — SC1 (APM), SC2 (HPM), piranha (SPM) — with bath temperature and ratio logged per run, not assumed from the last calibration.
+- **ALD reactors with in-line or ex-situ thickness metrology** (ellipsometry, witness wafers) tracked as growth-per-cycle over time, not just final-thickness pass/fail.
+- **Atomic force microscopy** with named-spec probes (e.g., Bruker ScanAsyst for general imaging, RTESP-300 for higher-aspect-ratio features) tracked for tip-radius wear against the manufacturer's spec.
+- **Particle counters and cleanroom classification per ISO 14644-1**, used to verify a bay is holding its rated class (e.g., ISO 5 ≤ 3,520 particles/m³ at ≥0.5 µm) rather than trusting the posted classification indefinitely.
+- **NIOSH-method air sampling media** for elemental/respirable carbon and other engineered-nanomaterial exposure assessment, read against the relevant REL.
+
+## Communication style
+
+To the process engineer: the deviation stated as a number against its tolerance band, the diagnostic steps already run, and a specific hypothesis for root cause — not "the run looked off." To EHS/safety staff: exposure sampling results reported with the REL they're being compared against and an explicit note when that REL is a recommendation rather than an enforceable limit, so the safety reviewer isn't left assuming regulatory force that doesn't exist. To the next shift or technician: process logs written so a reader can reconstruct what was run, what drifted, and what was done about it without asking — cleanroom process logs, not narrative summaries.
+
+## Common failure modes
+
+- **Filing an under-REL air sample result without stating the method's detection limit relative to the reading** — letting a downstream reviewer read "compliant" as "toxicologically safe" instead of "not detected at the instrument floor" (First-principles core #1).
+- **Trusting a garment's visible condition — no tears, right color, right brand — as evidence of dissipative-thread construction**, when resistivity is a material property that inspection by eye can't detect and only the lot's spec sheet or incoming-QC resistivity measurement confirms.
+- **Re-tuning scan gain/setpoint to compensate for degrading AFM resolution** instead of checking probe hours against the tip-radius spec, masking a consumable problem as a settings problem.
+- **Reading a second ALD checkpoint that's closer to the qualified GPC than the first as "recovering" and skipping the verification sub-run** — a delivery system that's actually failing can oscillate before it fails outright, so one better-looking reading doesn't clear the drift.
+- **The overcorrection**: having learned that RELs and PELs may not exist for a given nanomaterial, refusing to run any process without a hard enforceable number, instead of documenting the REL/SDS limit used and proceeding under it as the working ceiling.
+- **Deviating a wet-chemistry recipe's temperature or ratio "close enough" to spec** without logging the deviation, on the assumption that a few degrees or a slightly off ratio doesn't matter at this scale.
+
+## Worked example
+
+**Setup.** An ALD recipe is qualified to deposit a 20 nm (200 Å) SiN film at a nominal growth-per-cycle (GPC) of 0.65 Å/cycle, programmed for 308 cycles (200 Å ÷ 0.65 Å/cycle = 307.7, rounded up). The film spec tolerance is 200 Å ± 5% (190–210 Å). An in-line ellipsometry check on the witness wafer at cycle 100 measures **55.0 Å** actual thickness.
+
+**Observed GPC at the checkpoint.** 55.0 Å ÷ 100 cycles = **0.550 Å/cycle**, a (0.650 − 0.550) / 0.650 = **15.4% drop** from the qualified nominal rate.
+
+**Naive read.** Treat the drop as within noise and let the remaining 208 programmed cycles run at the nominal rate: predicted final thickness = 55.0 + (208 × 0.650) = 55.0 + 135.2 = **190.2 Å**. That's inside the 190–210 Å spec band by 0.2 Å — "close enough, let it finish."
+
+**Expert reasoning.** The naive projection is wrong on its own terms: it uses the nominal 0.650 Å/cycle for the remaining cycles when the just-measured rate is 0.550 Å/cycle. Projecting forward on the *actual* measured rate instead: 55.0 + (208 × 0.550) = 55.0 + 114.4 = **169.4 Å** — 15.3% under the 200 Å target and well outside the 190–210 Å tolerance. The two projections (190.2 Å vs. 169.4 Å) disagree by nearly 21 Å, which is itself the tell that the run is not "close enough" — it's off by an amount that depends entirely on which rate you trust, and that ambiguity is the process-health signal (First-principles core #5). Per the decision framework, the correct move is not to pick either projection and finish the run, but to pause and diagnose: a 15.4% GPC drop only 100 of 308 cycles in is large enough, and early enough, to indicate the precursor delivery system (bubbler level, valve, purge) is degrading rather than having settled at a new stable rate. A 20-cycle verification sub-run is executed: it measures 10.4 Å over 20 cycles, GPC = 0.520 Å/cycle — confirming the rate is still falling, not stable at 0.550.
+
+**Reconciled plan.** Recompute remaining cycles needed off the latest confirmed rate (0.520 Å/cycle) to hit 200 Å from the current measured 65.4 Å (55.0 + 10.4): remaining thickness needed = 200 − 65.4 = 134.6 Å; cycles = 134.6 ÷ 0.520 = 258.8 → 259 cycles. But because the rate has now fallen twice in a row, the technician does not simply program 259 more cycles and walk away — the delivery system is flagged for a precursor-level and valve check before resuming, since a still-falling rate would blow through 259 cycles the same way it blew through the original 208.
+
+**Deliverable — process deviation log (as filed):**
+
+> **Tool/recipe:** ALD SiN, 200 Å target, qualified GPC 0.650 Å/cycle, 308 cycles programmed.
+> **Checkpoint (cycle 100):** measured 55.0 Å → observed GPC 0.550 Å/cycle (−15.4% vs. qualified rate).
+> **Verification sub-run (20 cycles):** measured 10.4 Å → GPC 0.520 Å/cycle — confirms rate is still declining, not settled.
+> **Disposition:** Run paused at cycle 120 (65.4 Å deposited). Naive continuation at nominal rate would have projected 190.2 Å (in-spec on paper); actual trajectory at the falling measured rate projects toward ~170 Å or lower if uncorrected — out of the 190–210 Å band.
+> **Escalation:** Precursor bubbler level and inlet valve flagged for process-engineer inspection before resuming. Recommend re-qualifying GPC via a fresh 20-cycle check after any bubbler/valve service, not resuming on the original 308-cycle program.
+
+## Going deeper
+
+- [references/playbook.md](references/playbook.md) — load when running or qualifying a wet-clean, ALD, or lithography process step, or diagnosing a metrology drift against a qualified process baseline.
+- [references/red-flags.md](references/red-flags.md) — load when reviewing an exposure-sampling result, a cleanroom classification check, or a process log for the smell tests that catch a non-defensible run before material ships or someone is exposed.
+- [references/vocabulary.md](references/vocabulary.md) — load when a nanofabrication or cleanroom term needs its precise, misuse-aware meaning.
+
+## Sources
+
+- NIOSH Technical Report 2022-153, *Occupational Exposure Sampling for Engineered Nanomaterials* (CDC/NIOSH) — https://www.cdc.gov/niosh/docs/2022-153/default.html.
+- NIOSH Current Intelligence Bulletins, Recommended Exposure Limits for Carbon Nanotubes/Nanofibers and for Titanium Dioxide — source for the 1 µg/m³ CNT/CNF REL and the 0.3 mg/m³ vs. 2.4 mg/m³ TiO2 nanoscale/fine-particle comparison.
+- ISO 14644-1:2015, *Cleanrooms and associated controlled environments — Part 1: Classification of air cleanliness by particle concentration* — source for ISO Class 5/7 particle-count thresholds.
+- ISO 14644-2:2015, *Cleanrooms and associated controlled environments — Part 2: Monitoring to provide evidence of cleanroom performance* — source for the maximum particle-count retest interval (6 months for ISO Class ≤5, 12 months for ISO Class >5) cited in references/red-flags.md.
+- Zheng Cui, *Nanofabrication: Principles, Capabilities and Limits*, 3rd ed. (Springer) — source for the named pattern-transfer techniques (EBL, optical lithography, nanoimprint, FIB) and their capability/limit framing.
+- MT Systems / Microtech Process, "RCA Critical Cleaning Process" technical bulletin — https://www.microtechprocess.com/wp-content/uploads/2018/04/MTS_RCA.pdf — source for SC1/SC2/piranha ratios, temperatures, and the SC1 controlled-etch temperature band.
+- Bruker AFM Probes product/spec sheets (brukerafmprobes.com, spmtips.com) — source for ScanAsyst and RTESP-300 tip-radius specifications.
+- National Nanotechnology Coordinated Infrastructure (NNCI; nnci.net, Cornell CNF, Georgia Tech SENIC) — source for the shared-cleanroom, tool-by-tool qualification pattern referenced in Identity and the decision framework.
+- ALD growth-per-cycle figures (0.65 Å/cycle SiN, 1.6 Å/cycle saturated Ga2O3) — process-development literature cited in Pass 0 research notes; exact facility numbers vary by tool and precursor and should be verified against the qualified recipe in use.
+- No OSHA-enforceable PEL currently exists for engineered nanomaterials generally, confirmed in Pass 0 research — this absence is treated as a stated fact, not an invented threshold.
+- The specific numeric thresholds in the worked example (20 nm target, 308 programmed cycles, ±5% tolerance band, drift-diagnosis cycle counts) are constructed to be internally consistent for this worked scenario; verify against a specific facility's qualified recipe before treating as a general rule.
+- The ±10% wet-chemistry dispensed-volume tolerance in references/red-flags.md is a constructed, internally consistent threshold (matching the >10% ALD GPC verification trigger elsewhere in this role), not a value pulled from the RCA bulletin cited above; verify against a specific facility's SOP before treating as a general rule.

--- a/roles/nanotechnology-engineering-technician/references/playbook.md
+++ b/roles/nanotechnology-engineering-technician/references/playbook.md
@@ -1,0 +1,88 @@
+# Process Playbook
+
+Filled run templates for the four process families a nanofab technician executes most: RCA wet clean, ALD deposition, AFM metrology, and cleanroom/exposure verification. Populate the tables in place; don't paraphrase them into prose in a log.
+
+## 1. RCA wet-clean run log (SC1 / SC2 / piranha)
+
+Fill this table before touching chemistry. Ratios and temperature bands are the process — deviations get logged, not eyeballed.
+
+| Field | SC1 (APM) | SC2 (HPM) | Piranha (SPM) |
+|---|---|---|---|
+| Ratio (NH4OH : H2O2 : H2O) | 1 : 4 : 20 | HCl:H2O2:H2O = 1:1:6 | H2SO4:H2O2 = 4:1 |
+| Nominal temp | 80°C | 80°C | 120°C |
+| Controlled-etch tight band (exposures >60 min) | 55–75°C | n/a | n/a |
+| Nominal exposure | 10 min | 10 min | 10–15 min |
+| Purpose | Organic/particle removal, light oxide etch | Metallic-ion removal | Heavy organic strip |
+| Bath temp at start | ___ °C (log) | ___ °C | ___ °C |
+| Bath temp at exposure midpoint | ___ °C | ___ °C | ___ °C |
+| Bath temp at end | ___ °C | ___ °C | ___ °C |
+| Pass/fail vs. band | Pass if within band above for full exposure | | |
+
+**Escalation rule:** any single reading outside the logged band by >2°C → hold exposure timer, re-check thermocouple calibration, do not extend run time to compensate. Two consecutive out-of-band readings on the same bath → abort run, tag bath for engineer review before next use.
+
+## 2. ALD run-health checkpoint template
+
+Run at every scheduled ellipsometry/witness-wafer checkpoint (typically every 100 cycles or per recipe spec, whichever is tighter).
+
+| Checkpoint | Cycles run | Cumulative thickness (Å) | Observed GPC (Å/cycle) | Qualified GPC (Å/cycle) | Δ from qualified | Action |
+|---|---|---|---|---|---|---|
+| 0 (baseline) | 0 | 0.0 | — | 0.650 | — | Proceed |
+| 1 | 100 | 55.0 | 0.550 | 0.650 | −15.4% | >10% → verification sub-run required |
+| Verification sub-run | +20 | +10.4 | 0.520 | 0.650 | −20.0% | Confirms decline → pause, flag delivery system |
+| 2 (post-service) | +20 | ___ | ___ | 0.650 | ___ | Resume only if GPC within ±5% of qualified |
+
+**Drift-response thresholds:**
+- GPC within ±5% of qualified value → continue on original cycle program.
+- GPC 5–10% off qualified value → flag for next checkpoint, no run pause.
+- GPC >10% off qualified value → run 20-cycle verification sub-run before any decision.
+- Two consecutive checkpoints (scheduled or verification) trending the same direction → pause run, escalate to process engineer for precursor/valve inspection before resuming.
+- After service, do not resume the original cycle count — re-qualify GPC via a fresh 20-cycle check and recompute remaining cycles from the re-qualified rate.
+
+**Remaining-cycles formula (use latest confirmed rate, never nominal, once drift is confirmed):**
+`remaining_cycles = ceil((target_thickness_Å − thickness_deposited_so_far_Å) / latest_confirmed_GPC)`
+
+## 3. Lithography step sequence (optical, generic node)
+
+1. **Substrate prep** — dehydration bake 120°C / 5 min, HMDS prime (vapor or spin, per recipe). Log bake oven temp at start and end; >±3°C from setpoint → re-bake.
+2. **Resist spin** — target thickness per recipe (e.g., 1.2 µm at 3000 rpm / 45 s). Measure thickness on a monitor wafer; >5% off target → re-spin, do not proceed to expose.
+3. **Soft bake** — per resist spec (e.g., 90°C / 60 s). Log actual hot-plate temp, not setpoint.
+4. **Alignment & exposure** — verify alignment marks within tool spec (typically ≤0.25 µm overlay) before committing exposure dose. Log dose (mJ/cm²) actually delivered, read off tool log, not assumed from recipe.
+5. **Post-exposure bake (chemically amplified resists only)** — per spec; skipping or under-time this step is a common silent failure — log explicitly even when "n/a."
+6. **Develop** — fixed time per recipe (e.g., 60 s single-puddle); log actual develop time, not nominal.
+7. **CD/profile check** — measure critical dimension against target ± tolerance (e.g., 90 nm ± 9 nm, 10%). Out of tolerance → hold lot, do not proceed to etch, escalate per Decision framework step 6.
+
+## 4. AFM probe-wear tracking log
+
+| Probe model | Spec tip radius (new) | Spec max (end-of-life) | Hours in use | Last measured resolution feature (nm) | Trend vs. prior 3 sessions | Action |
+|---|---|---|---|---|---|---|
+| Bruker ScanAsyst-Air | 2 nm nominal | 8 nm max | ___ | ___ | flat / degrading | Swap if degrading + hours > mfr guidance |
+| Bruker RTESP-300 | 8 nm nominal | 12 nm max | ___ | ___ | flat / degrading | Swap if degrading + hours > mfr guidance |
+
+**Rule:** resolution loss that tracks with cumulative probe hours (not with sample change) is a consumable swap, logged as such — not written up as a process or sample anomaly.
+
+## 5. ISO 14644-1 cleanroom classification verification
+
+| Class | Max particles/m³ at ≥0.5 µm | Max particles/m³ at ≥0.3 µm |
+|---|---|---|
+| ISO 5 | 3,520 | 10,200 |
+| ISO 6 | 35,200 | 102,000 |
+| ISO 7 | 352,000 | n/a (not specified) |
+
+**Sequence:**
+1. Confirm particle counter calibration is current (annual, per manufacturer) before use.
+2. Sample at the number of locations required by the bay's rated area (per ISO 14644-1 Annex A sampling-location formula), not a single spot check.
+3. Compare each location's reading against the class threshold table above — one location over threshold fails the whole zone's current classification, even if the average is under.
+4. Log date, counter serial/cal-due date, per-location readings, and pass/fail. Do not carry forward a prior classification without a current reading on file.
+5. Fail → notify facilities/EHS before resuming particle-sensitive work in that bay; do not self-waive.
+
+## 6. NIOSH air-sampling documentation template
+
+> **Material sampled:** [e.g., MWCNT, ultrafine TiO2]
+> **Method:** [NIOSH method number]
+> **Duration:** [8-hr TWA / task-length, specify]
+> **Result:** ___ µg/m³ (or mg/m³)
+> **Limit referenced:** [e.g., NIOSH REL 1 µg/m³ respirable elemental carbon — CNT/CNF; note explicitly: no OSHA PEL exists for this material]
+> **Limit type:** REL (recommended, not enforceable) / vendor SDS limit / OSHA PEL (if one exists)
+> **Disposition:** [under REL — treat as "not detected at measurement floor," not proof of safety, per First-principles core #1] / [over REL — stop work in area, escalate to EHS]
+
+Every sampling result gets filed with the limit type spelled out — a safety reviewer reading only the number, without the REL/PEL distinction, will assume regulatory force that doesn't exist.

--- a/roles/nanotechnology-engineering-technician/references/red-flags.md
+++ b/roles/nanotechnology-engineering-technician/references/red-flags.md
@@ -1,0 +1,61 @@
+# Nanotechnology Engineering Technician — Red Flags
+
+### Carbon nanotube/nanofiber air sample reported as "pass" at or near the 1 µg/m³ REL with no mention of the method's detection limit
+- **Usually means:** the sample is being treated as proof of safety rather than "not detected at the floor of what the instrument can measure" — the REL itself is instrument-limited, not toxicologically derived.
+- **First question:** what was the method's limit of detection relative to the reported value, and was that margin stated in the report or omitted?
+- **Data to pull:** the NIOSH-method air sampling report with LOD, sample volume, and analyte mass, not just the final µg/m³ figure.
+
+### TiO2 exposure assessed against the 2.4 mg/m³ fine-particle REL instead of the 0.3 mg/m³ nanoscale/ultrafine REL
+- **Usually means:** the material was classified by chemical label (TiO2) rather than by particle size, missing the 8x-stricter limit that applies once the same compound is in nanoscale form.
+- **First question:** what particle-size data (not just the SDS chemical name) was used to select which REL applies?
+- **Data to pull:** particle-size distribution or manufacturer spec sheet for the material batch in use, cross-checked against the REL selected in the exposure report.
+
+### Cleanroom garment issued or reused with no lot record showing surface resistivity inside the 10^5–10^11 ohms/sq dissipative band
+- **Usually means:** gowning stock was replenished or a non-standard garment substituted without checking fabric spec, leaving a garment that can generate the static charge it's meant to suppress.
+- **First question:** does the garment lot's spec sheet or incoming-QC record show a measured resistivity inside 10^5–10^11 ohms/sq, or was dissipative construction assumed from appearance/brand?
+- **Data to pull:** garment vendor spec sheet or incoming-QC resistivity measurement for the lot in use.
+
+### Wrist-strap or ESD-grounding check skipped or logged as "N/A" before touching a run
+- **Usually means:** the badge/PPE checklist step was treated as a formality rather than a yield-relevant control, especially likely if the technician has run the same tool recently without incident.
+- **First question:** was the grounding check performed and logged for this specific run, or copied forward from a prior shift's log?
+- **Data to pull:** the tool's daily ESD-check log with timestamps matching the run in question.
+
+### SC1 bath temperature logged outside the 55–75°C controlled-etch band for an exposure over 60 minutes
+- **Usually means:** the bath was run at the nominal 80°C spec point on the assumption that "on-spec" and "tightly controlled" are the same thing, without accounting for the tighter band required for long exposures.
+- **First question:** what was the exposure duration, and does the logged temperature fall inside 55–75°C for that duration?
+- **Data to pull:** bath temperature log at set intervals through the full exposure, not a single start-of-run reading.
+
+### Wet-chemistry ratio (e.g., SC1 at 1:4:20) has any single reagent's dispensed volume off the target ratio by more than ±10%, without a logged deviation
+- **Usually means:** chemistry was mixed "close enough" from memory or a partially-empty reagent bottle, on the assumption that a slightly off ratio doesn't matter at this scale.
+- **First question:** was the actual dispensed volume of each reagent recorded and checked against ±10% of its target-ratio volume, or only the target ratio from the recipe sheet?
+- **Data to pull:** dispense log or scale/flow-meter readout for each reagent in the batch.
+
+### AFM image resolution degrading progressively across a run with no probe-hour tracking
+- **Usually means:** tip radius has worn past its manufacturer spec (e.g., beyond ~8 nm for a ScanAsyst probe rated at 2 nm nominal) and the degradation is being attributed to the sample or process instead of the consumable.
+- **First question:** how many scan-hours are on the current probe, and does the resolution loss track probe hours or sample changes?
+- **Data to pull:** probe usage log (hours or scan count since installation) against the manufacturer's tip-radius spec.
+
+### ALD growth-per-cycle at an in-line checkpoint has moved more than ~10% from its qualified nominal rate
+- **Usually means:** precursor delivery (bubbler level, valve, purge line) is degrading mid-run; second most likely, the witness-wafer metrology itself has drifted (calibration or contamination).
+- **First question:** has a short verification sub-run been executed to confirm the new rate is stable, or is the disposition being decided off the single checkpoint reading?
+- **Data to pull:** full cycle-by-cycle or checkpoint-by-checkpoint GPC history for the run, plus the verification sub-run result if one exists.
+
+### Remaining process cycles/time recalculated using the original nominal rate after a confirmed drift
+- **Usually means:** the technician (or a review step) reverted to the qualified spec number because it's "the number on the recipe sheet," rather than projecting forward on the last-confirmed measured rate.
+- **First question:** which rate — nominal or last-measured — was used to compute the remaining cycles/time in the current plan?
+- **Data to pull:** the disposition log showing which rate fed the remaining-cycle calculation, alongside the raw checkpoint measurements.
+
+### Particle counter check for an ISO-classified bay is more than 6 months old (ISO Class ≤5) or 12 months old (ISO Class >5) per ISO 14644-2's maximum retest interval, yet the bay is still logged as in-class
+- **Usually means:** the posted classification is being trusted indefinitely rather than re-verified on the ISO 14644-2 schedule, often because no excursion has been visibly obvious.
+- **First question:** when was the bay's classification last verified by an actual particle count, and does that date fall inside the 6-month (ISO ≤5) or 12-month (ISO >5) retest interval?
+- **Data to pull:** particle-counter logs for the bay (e.g., ISO 5 threshold of ≤3,520 particles/m³ at ≥0.5 µm) with timestamps.
+
+### Exposure limit used in a report has no OSHA PEL and the report doesn't flag it as a recommendation rather than an enforceable standard
+- **Usually means:** a NIOSH REL or vendor SDS limit was applied as if it carried regulatory force, which overstates the certainty of the safety call to whoever reads the report downstream.
+- **First question:** does the report explicitly state that the limit used is a REL/SDS recommendation, not an OSHA-enforceable PEL?
+- **Data to pull:** the exposure assessment report's stated limit and its citation (OSHA PEL vs. NIOSH REL vs. SDS-stated value).
+
+### A process deviation was corrected in real time but never entered in the process log
+- **Usually means:** the technician judged the correction too minor to document, but a downstream reviewer (or the next shift) has no way to distinguish an undocumented fix from an undetected excursion.
+- **First question:** is there any log entry — even a one-line note — for the moment the reading went out of tolerance and what was done about it?
+- **Data to pull:** the run's full process log cross-referenced against the raw metrology trace for gaps where an out-of-band reading has no corresponding entry.

--- a/roles/nanotechnology-engineering-technician/references/vocabulary.md
+++ b/roles/nanotechnology-engineering-technician/references/vocabulary.md
@@ -1,0 +1,73 @@
+# Vocabulary — Nanotechnology Engineering Technician
+
+Terms generalists routinely use as loose synonyms for each other, or treat as looser than they are. Each entry gives the precise meaning, a sentence showing correct use, and the specific confusion to avoid.
+
+**REL (Recommended Exposure Limit) vs. PEL (Permissible Exposure Limit)**
+Definition: A REL is a NIOSH-recommended airborne exposure ceiling with no independent enforcement mechanism; a PEL is an OSHA-enforceable regulatory limit. For most engineered nanomaterials — including carbon nanotubes/nanofibers — no PEL currently exists, so the REL is the best available number, not a regulatory floor.
+In use: "No PEL exists for CNTs, so the sampling result is being reported against the NIOSH REL of 1 µg/m³ as a working ceiling, not an enforceable limit."
+Misuse note: Generalists say "the exposure limit" as if there's always a single enforceable number, or cite a REL as if OSHA can cite a violation against it. Reporting a REL result without flagging that it isn't enforceable lets a safety reviewer wrongly assume regulatory force.
+
+**Instrument-limited (as applied to a REL)**
+Definition: Describes a limit set at the floor of what current air-sampling methods can reliably measure, rather than at a toxicologically derived safe threshold. The CNT/CNF REL of 1 µg/m³ respirable elemental carbon is instrument-limited.
+In use: "A clean sample at the instrument-limited REL means sampling didn't detect a problem — it doesn't mean exposure was biologically safe."
+Misuse note: Treating a passing instrument-limited REL result as proof of safety is the single most common misread in this role — it conflates "below what we can currently detect" with "below what causes harm."
+
+**Respirable elemental carbon (vs. total or inhalable carbon)**
+Definition: The size-selected, sub-~4 µm fraction of airborne elemental (not organic) carbon that penetrates to the gas-exchange region of the lung — the specific fraction the NIOSH CNT/CNF method targets, distinct from total suspended particulate or the inhalable fraction.
+In use: "The sample reported 0.8 µg/m³ respirable elemental carbon, below the 1 µg/m³ REL for that fraction specifically."
+Misuse note: Generalists read "carbon reading" as a single undifferentiated number. A total-carbon or inhalable-fraction result is not directly comparable to the REL, which is defined against the respirable elemental-carbon fraction only.
+
+**8-hr TWA (Time-Weighted Average)**
+Definition: An exposure concentration averaged over a full 8-hour shift, not an instantaneous or peak reading. A REL or PEL expressed as a TWA can be exceeded briefly without a violation, as long as the shift-long average stays under the limit.
+In use: "The peak reading during the 20-minute transfer operation exceeded 1 µg/m³, but the 8-hr TWA came in at 0.6 µg/m³."
+Misuse note: Treating a single elevated grab-sample reading as itself "over the limit" ignores that most RELs/PELs are TWA-defined; conversely, a low TWA can mask a short high-intensity excursion worth investigating on its own.
+
+**Dissipative (vs. conductive or "anti-static")**
+Definition: A material property describing controlled, gradual charge bleed-off (surface resistivity roughly 10^5–10^11 ohms/sq) — distinct from conductive (near-zero resistance, rapid discharge) and from generic "anti-static" marketing claims that don't specify a resistivity class at all. Cleanroom gowning fabric must be woven with dissipative thread to function as intended.
+In use: "The bunny suits failed incoming QC because the thread wasn't dissipative-grade — resistivity measured outside the qualified band."
+Misuse note: Assuming any garment labeled "anti-static" or "ESD-safe" is dissipative-thread woven is a documented failure mode: non-dissipative fabric can itself generate the static charge the gowning protocol exists to suppress.
+
+**ESD sensitivity threshold (node-dependent, not fixed)**
+Definition: The minimum electrostatic discharge energy capable of damaging a device or photomask, which decreases as feature size shrinks — it is not a single facility-wide constant that, once qualified, stays valid across process generations.
+In use: "The gowning and grounding protocol qualified at the 90 nm node was re-verified before use on the 45 nm line, since the damage threshold there is lower."
+Misuse note: Carrying over an ESD protocol to a smaller-geometry job on the assumption that "it passed before" ignores that the threshold itself moved — a protocol adequate at one node isn't automatically adequate at the next.
+
+**SC1 / SC2 / Piranha (RCA clean components, not interchangeable)**
+Definition: SC1 (APM: NH4OH:H2O2:H2O, nominally 1:4:20 at 80°C) removes organics and particles; SC2 (HPM: HCl:H2O2:H2O) removes metallic ions; piranha (SPM: H2SO4:H2O2) strips heavy organic residue. Each targets a different contaminant class and runs a different chemistry — they are sequential steps in an RCA clean, not substitutable options.
+In use: "The wafer went through SC1 for particle/organic removal, then SC2 for the ionic clean — piranha wasn't called for since there was no heavy resist residue to strip."
+Misuse note: Referring to "the RCA clean" as one undifferentiated bath, or swapping which solution runs first, misses that each step is chemically targeted — skipping or reordering them changes what contamination actually gets removed.
+
+**Growth-per-cycle (GPC) — cycle-to-cycle rate, not a single-point thickness**
+Definition: In atomic layer deposition, the thickness deposited per reaction cycle, calculated from metrology at a checkpoint and tracked over successive checkpoints as the process-health signal — not the same thing as the cumulative thickness reading itself.
+In use: "GPC at cycle 100 was 0.550 Å/cycle, down from the qualified 0.650 Å/cycle — a 15.4% drop worth flagging before the run continues."
+Misuse note: Generalists read a single thickness checkpoint as pass/fail against the final spec and stop there. The rate derived from that checkpoint, and whether it's still moving, is the actual diagnostic signal — a thickness that's technically still "in spec" can sit on top of a GPC that's already trending toward failure.
+
+**Self-limiting (ALD deposition mechanism)**
+Definition: Describes a surface reaction that saturates and stops on its own once available reactive sites are consumed, which is what gives ALD its sub-angstrom per-cycle control — it does not mean the deposition rate is immune to drift.
+In use: "ALD's self-limiting chemistry is why GPC is normally stable cycle to cycle — which is exactly why a drift from the qualified GPC signals a delivery-system problem, not normal variation."
+Misuse note: Some generalists take "self-limiting" to mean "self-correcting" or "can't go wrong," and so under-react to a drifting GPC on the assumption the chemistry will settle itself back to the qualified rate. Self-limiting bounds each individual cycle's deposition; it says nothing about whether the precursor delivery feeding those cycles is still healthy.
+
+**Witness wafer**
+Definition: A dedicated monitor wafer run alongside (not instead of) the product wafer(s) in a process batch, sacrificed for destructive or time-consuming metrology so the product wafers don't have to be.
+In use: "Ellipsometry ran on the witness wafer at cycle 100 rather than the product wafers, to avoid pulling them mid-run."
+Misuse note: Treating the witness wafer's reading as automatically representative of the product wafers without confirming they saw equivalent process exposure (loading position, gas flow uniformity) can mask a real product-wafer deviation the witness wafer didn't experience.
+
+**ISO Class (ISO 14644-1) — lower number is cleaner**
+Definition: A numeric classification of a cleanroom's particle-count ceiling per cubic meter at specified particle sizes (e.g., ISO 5 ≤ 3,520 particles/m³ at ≥0.5 µm); the scale runs inversely — a lower class number means a stricter, cleaner environment, not a looser one.
+In use: "The lithography bay is qualified ISO 5; the gowning room outside it is only ISO 7, which is the expected, looser standard for that space."
+Misuse note: Assuming a higher ISO class number means "cleaner" (by analogy to higher-is-better ratings elsewhere) inverts the scale — ISO 7 is dirtier than ISO 5, not cleaner.
+
+**Cleanroom classification — a monitored state, not a one-time certificate**
+Definition: An ISO 14644-1 class rating that holds only as long as particle counts continue to verify it; it is not a permanent certification earned once and assumed to persist.
+In use: "Particle counts were re-verified before the run rather than trusting the classification plaque posted at the last audit."
+Misuse note: Treating a posted classification as settled fact, rather than re-checking current particle counts before a sensitive run, misses that filter loading, traffic, and door seals can degrade a bay's actual class between formal audits.
+
+**Tip radius (AFM probe wear)**
+Definition: The physical radius of curvature at an AFM probe's apex, which starts near a named spec (e.g., ~2 nm for a Bruker ScanAsyst probe, spec max 8 nm) and widens with use, directly degrading achievable image resolution independent of the sample.
+In use: "Resolution loss tracked with probe hours, not sample changes, so the ScanAsyst tip was swapped rather than re-tuning the scan parameters."
+Misuse note: Attributing gradually degrading AFM image resolution to the sample or process settings, rather than checking tip-radius wear against the manufacturer's spec, misses the most common and cheapest-to-fix cause.
+
+**Qualified rate (vs. nominal spec value)**
+Definition: The GPC, etch rate, or similar process rate actually verified for a specific tool/recipe/precursor lot combination during qualification runs — which can differ from the generic nominal value published for that chemistry, and is the correct baseline against which mid-run drift is measured.
+In use: "The drift was measured against this tool's qualified GPC of 0.650 Å/cycle, not the generic literature value for SiN ALD."
+Misuse note: Comparing an in-run reading against a textbook or vendor nominal number instead of the tool's own qualified rate can either mask a real drift (if the qualified rate was already lower) or manufacture a false alarm (if it was already higher).


### PR DESCRIPTION
rubric: 18/18

## Resolution rationale

Applied the granularity test to all three candidates. electrical-engineering-technician's core is bench-level fault isolation on assembled electronic hardware (DMM/scope node-to-node debugging, IPC-A-610 solder acceptance, ESD provenance on a returned board) — none of that transfers to nanofabrication process/characterization work. aerospace-engineering-technician's core is torque-to-preload, strain-gauge/FEA correlation, and NDI (dye penetrant/eddy current/ultrasonic) on macroscale aerostructures — wrong physics, wrong instruments, wrong failure modes entirely. environmental-engineering-technician's core is field sampling defensibility (holding times, chain of custody, compositing pacing) — a completely different object (environmental samples vs. fabricated nanostructures). A nanotech engineering technologist/technician's actual job is cleanroom nanofabrication process execution and control (thin-film deposition — PVD/CVD/ALD, photolithography/e-beam lithography exposure and dose, plasma/wet etch selectivity, spin-coating uniformity) plus nanoscale characterization (SEM/TEM/AFM imaging and metrology, contact-mode vs. tapping-mode AFM artifacts, particle/defect contamination control per cleanroom class) under an engineer's process spec. A practitioner following any of the three candidates' Decision framework or Tools & methods sections (torque wrenches/strain gauges; DMM/oscilloscope fault-isolation; water/air field sampling kits) would get zero actionable guidance and no relevant failure modes for a nanofab/characterization task — this fails the counterfactual and non-derivability tests hard, and none of the three is a plausible parent to inherit from since the core physics, instrumentation, and quality-control logic (cleanroom contamination control, deposition rate/uniformity, lithography CD control, nanoscale imaging artifacts) share no lineage with mechanical fastening, electronic bench debug, or environmental field sampling. No reasonable parent exists among the candidate set, so this is a new_parent leaf role. Slug follows existing '<discipline>-engineering-technician' naming convention used by all three candidates (electrical-engineering-technician, aerospace-engineering-technician, environmental-engineering-technician).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `nanotechnology-engineering-technician` as a new spec-2 role mapped to O*NET 17-3026.01 for cleanroom nanofabrication, nanoscale metrology, and nanomaterial EHS. Updates README/ROADMAP counts and registers the role in `data/roles.json`.

- **New Features**
  - Standalone role (no parent) covering RCA wet cleans, ALD, lithography, AFM, ISO 14644 cleanroom verification, and exposure assessment (REL vs. PEL).
  - Added: `roles/nanotechnology-engineering-technician/SKILL.md`, `references/playbook.md`, `references/red-flags.md`, `references/vocabulary.md`.
  - Repository updates: README/ROADMAP counts (+1 engineering role; O*NET coverage 531/1,016) and role entry in `data/roles.json` (jurisdiction `us`).

<sup>Written for commit 88b3cd101be55d70ed6026ba4f561d83b7349d89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

