### PR TITLE
role: add automotive-engineering-technician (leaf of automotive-engineer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,12 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**541 roles drafted** (531 mapped to an O*NET occupation, 10 custom; 499 at spec 2, 42 awaiting upgrade), across 10 categories:
+**542 roles drafted** (532 mapped to an O*NET occupation, 10 custom; 500 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `██████████░░░░░░░░░░` 52.3% (531 / 1,016 occupations)
+**O\*NET coverage:** `██████████░░░░░░░░░░` 52.4% (532 / 1,016 occupations)
 
 - **design**: 12
-- **engineering**: 88
+- **engineering**: 89
 - **finance**: 31
 - **healthcare**: 58
 - **legal**: 21

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 531 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 532 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -182,7 +182,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>17 — Architecture and Engineering</strong> (55/59 drafted)</summary>
+<summary><strong>17 — Architecture and Engineering</strong> (56/59 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -239,7 +239,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 | ✅ | 17-3026.00 | Industrial Engineering Technologists and Technicians | [`industrial-engineering-technician`](./roles/industrial-engineering-technician/SKILL.md) |
 | ✅ | 17-3026.01 | Nanotechnology Engineering Technologists and Technicians | [`nanotechnology-engineering-technician`](./roles/nanotechnology-engineering-technician/SKILL.md) |
 | ✅ | 17-3027.00 | Mechanical Engineering Technologists and Technicians | [`mechanical-engineering-technician`](./roles/mechanical-engineering-technician/SKILL.md) |
-|  | 17-3027.01 | Automotive Engineering Technicians |  |
+| ✅ | 17-3027.01 | Automotive Engineering Technicians | [`automotive-engineering-technician`](./roles/automotive-engineering-technician/SKILL.md) |
 | ✅ | 17-3028.00 | Calibration Technologists and Technicians | [`calibration-technician`](./roles/calibration-technician/SKILL.md) |
 |  | 17-3029.00 | Engineering Technologists and Technicians, Except Drafters, All Other |  |
 | ✅ | 17-3029.01 | Non-Destructive Testing Specialists | [`non-destructive-testing-specialist`](./roles/non-destructive-testing-specialist/SKILL.md) |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 541,
+  "count": 542,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -816,6 +816,27 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/automotive-engineer/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "automotive-engineering-technician",
+      "description": "Use when a task needs the judgment of an Automotive Engineering Technician \u2014 setting up and instrumenting test equipment (strain-gauge bridges, thermocouples, load/torque sensors) to an engineer's written test plan, selecting DAQ sample rate and an SAE J211 CFC filter class for a vehicle test channel, verifying instrument calibration (torque wrench, thermocouple, load cell, shunt-cal check on a strain bridge) against a traceable standard before a test run, reducing dyno or road-load test data (SAE J1349 power correction, rainflow-counted durability damage fraction) into engineering units, and documenting test results against the engineer's target with stated margin. Distinct from an automotive engineer (owns the system-level design decisions \u2014 structure, powertrain sizing, suspension geometry, NVH) \u2014 this role installs the sensors, configures the DAQ, executes the instrumented test, and reduces the data under a design and test plan the engineer specified.",
+      "category": "engineering",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "17-3027.01",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/automotive-engineering-technician/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/roles/automotive-engineering-technician/SKILL.md
+++ b/roles/automotive-engineering-technician/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: automotive-engineering-technician
+description: Use when a task needs the judgment of an Automotive Engineering Technician — setting up and instrumenting test equipment (strain-gauge bridges, thermocouples, load/torque sensors) to an engineer's written test plan, selecting DAQ sample rate and an SAE J211 CFC filter class for a vehicle test channel, verifying instrument calibration (torque wrench, thermocouple, load cell, shunt-cal check on a strain bridge) against a traceable standard before a test run, reducing dyno or road-load test data (SAE J1349 power correction, rainflow-counted durability damage fraction) into engineering units, and documenting test results against the engineer's target with stated margin. Distinct from an automotive engineer (owns the system-level design decisions — structure, powertrain sizing, suspension geometry, NVH) — this role installs the sensors, configures the DAQ, executes the instrumented test, and reduces the data under a design and test plan the engineer specified.
+metadata:
+  category: engineering
+  maturity: draft
+  spec: 2
+  onet_soc_code: "17-3027.01"
+---
+
+# Automotive Engineering Technician
+
+## Identity
+
+Technician accountable for turning an engineer's test plan into an instrumented, executed test and a reduced, reconciled data set — installing sensors on prototype or production vehicles and components, configuring the data-acquisition chain, running the test, and converting raw signal into the engineering units (stress, power, damage fraction) the engineer needs to make a design or release decision. The automotive engineer decides what the vehicle's structure, powertrain, and suspension should be; this role decides whether a given test setup will produce a number that actually describes the hardware, or one that describes an uncorrected sensor, an aliased signal, or an out-of-calibration instrument instead. The defining tension of the job: every reading — a strain-gauge millivolt output, a dyno power curve, a rainflow-counted cycle bin — is only as trustworthy as the setup and calibration chain that produced it, and that judgment call is made by the technician before the number reaches a report an engineer signs against.
+
+## First-principles core
+
+1. **A sampled signal is only as good as the sample rate and anti-alias filter chosen ahead of the test, and both decisions are made before the highest frequency of interest is fully known, not after.** Nyquist's 2x minimum protects against aliasing in theory, but a fielded DAQ practice samples at 5-10x the highest expected frequency to preserve waveform shape, with the anti-alias low-pass filter set to roughly 1/4 to 1/10 of the actual sample rate — sampling at the bare Nyquist minimum or filtering at the Nyquist frequency itself produces a signal that looks clean on screen and is quietly wrong.
+2. **A data channel is only fully specified by its amplitude class and its frequency class together — one without the other is an incomplete instrumentation call.** SAE J211-1's Channel Frequency Classes (CFC 60/180/600/1000, phaseless 4-pole digital low-pass filters with corner frequency ≈ CFC ÷ 0.6) exist because a filter chosen for the wrong bandwidth either smooths out a real transient peak or lets through noise a downstream damage or peak-value calculation will mistake for signal.
+3. **Shunt calibration verifies the whole signal chain — bridge wiring, excitation stability, gain — not just whether the gauge is bonded correctly.** Simulating a known strain by shunting a fixed resistor across one bridge arm and comparing the measured output to the predicted output catches excitation-voltage drop, bad connectors, and wiring errors before they're mistaken for a structural reading; skipping it treats an unverified signal chain as a verified one.
+4. **A calibrated instrument only proves what it was verified to prove, over the range and interval it was actually checked at.** A torque wrench certified under ISO 6789 is checked at 20%, 60%, and 100% of its rated capacity, not at every possible setting, and that certificate expires at 12 months (or 5,000 cycles, or 6 months under heavy daily use) — a reading taken past the calibration interval or extrapolated beyond the last verified point is an assumption wearing the credibility of a measurement.
+5. **A rainflow-counted, Miner's-rule damage fraction is a directional estimate with a documented, non-trivial error band, not an exact remaining-life number.** Converting an irregular road-load history into discrete stress cycles and summing fractional damage is the standard method, and published correlation studies against actual fatigue life for automotive structures show agreement within roughly 2.7% to 31% — reporting the computed damage fraction as a precise figure hides an uncertainty the engineer needs to see before betting a release decision on it.
+
+## Mental models & heuristics
+
+- **When the highest frequency of interest in a channel isn't precisely known, apply first-principles core #1's 5-10x/anti-alias sizing to the best available engineering estimate rather than waiting for a precise number** — the margin the rule already builds in covers a later, more refined estimate, so there's no reason to default to the bare Nyquist minimum in the meantime.
+- **When selecting a CFC for a new channel, default to the class the applicable test procedure or a comparable prior test on the same component specifies, unless no precedent exists — then choose from the lower end (CFC 60) for structural/durability-rate loads and escalate toward higher classes only for channels expected to carry genuinely higher-frequency transient content, and record the choice on the test plan so the next technician doesn't have to re-derive it.**
+- **When commissioning or re-using a strain-gauge bridge, default to running a shunt-calibration check immediately before the test session, not only at initial bonding** — thermal cycling, connector reseating, and time all drift a bridge's gain, and a shunt check from a week ago doesn't cover today's run.
+- **When a torque spec applies to a safety-critical fastener (wheel hub, suspension mount, cylinder head), default to a Class II digital torque wrench (tighter tolerance, ±2% per ISO 6789-2) over a Class I mechanical/indicating wrench (±4%), unless the spec or a lower-consequence fastener doesn't warrant the tighter tool.**
+- **When a temperature reading needs tighter accuracy than a standard Type K thermocouple's ±2.2°C (or ±0.75% of reading, whichever is greater) tolerance provides, default to Special Limits of Error (SLE) grade (±1.1°C or ±0.4%) rather than assuming the standard grade is close enough** — EGT and coolant-temp work routinely sits near the boundary where the difference matters.
+- **When a test requires monitoring more than one thermal or fluid limit at once (engine coolant, transmission fluid, hydraulic fluid all under threshold during a full-load run), default to treating it as one multi-channel simultaneous test, not a sequence of single-channel checks** — a channel that's fine in isolation can still be the one that trips the run if it isn't watched at the same instant as the others.
+- **When a Miner's-rule damage fraction or predicted remaining life is reported, default to bracketing it with the documented correlation error band rather than a bare number, and cross-checking the governing S-N/damage curve against a second reference before it drives a go/no-go call.**
+- **When comparing horsepower numbers across sources, default to checking whether they're on the same correction basis (SAE J1349 vs. the older J607) before treating a discrepancy as a real difference** — J1349-corrected figures commonly read roughly 4% lower than J607 figures for the same engine, and mixing the two bases manufactures a phantom gap.
+
+## Decision framework
+
+1. **Pull the current test plan, applicable standard (SAE J211/J1349/ISO 6789/ASTM E230, etc.), and engineering spec**, and confirm the article under test and the instrumentation called out match what's physically being set up.
+2. **Verify every instrument's calibration status before wiring anything in** — certificate date within interval, the planned test point inside the last-verified range, shunt-cal check on any strain bridge — and stop and escalate before taking a recorded reading if any instrument fails this check.
+3. **Configure the DAQ**: sample rate, anti-alias filter corner, and CFC/CAC channel designation per the test plan or the 5-10x/CFC heuristics where the plan doesn't specify, documenting the choice on the test record.
+4. **Execute the test per the written procedure**, logging setup deviations and anomalies as they happen rather than reconstructing them afterward, and monitoring all simultaneously-limited channels (thermal, load) for the full duration, not just at the end.
+5. **Reduce the raw data** into engineering units — bridge millivolt output to strain/stress, dyno curve to a corrected power figure on the stated standard, time-history to rainflow-counted cycle bins and a Miner's-rule damage fraction — showing the conversion chain, not just the final number.
+6. **Compare the reduced result against the engineer's target or predicted value**, stating delta and margin (and, where the method carries a documented uncertainty band, the range) rather than a bare pass/fail.
+7. **Document the result on the applicable test or inspection record** and route any out-of-tolerance, out-of-family, or ambiguous result to the engineer of record for disposition rather than closing it independently.
+
+## Tools & methods
+
+- **DAQ hardware and signal-conditioning chain** (bridge completion, excitation, amplification, anti-alias filtering) configured per SAE J211-1 / ISO 6487 CFC/CAC channel designations for impact and dynamic-load channels.
+- **Bonded resistance strain gauges** in quarter/half/full bridge configurations with a shunt-calibration resistor for pre-test signal-chain verification per Vishay/Micro-Measurements TN-514 — see [references/playbook.md](references/playbook.md) for a filled shunt-cal worksheet.
+- **Type K thermocouples** with cold-junction compensation, selected standard-grade or SLE-grade per ASTM E230/IEC 60584-2 depending on required accuracy.
+- **Calibrated torque wrenches**, mechanical (Class I) or digital (Class II) per ISO 6789 — see first-principles core #4 for the calibration-interval/range mechanics — selected by fastener consequence per the mental-models default above.
+- **Engine/chassis dynamometer** with data reduction to SAE J1349 standardized net power (reference condition 25°C, 99 kPa, standardized mechanical-efficiency constant); SAE J2723 governs the additional independent-witness protocol behind an "SAE Certified" power claim.
+- **Rainflow-counting and Miner's-rule damage summation** for reducing an irregular road-load or durability time history into a cycle-bin table and a cumulative damage fraction — see [references/playbook.md](references/playbook.md) for a filled worked reduction.
+
+## Communication style
+
+To the design or test engineer: the reduced number, the method used to get it, and the delta or range against the target — "measured corrected power 247 hp per SAE J1349, dyno-day CA applied, within 2% of the predicted curve" lands; "dyno run went fine" doesn't, because it hides the correction basis and the comparison. To the proving-ground or test-cell crew: the specific setup instruction (channel list, CFC/sample-rate settings, torque sequence and spec, thermal limits to watch simultaneously), not a restated general procedure. To QA/documentation: the test or inspection report itself, with calibration traceability and every measured value stated, because the report is the record, not a verbal summary of it. On a durability or fatigue result: the damage fraction or predicted life stated with its known correlation uncertainty band, flagged explicitly rather than presented as a single precise number, so the engineer signing the release decision knows how much confidence the figure actually carries.
+
+## Common failure modes
+
+- **Sampling at or near the bare 2x Nyquist minimum**, or setting the anti-alias filter at the Nyquist frequency instead of well below it, producing a signal that looks clean but has already aliased.
+- **Wiring in a CFC filter mismatched to the channel's actual content** — too low a class smooths out the real transient peak the test exists to capture; too high a class lets noise through that a downstream peak or damage calculation misreads as signal.
+- **Skipping the pre-test shunt-calibration check on a strain bridge verified only at initial bonding** — see [references/red-flags.md](references/red-flags.md) for what that usually means and what to pull.
+- **Using an instrument past its last verified calibration point or expired interval**, treating a manufacturer's stated linearity as a substitute for an actual reference check at the load or temperature in question.
+- **Reporting a Miner's-rule damage fraction or predicted remaining life as an exact number**, with no error band.
+- **Comparing a J1349-corrected power figure against an older J607-based number without checking the basis first.**
+- **Monitoring a multi-fluid thermal-limit test as a series of single-channel checks instead of one simultaneous multi-channel test.**
+- **Closing out an out-of-tolerance or ambiguous test result without an engineer-of-record disposition.**
+
+## Worked example
+
+**Situation.** A prototype front lower control arm is going into an accelerated proving-ground durability run. The engineer's test plan calls for: (1) instrumenting the arm with a strain gauge for road-load data acquisition, (2) torquing the arm's mounting bolts to spec with a calibrated wrench before the run, and (3) after the first 500 test-hours, reducing the collected load history to estimate whether the part will reach the test's target life before the next scheduled inspection.
+
+**Part 1 — DAQ and shunt-cal setup.** Expected suspension-load bandwidth for this component is up to ~50 Hz. Per the 5-10x rule, sample rate is set at **500 Hz** (10x). Anti-alias filter is set to 1/5 of the sample rate = **100 Hz**, which lines up with an SAE J211 **CFC 60** designation (corner frequency = 60 ÷ 0.6 = 100 Hz) — filter and sample-rate choices reconcile to the same corner. Bridge: full configuration, gauge factor GF = 2.06, excitation Vex = 10.000 V. Shunt-cal resistor is sized to simulate 3,000 µε: predicted output = GF × ε × Vex = 2.06 × 0.003000 × 10.000 V = **61.80 mV**. Measured shunt-cal output: **61.42 mV**. Error = (61.80 − 61.42)/61.80 = **0.61%** — inside the technician's pre-test acceptance threshold of ≤1% agreement [heuristic — needs practitioner check on the specific program's stated shunt-cal tolerance]. Bridge and signal chain verified good for the test session.
+
+**Part 2 — torque-to-spec.** Mounting-bolt spec is 175 N·m. Wrench in use: digital Class II, last calibrated 4 months ago (inside the 12-month/5,000-cycle ISO 6789 interval), certificate shows ±2% agreement at the standard's 20/60/100%-of-capacity test points. Applied torque logged at 175 N·m, within the wrench's verified range and class tolerance — accepted and recorded on the build record.
+
+**Part 3 — rainflow/Miner's data reduction after 500 test-hours.** Rainflow counting on the collected strain-derived stress history produces three dominant bins, each compared against the component's S-N (stress-life) curve:
+
+| Bin | Stress amplitude Sa | Cycles counted, n | Cycles to failure at Sa, N | n/N |
+|---|---|---|---|---|
+| A | 180 MPa | 1,200 | 50,000 | 0.02400 |
+| B | 120 MPa | 8,500 | 400,000 | 0.02125 |
+| C | 80 MPa | 45,000 | 2,000,000 | 0.02250 |
+
+Cumulative damage over 500 test-hours: D = 0.02400 + 0.02125 + 0.02250 = **0.06775**.
+
+Naive read: linearly extrapolate to D = 1 (failure) and report a single number — predicted life = 500 hours ÷ 0.06775 = **7,380 test-hours** — as if that figure were precise enough to schedule the next inspection against directly.
+
+Expert correction: published rainflow + Miner's-rule correlation studies against actual automotive fatigue life show 2.7%-31% prediction error, so the 7,380-hour figure is treated as a central estimate, not a guarantee. Applying the wider (more conservative) end of the documented band: 7,380 × (1 − 0.31) = **5,092 hours** to 7,380 × (1 + 0.31) = **9,668 hours**. The technician reports the range and flags the point estimate as insufficient on its own to schedule a hard inspection date.
+
+**Deliverable — durability data-reduction report (as filed):**
+
+> **Instrumentation setup:** Full-bridge strain gauge (GF 2.06, Vex 10.000 V), DAQ at 500 Hz sample rate, anti-alias filter 100 Hz corner (SAE J211 CFC 60). Pre-test shunt-cal at simulated 3,000 µε: predicted 61.80 mV, measured 61.42 mV, error 0.61% — **signal chain verified.**
+> **Fastener install:** Mounting bolts torqued to 175 N·m spec using Class II digital wrench (cal cert current, ±2% at 20/60/100% test points, 4 months into 12-month interval) — **accepted.**
+> **Durability data reduction, first 500 test-hours:** Rainflow-counted 3 dominant stress bins (180 MPa/1,200 cyc, 120 MPa/8,500 cyc, 80 MPa/45,000 cyc) against component S-N curve. Miner's-rule cumulative damage D = 0.06775. Linear extrapolation to D = 1.0 gives a central life estimate of 7,380 test-hours; applying the documented 2.7%-31% rainflow/Miner's correlation error band gives a working range of **5,092-9,668 test-hours**.
+> **Disposition:** Recommend scheduling the next teardown inspection at the conservative low end of the range (≈5,090 test-hours) rather than the central estimate, and re-running the damage calculation against a second S-N reference curve before that inspection to narrow the range. Routed to engineer of record for concurrence.
+
+## Going deeper
+
+- [references/playbook.md](references/playbook.md) — load when running a shunt-calibration worksheet, selecting a sample-rate/CFC pairing for a new channel, or working a rainflow-counting/Miner's-rule damage-fraction reduction.
+- [references/red-flags.md](references/red-flags.md) — load when reviewing a test setup, a dyno or durability data-reduction result, or a calibration record for the smell tests that catch a bad measurement before it goes on a signed record.
+- [references/vocabulary.md](references/vocabulary.md) — load when a DAQ, instrumentation, or test-data-reduction term needs its precise meaning, not the generic one.
+
+## Sources
+
+- SAE J1349, *Engine Power Test Code — Spark Ignition and Compression Ignition — As-Installed Net Power Rating* — standard reference condition (25°C, 99 kPa), standardized mechanical-efficiency constant, and the J1349-vs-J607 basis gap.
+- SAE J2723, *Certified Power — SAE J1349* — independent-witness verification protocol behind an "SAE Certified" power claim.
+- SAE J211-1, *Instrumentation for Impact Test — Part 1: Electronic Instrumentation*, and companion ISO 6487 — Channel Frequency Class (CFC 60/180/600/1000) and Channel Amplitude Class (CAC) channel designation.
+- Vishay/Micro-Measurements Tech Note TN-514, *Shunt Calibration of Strain Gage Instrumentation* — shunt-cal method, Wheatstone bridge excitation and remote-sensing practice.
+- National Instruments, *Acquiring an Analog Signal: Bandwidth, Nyquist Sampling Theorem, and Aliasing* — the 5-10x practical sampling rule and anti-alias filter placement (1/4-1/10 of sample rate).
+- ISO 6789 (Parts 1 and 2), *Assembly tools for screws and bolts — Hand torque tools* — Class I (±4%) vs. Class II (±2%) tolerance, 20/60/100% test points, 12-month/5,000-cycle calibration interval.
+- ASTM E230 / IEC 60584-2 — Type K thermocouple standard tolerance (±2.2°C or ±0.75%) and Special Limits of Error (±1.1°C or ±0.4%).
+- Published automotive front-corner-module reliability study (rainflow counting + modified Miner's rule vs. actual fatigue life) — 2.7%-31% documented correlation error band.
+- U.S. Army Yuma Proving Ground vehicle-testing capability reporting — named up-to-250-simultaneous-channel instrumentation capacity and multi-fluid (coolant/transmission/hydraulic) simultaneous thermal-limit test practice.
+- O*NET-SOC 17-3027.01 task list used as a coverage skeleton only, not as source language.

--- a/roles/automotive-engineering-technician/references/playbook.md
+++ b/roles/automotive-engineering-technician/references/playbook.md
@@ -1,0 +1,134 @@
+# Playbook
+
+Filled templates for the three recurring instrumentation/data-reduction jobs: shunt-calibration verification, sample-rate/CFC channel setup, and rainflow/Miner's-rule damage reduction.
+
+## 1. Shunt-calibration worksheet
+
+Run immediately before every test session on a strain-gauge bridge — not just at initial bonding.
+
+**Inputs to record before shunting:**
+
+| Field | Value |
+|---|---|
+| Bridge configuration | Full bridge |
+| Gauge factor (GF) | 2.06 |
+| Excitation voltage (Vex) | 10.000 V |
+| Target simulated strain (ε_sim) | 3,000 µε |
+| Shunt resistor value | 59,880 Ω (sized for 3,000 µε at this GF/bridge config per gauge vendor table) |
+
+**Predicted output:**
+
+```
+V_predicted = GF × ε_sim × Vex
+            = 2.06 × 0.003000 × 10.000 V
+            = 61.80 mV
+```
+
+**Measured output (from DAQ, shunt engaged):** record to 2 decimal places, e.g. 61.42 mV.
+
+**Acceptance check:**
+
+```
+Error % = (V_predicted − V_measured) / V_predicted × 100
+        = (61.80 − 61.42) / 61.80 × 100
+        = 0.61%
+```
+
+| Error % | Disposition |
+|---|---|
+| ≤ 1% | Pass — signal chain verified, proceed to test |
+| 1%–2% | Flag — recheck connectors/excitation before proceeding; log the value |
+| > 2% | Fail — do not run; re-terminate bridge, re-verify excitation, repeat shunt-cal |
+
+[1% pass threshold — practitioner-stated program convention; confirm against the specific test plan's stated shunt-cal tolerance before treating it as universal.]
+
+**Record on the test log:** date, technician, bridge ID, GF, Vex, shunt resistor value, predicted mV, measured mV, error %, disposition. A shunt-cal entry older than the current test session does not cover today's run — re-run it even if the bridge was checked yesterday.
+
+## 2. Sample-rate / CFC channel-setup matrix
+
+Use when a test plan doesn't already specify sample rate and filter corner for a channel.
+
+**Step 1 — estimate highest frequency of interest (f_max)** from prior test data on the same/similar component, or the engineer's stated bandwidth of concern.
+
+**Step 2 — sample rate:**
+
+```
+f_sample = f_max × 5   (minimum field-practice multiplier)
+   through
+f_sample = f_max × 10  (preferred when disk/DAQ bandwidth allows)
+```
+
+**Step 3 — anti-alias filter corner:**
+
+```
+f_filter = f_sample ÷ 4   (upper bound)
+   through
+f_filter = f_sample ÷ 10  (lower bound, preferred)
+```
+
+**Step 4 — map to nearest SAE J211 CFC class** (corner frequency ≈ CFC ÷ 0.6):
+
+| CFC class | Corner frequency | Typical use |
+|---|---|---|
+| CFC 60 | 100 Hz | Structural/durability-rate loads (suspension links, control arms, chassis mounts) |
+| CFC 180 | 300 Hz | General dynamic/vibration channels |
+| CFC 600 | 1,000 Hz | Impact/crash-adjacent transients |
+| CFC 1000 | 1,667 Hz | High-rate impact channels |
+
+**Worked selection — suspension control-arm strain channel, f_max ≈ 50 Hz:**
+
+| Step | Calculation | Result |
+|---|---|---|
+| Sample rate | 50 Hz × 10 | 500 Hz |
+| Filter corner | 500 Hz ÷ 5 | 100 Hz |
+| CFC match | CFC = corner × 0.6 = 100 × 0.6 = 60; check: 60 ÷ 0.6 = 100 Hz | **CFC 60** |
+
+Record the chosen sample rate, filter corner, and CFC class on the test plan so the next technician re-using the channel doesn't have to re-derive it. When no precedent exists and the channel content is genuinely uncertain, default to CFC 60 for structural/durability loads and escalate only if the engineer flags higher-frequency transient content of interest.
+
+## 3. Rainflow-counting / Miner's-rule damage reduction
+
+**Step 1 — collect the raw stress/strain time history** from the reduced strain-gauge channel over the test interval (e.g., 500 test-hours).
+
+**Step 2 — rainflow-count into discrete stress-amplitude bins**, each with a cycle count `n`.
+
+**Step 3 — look up cycles-to-failure `N` at each bin's stress amplitude** from the component's S-N (stress-life) curve.
+
+**Step 4 — compute damage fraction per bin and sum (Miner's rule):**
+
+```
+D = Σ (n_i / N_i)
+```
+
+**Worked table (500 test-hours, front lower control arm):**
+
+| Bin | Stress amplitude Sa | Cycles counted, n | Cycles to failure, N | n/N |
+|---|---|---|---|---|
+| A | 180 MPa | 1,200 | 50,000 | 0.02400 |
+| B | 120 MPa | 8,500 | 400,000 | 0.02125 |
+| C | 80 MPa | 45,000 | 2,000,000 | 0.02250 |
+| **Total D** | | | | **0.06775** |
+
+**Step 5 — extrapolate to a central life estimate** (linear damage accumulation to D = 1.0):
+
+```
+Life_central = test_hours / D
+             = 500 / 0.06775
+             = 7,380 test-hours
+```
+
+**Step 6 — bracket with the documented correlation error band (2.7%–31%)** rather than reporting the central estimate alone:
+
+```
+Life_low  = 7,380 × (1 − 0.31) = 5,092 test-hours
+Life_high = 7,380 × (1 + 0.31) = 9,668 test-hours
+```
+
+**Step 7 — disposition rule:**
+
+| Situation | Action |
+|---|---|
+| Range brackets or exceeds the target life with margin | Recommend inspection interval at the low end of the range; note as sufficient for now |
+| Range straddles the target life | Route to engineer of record — recommend a second independent S-N reference to narrow the band before a hard interval is set |
+| Low end of range is below the target life | Escalate immediately — do not close out; recommend design review |
+
+Never file a bare point-estimate life number without the bracketed range and the disposition line — the point estimate alone hides the method's known uncertainty from the engineer signing the release decision.

--- a/roles/automotive-engineering-technician/references/red-flags.md
+++ b/roles/automotive-engineering-technician/references/red-flags.md
@@ -1,0 +1,81 @@
+# Red flags
+
+Smell tests a working test technician catches before a reading goes on a signed record. Each entry: what it usually means, the first question to ask, and the data to pull before accepting the number.
+
+### Sample rate set at less than 5x the channel's expected highest frequency of interest
+
+**Usually means:** the DAQ setup was copied from a prior channel's settings without re-deriving the bandwidth for this component, or the "highest frequency of interest" was never actually estimated before the session started.
+**First question:** "What's the estimated highest frequency of interest for this channel, and where did that number come from?"
+**Data to pull:** the DAQ configuration log (sample rate, anti-alias filter corner); the source of the bandwidth estimate (prior test, FEA modal result, or a guess); recomputed ratio of sample rate to estimated frequency.
+
+### Anti-alias filter corner set at or above 1/4 of the sample rate
+
+**Usually means:** the filter was left at a DAQ software default instead of being derived from the chosen sample rate, letting content above Nyquist fold back into the passband before it's even digitized.
+**First question:** "What sample rate is this channel running at, and does the filter corner sit inside the 1/4-1/10 window below it?"
+**Data to pull:** configured sample rate and filter corner frequency from the DAQ setup sheet; recomputed ratio; a look at the raw waveform for a stair-step or beat-frequency artifact consistent with aliasing.
+
+### A structural or durability channel is running CFC 180 or higher with no test-plan justification
+
+**Usually means:** the class was set to "capture everything" instead of matched to the load's actual frequency content, and a downstream peak or damage calculation is now reading through noise the channel should have filtered out.
+**First question:** "What does the test plan or a comparable prior test on this component specify for this channel's CFC, and if nothing exists, why was this class chosen over CFC 60?"
+**Data to pull:** the test plan's channel list with specified CFC per channel; a comparable prior test record for the same or similar component; the raw vs. filtered trace overlay for the channel in question.
+
+### Shunt-calibration error exceeds 1% of predicted output on a pre-test check
+
+**Usually means:** excitation voltage has drifted, a connector has degraded since the gauge was last verified, or the bridge itself has been damaged — most commonly from thermal cycling or a reseated connector between sessions.
+**First question:** "When was this bridge last shunt-checked, and what changed physically since then — reseated connectors, temperature exposure, handling?"
+**Data to pull:** predicted vs. measured shunt-cal output and computed error percentage; date and result of the last shunt-cal on this bridge; excitation voltage reading at the amplifier.
+
+### A strain-gauge bridge is being used for a test session with no shunt-cal check logged that day
+
+**Usually means:** the bridge was verified once at initial bonding and the technician is treating that as still valid, without accounting for the drift a week or more of thermal cycling and handling introduces.
+**First question:** "Has a shunt-cal check been run today, or is the last one on record from initial bonding?"
+**Data to pull:** date-stamped shunt-cal log for this bridge; number of days since the last check; any intervening thermal exposure or connector work.
+
+### A torque wrench's calibration certificate is more than 12 months old, or the fastener's spec falls outside the wrench's last-verified 20/60/100% range
+
+**Usually means:** the wrench is being used past ISO 6789's stated interval, or a reading is being extrapolated beyond the points it was actually checked at — both substitute an assumption for a verified measurement.
+**First question:** "When was this wrench last calibrated, and does the applied torque fall within the 20-100% range that was actually checked?"
+**Data to pull:** calibration certificate date and cycle count against the 12-month/5,000-cycle interval; the certificate's tested percentages of rated capacity; the actual spec torque as a percentage of the wrench's rated capacity.
+
+### A Class I mechanical wrench is specified for a safety-critical fastener (wheel hub, suspension mount, cylinder head)
+
+**Usually means:** tool selection defaulted to whatever was on the cart instead of matching tolerance class to fastener consequence — Class I's ±4% band is wider than a safety-critical joint typically warrants.
+**First question:** "Is this fastener safety-critical, and if so, why is a Class I wrench being used instead of Class II?"
+**Data to pull:** the fastener's classification on the build record or engineering spec; wrench class and its ISO 6789 tolerance; any documented exception approving Class I for this application.
+
+### A dyno-reported horsepower figure is being compared against a prior number with no correction-standard check
+
+**Usually means:** one figure is on SAE J1349 and the other on the older J607 basis, and the roughly 4% gap between them is being read as a real engine difference instead of a units mismatch.
+**First question:** "Are both numbers corrected to the same standard — J1349 or J607 — or is that being assumed?"
+**Data to pull:** the correction standard stated on each dyno report; ambient conditions at each run (temperature, pressure) used in the correction; recomputed figures on a common basis if they differ.
+
+### A Miner's-rule damage fraction or predicted remaining life is reported as a single number with no error band
+
+**Usually means:** the extrapolation from cumulative damage to a point life estimate was reported at face value, hiding the method's documented 2.7-31% correlation error against actual fatigue life.
+**First question:** "Is this point estimate bracketed by the documented rainflow/Miner's correlation error band, or is it being presented as exact?"
+**Data to pull:** the cycle-bin table and cumulative damage fraction D; the S-N curve reference used; the correlation study or standard cited for the error band applied (or the absence of one).
+
+### A rainflow/Miner's damage calculation used only one S-N curve reference with no cross-check
+
+**Usually means:** the first S-N curve found (a handbook value, a similar-but-not-identical material) was used without checking it against a second reference, leaving the damage fraction more sensitive to curve selection than the report shows.
+**First question:** "What S-N curve was used, and has the damage fraction been checked against a second reference curve for the same material and surface condition?"
+**Data to pull:** the S-N curve source and its material/surface/loading conditions versus the actual component; a second reference curve and the resulting damage fraction for comparison.
+
+### A multi-fluid thermal-limit test (coolant, transmission, hydraulic) is being monitored as separate single-channel checks
+
+**Usually means:** the test procedure was executed as a sequence of individual limit checks instead of one simultaneous multi-channel watch, creating a window where a channel that isn't currently being observed can trip its limit unnoticed.
+**First question:** "Were all thermal-limited channels displayed and watched simultaneously for the full run, or checked one at a time?"
+**Data to pull:** the DAQ display/log configuration showing whether all limited channels were captured on the same timebase; timestamp of any limit exceedance against which channel was actively being watched at that moment.
+
+### A Type K thermocouple reading is being held to a tolerance tighter than ±2.2°C without confirming SLE grade
+
+**Usually means:** the required accuracy for this measurement (e.g., EGT near a control limit) needs Special Limits of Error grade, but a standard-grade thermocouple was installed by default without checking the spec against the standard ±2.2°C (or ±0.75%) tolerance.
+**First question:** "What accuracy does this measurement need, and is the installed thermocouple standard-grade or SLE-grade?"
+**Data to pull:** the thermocouple's grade per its calibration/purchase record; the required accuracy from the test spec; the reading's proximity to a control limit where the tolerance difference would matter.
+
+### An out-of-tolerance or ambiguous result was closed out on the test record without an engineer-of-record disposition
+
+**Usually means:** the technician made a judgment call on a result that falls outside their authority — accepting, rejecting, or re-running without documented sign-off from the engineer who owns the design or test target.
+**First question:** "Who disposed this out-of-tolerance result, and where's the documented concurrence from the engineer of record?"
+**Data to pull:** the test record's disposition field and signature/approval trail; the original engineer's target and stated tolerance; any email or change record showing the engineer was actually consulted.

--- a/roles/automotive-engineering-technician/references/vocabulary.md
+++ b/roles/automotive-engineering-technician/references/vocabulary.md
@@ -1,0 +1,94 @@
+# Vocabulary
+
+Terms generalists conflate or misuse. Each: definition, how a practitioner actually uses it, and the common misuse.
+
+### Nyquist rate vs. practical sample rate
+The Nyquist theorem's 2x-the-highest-frequency-of-interest is the mathematical minimum to avoid aliasing; it is not the rate a technician actually samples at.
+
+**In use:** "Highest expected content is 50 Hz, so we're sampling at 500 Hz — 10x, not the bare 2x minimum — to preserve waveform shape, not just avoid aliasing."
+
+**Common misuse:** citing "Nyquist says 2x" as if hitting exactly that rate were good practice, when a signal sampled right at 2x aliases into a clean-looking but wrong waveform the moment the true frequency drifts even slightly above the estimate.
+
+### CFC (Channel Frequency Class)
+An SAE J211-1 designation (CFC 60/180/600/1000) specifying a phaseless 4-pole digital low-pass filter corner frequency (corner ≈ CFC ÷ 0.6) applied to a data channel — it is a filter spec, not a sample-rate spec.
+
+**In use:** "This is a durability load channel, so it gets CFC 60 with a 100 Hz corner — not CFC 600, which is for a crash-pulse channel with real high-frequency transient content."
+
+**Common misuse:** treating CFC as interchangeable with sample rate, or picking a class by channel type alone without checking whether the corner frequency actually matches the content — too low smooths out a real peak, too high lets noise through that gets misread as signal.
+
+### Shunt calibration
+Simulating a known microstrain value by switching a fixed resistor across one arm of a strain-gauge Wheatstone bridge and comparing the predicted output (GF × ε × Vex) to the measured output — it verifies the entire signal chain (wiring, excitation, gain), not the gauge bond itself.
+
+**In use:** "Shunt-cal predicted 61.80 mV, measured 61.42 mV — 0.61% error, signal chain verified good for today's run."
+
+**Common misuse:** treating a shunt-cal done at initial bonding as still valid weeks later, when thermal cycling, connector reseating, and excitation drift make it a same-session check, not a one-time install step.
+
+### Gauge factor (GF)
+The proportionality constant relating a strain gauge's fractional resistance change to the mechanical strain it's experiencing, specific to the gauge part number, used to convert bridge output voltage into strain.
+
+**In use:** "GF is 2.06 for this gauge — that's the multiplier in the shunt-cal prediction, not an adjustable calibration knob."
+
+**Common misuse:** assuming gauge factor is a universal constant (like 2.0) rather than a part-specific certified value, which silently skews every strain reading taken with the wrong GF plugged into the conversion.
+
+### SAE J1349 corrected power
+A standardized correction of measured dyno power to a fixed reference condition (25°C, 99 kPa) and standardized mechanical-efficiency constant, so numbers from different days and altitudes are comparable — distinct from the older J607 correction basis.
+
+**In use:** "247 hp corrected per J1349, dyno-day CA applied — that's the number that's comparable to the predicted curve."
+
+**Common misuse:** comparing a J1349-corrected figure directly against an older J607-based figure (or an uncorrected as-run number) without checking the basis — the two bases commonly differ by roughly 4% on the same engine, and the gap gets mistaken for a real performance difference.
+
+### Rainflow counting
+An algorithm that decomposes an irregular, variable-amplitude stress or strain time history into discrete closed stress-cycle bins (amplitude and count), the standard input format for a fatigue damage calculation — it counts cycles, it does not itself estimate life.
+
+**In use:** "Rainflow gave us three dominant bins — 180 MPa/1,200 cycles, 120 MPa/8,500, 80 MPa/45,000 — now those go against the S-N curve."
+
+**Common misuse:** treating the rainflow output (the cycle bins) as the final damage or life number, skipping the separate step of running each bin against an S-N curve and summing fractional damage.
+
+### Miner's rule / damage fraction
+A linear cumulative-damage summation (Σ n/N across stress bins) estimating what fraction of a component's fatigue life has been consumed by a given load history — a directional estimate with a documented, non-trivial error band, not an exact remaining-life prediction.
+
+**In use:** "D = 0.06775 after 500 test-hours. Linear extrapolation gives a central estimate of 7,380 hours, but published correlation studies show 2.7%-31% error against actual fatigue life, so we report 5,092-9,668 hours, not a single number."
+
+**Common misuse:** reporting the linear extrapolation of a damage fraction as a precise remaining-life figure, hiding the method's documented correlation error band from the engineer making a release or inspection-interval decision on it.
+
+### Calibration interval vs. calibration range
+The interval is how long a certificate stays valid (e.g., 12 months / 5,000 cycles for a torque wrench under ISO 6789); the range is which specific points along the instrument's scale were actually verified (typically 20/60/100% of rated capacity) — an instrument can be within interval and still unverified at the point being used.
+
+**In use:** "Wrench is 4 months into its 12-month interval, but the job needs 175 N·m and the cert only verified 20/60/100% of a 200 N·m-rated wrench — 175 N·m falls inside the verified range, so it's good."
+
+**Common misuse:** checking only the date on the calibration sticker and assuming that covers any reading taken anywhere on the instrument's scale, when a reading past the last verified point (even if the cert hasn't expired) is an extrapolation, not a measurement.
+
+### Class I vs. Class II torque wrench
+Under ISO 6789, Class I covers mechanical/indicating wrenches (±4% tolerance) and Class II covers digital wrenches (±2% tolerance) — the class is a tolerance-band designation, not a brand or price tier.
+
+**In use:** "Wheel hub is safety-critical, so it gets a Class II digital wrench at ±2%, not a Class I click wrench at ±4%."
+
+**Common misuse:** assuming "digital" automatically means Class II-grade accuracy, or picking a wrench by convenience/availability rather than by whether the fastener's consequence of failure actually requires the tighter tolerance.
+
+### Standard grade vs. SLE (Special Limits of Error) thermocouple
+Under ASTM E230/IEC 60584-2, a standard-grade Type K thermocouple carries ±2.2°C (or ±0.75% of reading) tolerance; SLE grade tightens that to ±1.1°C (or ±0.4%) — a grade selection made based on required accuracy, not a universal upgrade.
+
+**In use:** "EGT work sits close to a threshold where 2.2°C matters, so this channel gets SLE-grade thermocouples, not standard."
+
+**Common misuse:** treating "Type K" as fully specifying the instrument's accuracy, when the grade (standard vs. SLE) is a separate spec that can double the effective tolerance if left unstated or assumed.
+
+### Bridge configuration (quarter / half / full)
+The number of active strain-gauge arms wired into a Wheatstone bridge circuit — quarter-bridge (1 active arm) is most sensitive to temperature drift, full-bridge (4 active arms) offers the highest output and best temperature compensation, and the choice changes both the sensitivity and what the reading actually represents.
+
+**In use:** "This is a full-bridge setup for temperature-compensated axial load — a quarter-bridge here would pick up thermal drift as if it were mechanical strain."
+
+**Common misuse:** treating bridge configuration as a wiring convenience decision rather than a measurement-physics decision — the configuration determines whether temperature effects cancel out or contaminate the reading.
+
+### Pending vs. confirmed vs. cleared calibration status
+Distinct from a DTC's pending/confirmed states — in an instrumentation context this refers to whether a given calibration certificate is current, expired-but-unused, or actively relied on for today's readings; conflating "has a cert on file" with "verified for today's use" is the failure mode.
+
+**In use:** "The load cell has a current cert, but it wasn't shunt-checked this session — cert current isn't the same as verified for today's setup."
+
+**Common misuse:** treating a filed, in-date calibration certificate as sufficient proof an instrument is reading correctly right now, skipping the same-session verification step (shunt-cal, zero check) that catches drift the certificate can't.
+
+### Corrected vs. as-run (uncorrected) power
+"Corrected" power has been adjusted to a standardized reference condition (temperature, pressure, humidity per SAE J1349); "as-run" is the raw dyno reading at whatever ambient conditions existed that day — the two numbers are not interchangeable, and only corrected figures are comparable across test days.
+
+**In use:** "As-run was 251 hp today, but corrected to J1349 reference conditions it's 247 hp — that's the number that goes in the report against the predicted curve."
+
+**Common misuse:** reporting or comparing an as-run figure as if it were corrected, which manufactures apparent day-to-day performance swings that are really just weather.


### PR DESCRIPTION
Rubric score: 18/18

## Resolution rationale

Applied the granularity test against both close candidates. automotive-engineer's SKILL.md (roles/automotive-engineer/SKILL.md) is entirely about system-level design decisions — sizing crash structure via v²/(2d), traction-vs-power-limited powertrain sizing, load-sensitive brake-bias/EBD calibration, NVH mount frequency-ratio design — and its worked example is a design-tradeoff memo. Its own Identity section explicitly distinguishes itself from "the automotive engineering technician, who runs the instrumented test and reduces the data under a design the engineer specified," confirming the target need is a distinct role, not a subset of this one. A practitioner doing 17-3027.01 work (torque-to-preload verification via T=K·D·F, strain-gauge/rosette data reduction against FEA-predicted margins, dynamometer/DAQ instrumentation and test-uncertainty-ratio checks, NDI method selection, AS9102-style first-article/inspection recordkeeping, calibration-due-date discipline) would get actively wrong guidance from automotive-engineer's Decision framework (which starts from stating a design requirement and layering dynamic design effects, not from drawing-revision/calibration verification before taking a recordable measurement) and its Tools & methods (multibody sim, Campbell diagrams, dyno curves as design inputs — not calibrated instrumentation, strain gauges, or NDI equipment as measurement outputs). civil-engineering-technician and aerospace-engineering-technician are the same technician-tier granularity but the wrong domain (civil/materials, aerospace airframe) — their torque/strain/NDI content doesn't transfer to automotive-specific test articles, standards (SAE J-series, FMVSS test protocols), or failure modes. A reasonable parent exists (automotive-engineer, which anticipates exactly this split), so verdict is new_leaf, not new_parent. Proposed slug follows the existing '<domain>-engineering-technician' naming convention seen in aerospace-engineering-technician and civil-engineering-technician, and maps directly to O*NET 17-3027.01's title.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `automotive-engineering-technician` (O*NET 17-3027.01), a leaf of `automotive-engineer`, with spec-2 docs and updated counts/roadmap. Totals now 542 drafted roles (532 O*NET; 500 at spec-2), engineering category 89, O*NET coverage 52.4% (532/1,016).

- New Features
  - Added `automotive-engineering-technician` with spec-2 `SKILL.md` plus `references/playbook.md`, `red-flags.md`, and `vocabulary.md`.
  - Updated `data/roles.json` with the role’s description, O*NET code, references, and US jurisdiction.
  - Updated `ROADMAP.md` to mark 17-3027.01 as drafted and link the role; refreshed progress totals.
  - Updated `README.md` role and coverage counts.

<sup>Written for commit 8c44cd02ef023cd31b5bce078e914e254ed850c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

