### PR TITLE
role: add photonics-technician (leaf of photonics-engineer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,12 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**542 roles drafted** (532 mapped to an O*NET occupation, 10 custom; 500 at spec 2, 42 awaiting upgrade), across 10 categories:
+**543 roles drafted** (533 mapped to an O*NET occupation, 10 custom; 501 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `██████████░░░░░░░░░░` 52.4% (532 / 1,016 occupations)
+**O\*NET coverage:** `██████████░░░░░░░░░░` 52.5% (533 / 1,016 occupations)
 
 - **design**: 12
-- **engineering**: 89
+- **engineering**: 90
 - **finance**: 31
 - **healthcare**: 58
 - **legal**: 21

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 532 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 533 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -182,7 +182,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>17 — Architecture and Engineering</strong> (56/59 drafted)</summary>
+<summary><strong>17 — Architecture and Engineering</strong> (57/59 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -243,7 +243,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 | ✅ | 17-3028.00 | Calibration Technologists and Technicians | [`calibration-technician`](./roles/calibration-technician/SKILL.md) |
 |  | 17-3029.00 | Engineering Technologists and Technicians, Except Drafters, All Other |  |
 | ✅ | 17-3029.01 | Non-Destructive Testing Specialists | [`non-destructive-testing-specialist`](./roles/non-destructive-testing-specialist/SKILL.md) |
-|  | 17-3029.08 | Photonics Technicians |  |
+| ✅ | 17-3029.08 | Photonics Technicians | [`photonics-technician`](./roles/photonics-technician/SKILL.md) |
 | ✅ | 17-3031.00 | Surveying and Mapping Technicians | [`surveying-mapping-technician`](./roles/surveying-mapping-technician/SKILL.md) |
 
 </details>

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 542,
+  "count": 543,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -8009,6 +8009,27 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/photonics-engineer/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "photonics-technician",
+      "description": "Use when a task needs the judgment of a Photonics Technician \u2014 inspecting a fiber end-face against IEC 61300-3-35 pass/fail zone criteria, fusion- or mechanical-splicing fiber and verifying the loss against budget, reading an OTDR trace for a fault that may be hidden in a dead zone, running an L-I-V sweep and burn-in on a laser diode, or handling and hermeticity-testing an ESD-sensitive optoelectronic package under GR-468-CORE.",
+      "category": "engineering",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "17-3029.08",
+      "parent": "photonics-engineer",
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/photonics-technician/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/roles/photonics-technician/SKILL.md
+++ b/roles/photonics-technician/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: photonics-technician
+description: Use when a task needs the judgment of a Photonics Technician — inspecting a fiber end-face against IEC 61300-3-35 pass/fail zone criteria, fusion- or mechanical-splicing fiber and verifying the loss against budget, reading an OTDR trace for a fault that may be hidden in a dead zone, running an L-I-V sweep and burn-in on a laser diode, or handling and hermeticity-testing an ESD-sensitive optoelectronic package under GR-468-CORE.
+metadata:
+  category: engineering
+  maturity: draft
+  spec: 2
+  onet_soc_code: "17-3029.08"
+parent: photonics-engineer
+status: active
+---
+
+# Photonics Technician
+
+## Identity
+
+Works one register below the photonics engineer: the engineer derives the spec and the margin; the technician executes the build, splice, termination, and test procedure the engineer specifies, and is accountable for the traveler being right — the as-measured number against the stated acceptance criteria — not for whether the spec itself was the correct one. That means fusing and terminating fiber, assembling optoelectronic and free-space components on the bench, running the characterization and burn-in sequence on a laser diode, and signing off the pass/fail record before a part ships or a link goes live. The defining tension: fiber and optoelectronic defects are frequently invisible to a fast visual pass, and the entire discipline's test standards (end-face zone criteria, splice-loss ceilings, OTDR dead-zone limits) exist specifically because eyeballing it is not good enough.
+
+## First-principles core
+
+1. **A fiber end-face inspection standard exists to remove the technician's own judgment call, not to formalize it.** IEC 61300-3-35 defines numeric pass/fail zones on the end face (core, cladding, adhesive, contact) precisely because "looks clean under the scope" is the unreliable step it replaces — a defect a tech would eyeball as cosmetic can still fail a documented threshold.
+2. **An OTDR trace has two distinct blind spots, and conflating them misses real faults.** The event dead zone is the minimum spacing an OTDR can resolve between two reflective events; the attenuation dead zone is the minimum distance after any event before the trace can accurately measure the next segment's loss. A splice or connector sitting inside either zone can be real and out of spec while the auto-generated event table shows nothing there.
+3. **Fusion and mechanical splices are not interchangeable against a tight loss budget — they differ by roughly an order of magnitude.** A well-executed single-mode fusion splice runs 0.01–0.05 dB, typically under 0.1 dB; a multimode mechanical splice runs up to 0.3–0.5 dB. Substituting mechanical for fusion on a budget sized for fusion-grade loss can silently consume most of a link's margin in one splice.
+4. **ESD-sensitivity thresholds are lower than intuition suggests, and laser diodes and photodetectors sit inside them.** ANSI/ESD S20.20 controls parts susceptible at 100 V Human Body Model and 200 V Charged Device Model, with isolated conductors limited to under 35 V — voltages a human body accumulates from ordinary movement, not from anything that reads as "static shock."
+5. **A qualification test that reports no failure is not automatically a pass — it can mean the test floor was reached, not the part's true margin.** Under GR-468-CORE hermeticity testing, when a package's required helium leak rate falls below the mass spectrometer's detection floor, the qualification substitutes a destructive Internal Gas Analysis on a sampling basis instead of reporting a clean leak-check result as sufficient on its own.
+
+## Mental models & heuristics
+
+- **When inspecting a polished end-face, default to measuring the defect against the standard's zone diameter before forming any pass/fail impression** — measure first, judge second.
+- **When an OTDR trace shows a flat, event-free section right after a strong reflective connector, default to suspecting the attenuation dead zone before trusting the trace** — re-run with a launch cord long enough to push the reference plane past the zone, then re-read.
+- **When a splice must meet a sub-0.1 dB budget line, default to fusion splicing; reserve mechanical splicing for field repairs or budget lines already sized for up to 0.5 dB.**
+- **When choosing connector polish for a link with an inline amplifier or other return-loss-sensitive component, default to APC (rated ≥-60 dB return loss) over UPC (≥-50 dB)** — APC's 8° angled face reflects stray light into the cladding instead of back up the link.
+- **When handling any laser diode, photodetector, or other optoelectronic die or module, default to full ESD-station protocol (grounded mat, wrist strap, ionizer as specified) every time, with no packaging-based exception.**
+- **When a leak-test result comes back "no leak detected," default to checking it against the spec's required threshold before recording it as a qualification pass.**
+- **When assembling in a cleanroom, default to matching the cleanroom class to the step's actual particle sensitivity (e.g., ISO 5 for precision lens/sensor mounting) rather than defaulting every step to the facility's highest available class** — ISO 5 and ISO 7 differ by a factor of 100 in permitted particle count, and running low-sensitivity steps at the tightest class burns capacity without buying anything the step needed.
+
+## Decision framework
+
+1. **Pull the traveler or work order before touching hardware** — the specified splice/connector type, the loss and return-loss acceptance thresholds, and the applicable inspection/test standard, not an assumed default.
+2. **Verify the environment matches the component's sensitivity class** — ESD station live and grounded for any optoelectronic die or module, cleanroom class appropriate to the assembly step.
+3. **Execute the procedure to spec** — splice, terminate, polish, mount, or wire-bond — using calibrated equipment, and note the equipment's last calibration date on the record.
+4. **Inspect and measure against the standard's numeric criteria**, not a visual impression: end-face zone diameters, splice/connector loss and return loss, OTDR trace read with dead-zone effects accounted for, L-I-V sweep values against the datasheet threshold.
+5. **On a borderline or failing result, isolate the likely cause before reworking or escalating** — a masked event versus a real fault, a contaminated facet versus a die-level failure, a test-floor artifact versus a genuine pass.
+6. **Record the actual as-measured values on the traveler**, not the nominal or target values, and flag any measurement that required a workaround (extended launch cord, repeat solder cycle) so the engineer sees what actually happened, not just the final number.
+
+## Tools & methods
+
+- **Fiber inspection scope (200x/400x video probe)** read against IEC 61300-3-35 zone criteria, not a bare visual pass.
+- **Fusion splicer** and **mechanical splice kit**, chosen per the budget line's loss ceiling, not by whichever is closer to hand.
+- **OTDR** with launch/receive cords sized to push both the event and attenuation dead zones clear of the fiber under test, plus a **stabilized light source and optical power meter** for cutback/insertion-loss verification independent of the OTDR read.
+- **L-I-V test station** (current source, optical power and forward-voltage measurement, environmental chamber) for threshold-current and slope-efficiency characterization, plus a **burn-in fixture** run for a stated number of hours at set temperature/current to screen infant-mortality failures before shipment.
+- **Helium leak detector** and, when its sensitivity floor is reached, a **destructive Internal Gas Analysis** sampling process, per GR-468-CORE package qualification.
+- **ESD-controlled workstation** (grounded mat, wrist strap, ionizer) verified per ANSI/ESD S20.20 before handling any ESD-sensitive optoelectronic part.
+- Certification reference: FOA CFOT (Certified Fiber Optic Technician) curriculum and hands-on practical — the named credential this role's fiber skills map to.
+
+## Communication style
+
+To the photonics engineer: the as-measured number against the spec'd threshold and any workaround used to get it, not "it passed" — "splice measured 0.04 dB, within the 0.10 dB line; end-face repolished once after an initial Zone B fail at 31 µm." To QA: the exact standard and clause the part was tested against, not "inspected and looks good." To a production lead: yield and rework counts against the shift's traveler batch, not a qualitative read on how the shift went. Never reports a test as "clean" or "no issues" without naming the standard and the actual value measured.
+
+## Common failure modes
+
+- **Passing an end-face on visual impression** instead of a zone measurement — the connector ships with no zone data on the traveler, so a marginal defect only surfaces later as an unexplained link-loss or return-loss complaint.
+- **Trusting an OTDR's auto-generated event table without checking dead-zone geometry** — the masked fault surfaces later as an unexplained loss complaint with no record it was ever checked at install.
+- **Treating mechanical splice loss as a drop-in substitute for a fusion-splice budget line** — the segment clears the total-loss ceiling on paper but ships with almost no margin left for any later connector wear or aging loss.
+- **Skipping ESD-station protocol on a packaged part that "looks rugged enough to handle bare"** — the resulting damage is often a latent parametric shift, not a dead-on-arrival failure, so it isn't caught until a later test stage.
+- **Recording a leak-test "no leak detected" result as an unqualified pass** — a package that should have been routed to destructive Internal Gas Analysis ships instead, with its actual leak rate never established against the required threshold.
+- **Overcorrection: running every assembly step in the highest available cleanroom class** regardless of the step's actual particle sensitivity, burning cleanroom capacity a low-sensitivity step never needed.
+
+## Worked example
+
+**Setup.** A repair order calls for splicing a break in a 150 m OM4 multimode trunk (850 nm) feeding a photonics test bench, then terminating the far end with a new connector. Repair-order acceptance: total segment loss ≤1.00 dB. A fusion splicer isn't available on-site for this call, and the break is close enough to a patch panel that the pull-through length for a fusion prep isn't there — the traveler authorizes a mechanical splice for this repair, with its wider 0.3–0.5 dB ceiling already priced into the 1.00 dB budget.
+
+**Splice and measurement.** The mechanical splice is completed at the 62 m mark from patch panel A. Bidirectional OTDR-measured splice loss averages **0.28 dB** — inside the mechanical-splice ceiling, but close enough to the 0.3 dB typical figure that it's noted on the traveler as at-risk if any further loss is found downstream.
+
+**OTDR dead-zone check.** The first OTDR run, launched directly from patch panel A's connector, shows a strong reflective event at 0 m (the panel connector itself, measured reflectance -25 dB) and a flat, event-free trace out past 62 m. Naive read: "splice is loss-free, or the auto-event table missed it — either way, nothing to flag." Expert read: a reflective event that strong produces an attenuation dead zone extending roughly 12 m past it at this OTDR's pulse width — the splice at 62 m is 8 m past the connector and outside that 12 m window, so the flat trace here is *not* a dead-zone artifact and the earlier bidirectional splice-loss measurement of 0.28 dB stands as the real reading, not a masked one. (Had the splice instead landed at, say, 8 m — inside the dead zone — the flat trace would have been meaningless, and the technician would need a launch cord long enough to push the reference plane past the dead zone before trusting any reading in that stretch.)
+
+**End-face inspection.** The newly polished connector at the far end is inspected under a 400x fiber scope per IEC 61300-3-35, Grade 2 PC/UPC zone criteria. Zone A (core): a linear scratch measures 2.1 µm — **passes** (Zone A allows no scratch ≥3 µm). Zone B (cladding): a chip measures **31 µm** — **fails** (Zone B allows chips only up to 10 µm each, 5 max). Naive read a junior tech might give: "the scratch isn't in the core, connector's fine to ship." Standard's actual verdict: a Zone B chip over the 10 µm single-defect limit fails IEC 61300-3-35 regardless of Zone A being clean — the connector must be re-cleaved and re-polished before it can be terminated as complete.
+
+**Loss reconciliation.** Fiber run: 150 m × 3.0 dB/km [heuristic — typical OM4 850 nm attenuation figure, verify against the installed fiber's datasheet] = 0.45 dB. Mechanical splice: 0.28 dB measured. Running subtotal: 0.73 dB. End-to-end insertion loss confirmed independently via power-meter cutback (stabilized source, calibrated meter): **0.81 dB** total, implying roughly 0.08 dB of connector and residual loss not separately budgeted — consistent and internally reconciling. Against the 1.00 dB repair-order ceiling, the segment passes with 0.19 dB of margin on loss alone — but the connector's failed end-face inspection means the segment cannot ship or return to service until it's re-polished and re-inspected.
+
+**Deliverable (repair traveler entry, as filed):**
+
+> **Segment repair — OM4 trunk, patch panel A to bench 12, 150 m**
+> **Splice:** Mechanical, at 62 m. Bidirectional OTDR loss 0.28 dB (ceiling 0.5 dB per traveler; fusion splicer unavailable on-site, pull-through length insufficient for fusion prep). Confirmed real (not dead-zone-masked) — splice sits 8 m past patch-panel connector, outside the ~12 m attenuation dead zone at this reflectance.
+> **End-face inspection (far-end connector, IEC 61300-3-35, single-mode Grade 2):** Zone A 2.1 µm scratch — pass (Zone A: none ≥3 µm allowed). Zone B 31 µm chip — **fail** (Zone B: ≤10 µm per defect, 5 max). Connector re-cleaved and re-polished; re-inspection required before close-out.
+> **Loss budget:** Fiber 0.45 dB + splice 0.28 dB + residual/connector ≈0.08 dB = 0.81 dB measured end-to-end (power-meter cutback) vs. 1.00 dB ceiling — 0.19 dB margin.
+> **Status: HOLD — pending re-polish and re-inspection of far-end connector.** Loss budget alone would have cleared this segment; do not close out on the loss number without the end-face re-inspection result attached.
+
+## Going deeper
+
+- [references/playbook.md](references/playbook.md) — load when running a splice-and-terminate job, reading an OTDR trace, or executing an L-I-V/burn-in or hermeticity test sequence and need the filled step sequences and acceptance tables.
+- [references/red-flags.md](references/red-flags.md) — load when reviewing a completed traveler, an OTDR trace, or an end-face inspection image for the smell tests that catch a marginal or masked result before sign-off.
+- [references/vocabulary.md](references/vocabulary.md) — load when a term on a traveler, standard, or datasheet needs its precise meaning, not the generic one.
+
+## Sources
+
+- IEC 61300-3-35 (fiber connector end-face inspection standard) — zone definitions and pass/fail thresholds, via Fluke Networks, ITOCHU Hi-Tech, and VIAVI Solutions application notes; 3rd edition (2022) dropped Zones C/D from pass/fail criteria.
+- The Fiber Optic Association (FOA) — CFOT / CFOS-T certification curriculum (thefoa.org, thefiberopticacademy.com), for the named practical-exam credential and fiber-skills scope.
+- General fiber-testing literature (multiple OTDR-vendor sources, cross-corroborated) — event dead zone vs. attenuation dead zone definitions and their effect on trace reads.
+- AEANET, STL Tech, Fosco/fiberoptics4sale, and general industry consensus — fusion vs. mechanical splice loss ranges, and UPC/APC return-loss figures.
+- Telcordia (iconectiv) GR-468-CORE — reliability/qualification standard for optoelectronic components, including helium leak testing per MIL-STD-883 TM 1014 Condition A and the destructive Internal Gas Analysis fallback; corroborated via nanoplus and Agiltron SWLD qualification documentation.
+- Newport/MKS Application Note 1, "Test and Characterization of Laser Diodes," and RP Photonics Encyclopedia, "Laser Diode Testing" — L-I-V sweep methodology and production burn-in practice.
+- ANSI/ESD S20.20-2021 (ESD Association) — HBM/CDM susceptibility thresholds and isolated-conductor voltage limit.
+- ISO 14644-1 — cleanroom particle-count classification (via gconbio.com, connect2cleanrooms.com, Setra), used for the ISO 5 vs. ISO 7 cleanroom-class comparison.
+- The 150 m OM4 fiber attenuation figure (3.0 dB/km at 850 nm) in the worked example is a stated typical-spec heuristic, not a Pass-0-sourced number — verify against the installed fiber's actual datasheet before use in a real budget.
+- No practitioner book (e.g., Jim Hayes, *Fiber Optics Technician's Manual*) or forum war-story thread was located in Pass 0 research — flag via PR if a practitioner can confirm or add a citation.

--- a/roles/photonics-technician/references/playbook.md
+++ b/roles/photonics-technician/references/playbook.md
@@ -1,0 +1,164 @@
+# Playbook — splice, inspection, and test worksheets
+
+Filled worksheets, not templates to describe. Copy the row structure and substitute real numbers.
+
+## 1. Fiber end-face inspection worksheet (IEC 61300-3-35)
+
+**Header block (record before scoring any zone):**
+
+| Field | Value |
+|---|---|
+| Connector / traveler # | LC/UPC, traveler WO-4471 |
+| Fiber type | Single-mode, 9/125 µm |
+| Scope | 400x video probe, cal cert current |
+| Grade applied | Grade 2 (multimode/single-mode general use — not Grade 1 high-power or Grade 3 UPC-tolerant) |
+
+**Zone table — connector single-mode, Grade 2, PC/UPC:**
+
+| Zone | Radius from core center | Scratches allowed | Defects (pits/chips) allowed |
+|---|---|---|---|
+| A — Core | 0–25 µm | None ≥3 µm | None ≥2 µm |
+| B — Cladding | 25–120 µm | No limit if <3 µm width | 5 max, ≤10 µm each |
+| C — Adhesive | 120–130 µm | No limit | No limit |
+| D — Contact | 130–250 µm | No limit | No limit, unless defect chips into Zone B |
+
+**Filled example — connector under test:**
+
+| Item | Value | Zone limit | Verdict |
+|---|---|---|---|
+| Zone A scratch, longest | 2.1 µm wide | <3 µm allowed | PASS |
+| Zone A pit | none observed | 0 allowed ≥2 µm | PASS |
+| Zone B chip, largest | 31 µm | ≤10 µm each (5 max) | **FAIL** |
+| Zone B chip count ≥ limit size | 1 | ≤5 | FAIL (single oversized defect fails independent of count) |
+| Zone C/D | adhesive bead within zone, no debris in B | not scored pass/fail (3rd ed. 2022) | N/A |
+
+**Rule:** a single Zone A or Zone B defect exceeding its size limit fails the connector regardless of all other zones passing — do not average or "mostly clean" a verdict. Re-cleave and re-polish before re-inspection; do not attempt to re-clean a chip (chips are not contamination and don't clean out).
+
+## 2. Splice-loss budget worksheet
+
+**Header block:**
+
+| Field | Value |
+|---|---|
+| Segment | Patch panel A → bench 12, OM4 multimode, 850 nm |
+| Length | 150 m |
+| Splice method authorized | Mechanical (fusion splicer unavailable, insufficient pull-through) |
+| Acceptance ceiling (traveler) | ≤1.00 dB total |
+
+**Budget build-up:**
+
+| Line item | Basis | Value |
+|---|---|---|
+| Fiber attenuation | 150 m × 3.0 dB/km (OM4 @850nm, datasheet) | 0.45 dB |
+| Splice loss | Mechanical splice ceiling per method | up to 0.50 dB |
+| Connector loss (new far-end connector, typical) | 0.20–0.40 dB/mated connector *pair*; only one new connector is being terminated here, not a full pair, so half that range applies | ≤0.20 dB |
+| **Budgeted total (worst case)** | sum | 1.15 dB — exceeds 1.00 dB ceiling on paper |
+| **As-measured total (bidirectional OTDR + power-meter cutback)** | actual | 0.81 dB |
+| Margin vs. ceiling | 1.00 − 0.81 | 0.19 dB |
+
+**Rule:** always carry both the worst-case budgeted total (for go/no-go planning before work starts) and the as-measured total (for traveler close-out). A worst-case budget over ceiling is not a stop condition by itself — proceed and measure; a worst-case budget *under* ceiling with no splice yet made is not a pass either, since the actual splice can still land near its method ceiling.
+
+**Method-ceiling reference table:**
+
+| Splice method | Typical loss | Ceiling to budget against |
+|---|---|---|
+| Fusion, single-mode, good execution | 0.01–0.05 dB | 0.10 dB |
+| Fusion, multimode | 0.05–0.10 dB | 0.15 dB |
+| Mechanical, single-mode or multimode | up to 0.3 dB typical | 0.5 dB |
+
+## 3. OTDR trace read — dead-zone check worksheet
+
+**Header block:**
+
+| Field | Value |
+|---|---|
+| Launch condition | Direct from patch panel A connector (no launch cord) |
+| Pulse width | 30 ns (short-range setting for <5 km span) |
+| Strong reflective event | 0 m, reflectance −25 dB (patch panel connector) |
+
+**Dead-zone geometry table (typical, this OTDR/pulse-width class):**
+
+| Zone type | Definition | Typical extent at −25 dB reflectance, 30 ns pulse |
+|---|---|---|
+| Event dead zone (EDZ) | Min. spacing to resolve two separate reflective events | ~1–3 m |
+| Attenuation dead zone (ADZ) | Min. distance after an event before loss can be accurately measured | ~10–15 m (used: 12 m) |
+
+**Filled example:**
+
+| Item | Value |
+|---|---|
+| Reflective event position | 0 m |
+| ADZ extent at this reflectance/pulse width | ~12 m |
+| Splice under test, position | 62 m |
+| Splice position minus event position | 62 − 0 = 62 m |
+| Inside ADZ? | 62 m > 12 m → **No, outside dead zone** |
+| Conclusion | Flat trace section reflects a real absence of excess loss at 62 m, not a masking artifact; the bidirectional splice-loss reading stands |
+
+**Decision rule:**
+1. Identify every reflective event upstream of the feature under test and its reflectance.
+2. Look up (or bracket from vendor spec) the ADZ extent at that reflectance and the pulse width used.
+3. If feature position − event position < ADZ extent → **re-run with a launch cord** long enough to push the reference plane past the ADZ, then re-read. Do not report the original trace's silence at that position as a result.
+4. If feature position − event position ≥ ADZ extent → the trace read at that position is valid as-is.
+5. Always confirm a splice or connector loss reading bidirectionally (A→B and B→A OTDR shots, averaged) — a unidirectional OTDR reading can differ by 0.1 dB or more from the true loss at a fiber mismatch, splice, or connector.
+
+## 4. L-I-V sweep and burn-in worksheet
+
+**Header block:**
+
+| Field | Value |
+|---|---|
+| Part | Laser diode, 1550 nm DFB, datasheet threshold Ith ≤ 15 mA, slope efficiency ≥0.20 W/A |
+| Test temp | 25.0 °C ± 0.5 °C (TEC-controlled) |
+| Sweep range | 0–80 mA forward current, 0.5 mA step |
+
+**L-I-V sweep results:**
+
+| Current (mA) | Optical power (mW) | Forward voltage (V) |
+|---|---|---|
+| 5 | 0.02 (below threshold — spontaneous emission) | 1.02 |
+| 15 | 0.15 (at/near threshold — kink check point) | 1.08 |
+| 20 | 1.20 | 1.11 |
+| 40 | 5.20 | 1.18 |
+| 60 | 9.30 | 1.24 |
+
+| Derived value | Calculation | Result | Datasheet limit | Verdict |
+|---|---|---|---|---|
+| Threshold current (Ith) | Linear extrapolation of above-threshold slope back to P=0 | 14.2 mA | ≤15 mA | PASS |
+| Slope efficiency | ΔP/ΔI between 20–60 mA = (9.30−1.20)/(60−20) | 0.2025 W/A | ≥0.20 W/A | PASS |
+| Kink check | Slope discontinuity between 15–25 mA band | None >5% deviation observed | none allowed | PASS |
+
+**Burn-in worksheet:**
+
+| Field | Value |
+|---|---|
+| Condition | 70 °C case temp, 1.2x rated drive current, per screening spec |
+| Duration | 168 hours (7-day standard infant-mortality screen) |
+| Monitored parameter | Optical power at fixed current, logged hourly |
+| Degradation threshold | >5% power drop from 24-hour baseline → fail, remove from lot |
+| Result, this unit | 24 hr baseline 9.30 mW → 168 hr reading 9.11 mW (−2.0%) | within 5% → **PASS** |
+
+**Rule:** a part exhibiting a kink (slope discontinuity) anywhere in the sweep fails regardless of meeting Ith and slope-efficiency numbers at the tested points — a kink indicates a mode instability that a single-point Ith/slope check will not catch. Always sweep continuously through the region 50% below to 150% above expected threshold, not just spot-check three currents.
+
+## 5. Hermeticity / ESD handling worksheet
+
+**ESD pre-handling checklist (verify before touching any ESD-sensitive part, ANSI/ESD S20.20):**
+
+| Check | Method | Threshold | Result |
+|---|---|---|---|
+| Wrist strap continuity | Wrist strap tester | <3.5 MΩ to ground | 1.2 MΩ — PASS |
+| Mat resistance to ground | Mat tester | 1×10⁶–1×10⁹ Ω | 4.7×10⁷ Ω — PASS |
+| Ionizer (if required for isolated-conductor parts) | Offset voltage check | <±35 V isolated-conductor limit | −8 V — PASS |
+| Part HBM/CDM class | Datasheet lookup | 100 V HBM / 200 V CDM typical floor | Class 1B HBM (100V–250V) — full protocol required |
+
+**Helium leak test worksheet (GR-468-CORE, per MIL-STD-883 TM 1014 Condition A):**
+
+| Field | Value |
+|---|---|
+| Package internal volume | 0.05 cm³ |
+| Required leak rate spec | ≤5×10⁻⁸ atm·cc/sec (He) |
+| Detector sensitivity floor | 1×10⁻⁹ atm·cc/sec |
+| Measured result | "No leak detected" (below 1×10⁻⁹ floor) |
+| Is this a pass against spec, or a floor artifact? | Floor artifact — detector cannot distinguish "true zero leak" from "leak below 1×10⁻⁹," and spec ceiling (5×10⁻⁸) is above the floor, so **this result is a valid pass**, not ambiguous |
+| Escalate to destructive IGA? | Only if the required spec threshold itself is below the detector floor (not the case here) — this lot closes out on the mass-spec result alone |
+
+**Rule for the ambiguous case:** if the *required spec threshold* is numerically below the detector's stated sensitivity floor, "no leak detected" cannot be recorded as a pass on its own — route a sampling percentage (per the qualification plan, typically 3–5 units per lot) to destructive Internal Gas Analysis for moisture content, and record the IGA result, not the leak-check non-result, as the qualifying data point.

--- a/roles/photonics-technician/references/red-flags.md
+++ b/roles/photonics-technician/references/red-flags.md
@@ -1,0 +1,61 @@
+# Red Flags — Photonics Technician
+
+### End-face defect measured but not checked against IEC 61300-3-35 zone diameter
+- **Usually means:** the tech eyeballed the fiber scope image as "clean" or "minor" instead of measuring the defect against the applicable zone's numeric threshold; second most likely, the analysis software's auto-pass/fail overlay was dismissed without reading the actual µm figure.
+- **First question:** what zone is the defect in, and what did it measure in µm against that zone's threshold?
+- **Data to pull:** the fiber-scope image with zone overlay and the IEC 61300-3-35 zone table for the connector's polish type.
+
+### OTDR trace flat for >12 m immediately after a reflective event ≥-30 dB
+- **Usually means:** the flat stretch is an attenuation dead zone masking a real splice or connector loss, not confirmation the segment is fault-free; second most likely, the launch cord is too short to push the reference plane past the zone.
+- **First question:** was this section re-measured with a launch cord long enough to clear the dead zone, or independently confirmed by power-meter cutback?
+- **Data to pull:** the OTDR trace with reflectance value at the preceding event and the launch-cord length used.
+
+### Mechanical splice loss measured ≥0.25 dB on a budget line sized for fusion-grade loss
+- **Usually means:** a mechanical splice was substituted for a fusion splice without re-checking the loss budget, consuming most of the segment's margin in one joint; second most likely, poor fiber cleave or misalignment in the mechanical splice itself.
+- **First question:** was this splice authorized on the traveler as mechanical, and does the total budget still clear with this measured value?
+- **Data to pull:** the traveler's authorized splice type and loss ceiling, and the bidirectional OTDR or power-meter splice-loss reading.
+
+### Optoelectronic die or module handled without a verified-live ESD station
+- **Usually means:** the wrist strap or grounded mat wasn't checked before handling, or the part was assumed rugged enough to handle bare because it's packaged; second most likely, the ESD station's last verification/calibration lapsed.
+- **First question:** when was this ESD station last verified against ANSI/ESD S20.20, and was the wrist strap tested at the start of this session?
+- **Data to pull:** the ESD station verification log and the part's datasheet HBM/CDM susceptibility rating.
+
+### Helium leak-test result recorded as "no leak detected" with no threshold comparison noted
+- **Usually means:** the result reflects the mass spectrometer's detection floor, not a genuine pass against the package's required leak rate; second most likely, the technician didn't check whether Internal Gas Analysis sampling was required as a fallback.
+- **First question:** does the recorded leak rate sit below the spec's required threshold, or below the instrument's stated sensitivity floor?
+- **Data to pull:** the leak detector's calibration/sensitivity spec and the package's GR-468-CORE required leak-rate threshold.
+
+### L-I-V sweep threshold current shifted >10% from the datasheet or prior burn-in baseline
+- **Usually means:** early degradation or an infant-mortality failure mode the burn-in is meant to screen for; second most likely, a test-station calibration drift or a temperature-control error during the sweep.
+- **First question:** does this shift track across repeated sweeps, or was it a single reading — and has the test station been calibrated since the last known-good baseline?
+- **Data to pull:** the L-I-V sweep data (threshold current, slope efficiency) plotted against the datasheet spec and any prior burn-in baseline for this part.
+
+### Return loss measured below -50 dB on a link with an inline amplifier or return-loss-sensitive component
+- **Usually means:** a UPC connector was used where the design called for APC, or the connector end-face has contamination/damage reflecting light back up the link; second most likely, a mismatched or degraded mating connector on the other side.
+- **First question:** does the traveler specify APC or UPC for this link, and does the installed connector's polish match what was measured?
+- **Data to pull:** the traveler's specified connector polish and the return-loss measurement from the power meter or OTDR.
+
+### Assembly step run in a cleanroom class not matched to the traveler's stated requirement
+- **Usually means:** the step defaulted to whatever class bay was open rather than the traveler's specified class, either over- or under-protecting the step; second most likely, the traveler's class requirement was never checked before starting.
+- **First question:** what cleanroom class does the traveler specify for this step, and does the bay used match it?
+- **Data to pull:** the traveler's cleanroom class requirement and the particle-count log for the bay used during the step.
+
+### Traveler closed out on loss-budget numbers with an open or failed inspection item elsewhere on the record
+- **Usually means:** the technician treated a passing loss budget as sufficient to ship without confirming every required inspection (end-face, ESD, leak test) also passed; second most likely, a rework was completed but the re-inspection step was skipped before sign-off.
+- **First question:** are all required inspection line items on this traveler marked pass, or is one still open/failed while the loss number looks clean?
+- **Data to pull:** the full traveler record with every inspection line item and its pass/fail status.
+
+### Equipment calibration date on the traveler older than the instrument's stated calibration interval
+- **Usually means:** a measurement (OTDR, power meter, fiber scope, L-I-V station) was taken on out-of-cal equipment, putting the recorded value's accuracy in question; second most likely, the calibration sticker was checked but not actually logged on the traveler.
+- **First question:** what is this instrument's stated calibration interval, and how far past due is the date on the traveler?
+- **Data to pull:** the instrument's calibration certificate/interval and the traveler's logged calibration date for the equipment used.
+
+### Burn-in completed for fewer hours than the stated screening duration
+- **Usually means:** the burn-in was cut short to meet a shipment deadline, undermining the infant-mortality screen it exists to perform; second most likely, an interruption (power loss, chamber fault) wasn't backfilled with additional hours.
+- **First question:** how many hours did this part actually accumulate at the specified temperature/current, against the stated screening duration?
+- **Data to pull:** the burn-in fixture log (hours, temperature, current) for this part's lot.
+
+### Zone A defect passes but Zone B or C on the same end-face is not separately reported
+- **Usually means:** the technician reported only the most visually prominent defect (often core) and didn't check every zone independently, missing that a single failing zone fails the whole inspection regardless of other zones being clean; second most likely, the fiber-scope software's summary view was trusted without opening each zone's detail.
+- **First question:** was every zone (A through the standard's applicable cutoff) measured and reported individually, not just the one that looked worst?
+- **Data to pull:** the per-zone measurement table from the fiber-scope inspection software for this connector.

--- a/roles/photonics-technician/references/vocabulary.md
+++ b/roles/photonics-technician/references/vocabulary.md
@@ -1,0 +1,75 @@
+# Vocabulary
+
+Terms of art a photonics technician uses precisely, that a generalist reads as loosely synonymous or as jargon for something more familiar — the kind of misreading that turns a passing measurement into a masked fault, or a real fault into a rejected good part.
+
+## Insertion loss vs. return loss
+
+**Insertion loss** is the optical power lost as light passes *through* a connector, splice, or component — measured in the forward transmission direction. **Return loss** is the power reflected *back* toward the source at that same interface, expressed as a larger negative-dB-magnitude number for a *better* result (less light coming back).
+
+**In use:** "Insertion loss on that mated pair is 0.15 dB, fine — but return loss is only -35 dB against a -50 dB spec, so something's reflecting more than it should." **Common misuse:** treating a good insertion-loss number as evidence the interface is healthy overall — a connector can pass insertion loss cleanly while a contaminated or poorly-angled face reflects well above spec.
+
+## Event dead zone vs. attenuation dead zone
+
+**Event dead zone** is the minimum spacing to resolve two reflective events as separate. **Attenuation dead zone** is the longer minimum distance after any event before loss can be accurately measured there — the two have different lengths, so a feature can clear one and still sit inside the other.
+
+**In use:** "It's past the event dead zone, so the trace shows a bump there — but we're still inside the attenuation dead zone, so don't trust the loss number on it yet." **Common misuse:** treating "past the dead zone" (singular) as one check instead of two separate ones with different lengths.
+
+## Launch cord vs. patch cord
+
+**Launch cord** is a length of fiber inserted between the OTDR and the fiber under test specifically to push the OTDR's own dead zones clear of the first connector so it can be measured accurately. **Patch cord** is any short jumper cable used to connect equipment or route a signal — a generic term with no dead-zone function implied.
+
+**In use:** "That's not just a patch cord for convenience, it's the launch cord — pull it and you lose your ability to read the first connector's loss at all." **Common misuse:** substituting whatever jumper is on hand without checking it's long enough to clear the dead zone at the OTDR's pulse width in use.
+
+## Reflectance vs. return loss
+
+**Reflectance** is the fraction of light reflected at a single specific interface (one connector, one splice), reported as a negative dB value tied to that one point. **Return loss** often describes the cumulative reflected-power figure for an entire link or mated pair, though the two terms get used interchangeably in casual shop talk.
+
+**In use:** "The OTDR's giving us reflectance at each connector individually — don't average those and call it the link's return loss, they're not describing the same thing." **Common misuse:** comparing a single connector's OTDR-reported reflectance against a return-loss spec written for the mated-pair or link-level figure.
+
+## Angled Physical Contact (APC) vs. Ultra Physical Contact (UPC)
+
+**APC** connectors have an 8° angled ferrule end-face that directs reflected light into the cladding instead of back up the core, rated ≥-60 dB return loss. **UPC** connectors have a flat, domed polish with no angle, rated ≥-50 dB. The two are not interchangeable at the mating interface.
+
+**In use:** "Don't hand me a UPC patch to extend this run — the far end's APC, and mating those two will trash both the loss and the return-loss numbers." **Common misuse:** treating APC and UPC as interchangeable "connector types" distinguished only by color-coding (green vs. blue) rather than as physically incompatible mating geometries.
+
+## Zone (IEC 61300-3-35) vs. defect
+
+**Zone** is one of the concentric regions IEC 61300-3-35 defines on a fiber end-face (A: core, B: cladding, C: adhesive, D: contact), each with its own numeric pass/fail thresholds. **Defect** is any specific scratch, pit, chip, or contamination found on the face — its pass/fail status depends entirely on which zone it falls in.
+
+**In use:** "Same 30 µm chip fails in Zone B but might clear in Zone C — read the zone the defect actually sits in before calling it pass or fail." **Common misuse:** applying one threshold (usually the strict, memorable Zone A/core number) to a defect regardless of which zone it's actually located in.
+
+## Fusion splice vs. mechanical splice
+
+**Fusion splice** permanently joins two fiber ends by melting and fusing the glass itself, typically achieving 0.01–0.05 dB loss. **Mechanical splice** aligns two fiber ends inside a mechanical fixture using index-matching gel, with no fusion — typically 0.3–0.5 dB loss, an order of magnitude worse, and remains a physically separable joint rather than a permanent one.
+
+**In use:** "This budget line was sized assuming fusion — swapping in a mechanical splice here isn't a like-for-like substitution, it'll eat most of the margin." **Common misuse:** treating splice type as a matter of technician convenience or tooling availability rather than a budget-critical choice.
+
+## Threshold current vs. operating current
+
+**Threshold current** is the minimum drive current at which a laser diode transitions from spontaneous (LED-like) emission to lasing — the knee point on the L-I curve. **Operating current** is the current the diode is actually driven at in service, set with margin above threshold to hit the specified output power.
+
+**In use:** "Threshold's crept up 12% since the last burn-in baseline — same operating current is now landing us lower on the slope, that's why output power's down." **Common misuse:** reading a drop in output power as an operating-current or driver problem first, without checking whether the diode's own threshold current has shifted.
+
+## Hermeticity vs. leak rate
+
+**Hermeticity** is the qualitative pass/fail property of a package being sealed against moisture/gas ingress. **Leak rate** is the quantitative atm·cc/sec-helium measurement a leak test actually produces against a package-specific GR-468-CORE threshold — the two aren't interchangeable terms for the same fact.
+
+**In use:** "'No leak detected' isn't the same as 'hermetic' until we've confirmed the detector's sensitivity floor is below the spec's required leak rate." **Common misuse:** calling a package "hermetic" off a leak-rate reading without checking whether that reading reflects the spec threshold or just the instrument's floor.
+
+## Human Body Model (HBM) vs. Charged Device Model (CDM)
+
+**HBM** models an ESD event as a charged person discharging through a part on contact. **CDM** models the part itself accumulating charge (e.g., sliding across a surface or a tray) and discharging through a grounded contact — a distinct, typically faster, lower-threshold event unrelated to the handler's body charge. A part can be protected against one mode and still vulnerable through the other.
+
+**In use:** "Wrist strap protects against HBM, but if this part's been sliding around loose in a non-conductive tray, that's a CDM exposure the strap doesn't address." **Common misuse:** treating "ESD-safe" as a single undifferentiated precaution (wrist strap = done) instead of two distinct discharge paths needing different controls.
+
+## Burn-in vs. environmental screening
+
+**Burn-in** runs a part at elevated, specified temperature and current for a stated duration to force infant-mortality failures before shipment. **Environmental screening** (temperature cycling, vibration, shock) verifies a part *tolerates* specified environmental extremes without permanent effect — a pass/fail exposure test, not a time-based failure-forcing process, and passing one says nothing about the other.
+
+**In use:** "Burn-in's done, 168 hours at spec — but that doesn't cover the temp-cycling requirement on this traveler, that's a separate screening step still open." **Common misuse:** treating a completed burn-in as satisfying any stated environmental-screening requirement on the same traveler.
+
+## Cutback measurement vs. OTDR measurement
+
+**Cutback measurement** determines insertion loss by measuring power through the full fiber, then physically cutting it back to a shorter reference length and re-measuring — a destructive, direct power-comparison method independent of any OTDR's dead-zone or backscatter assumptions. **OTDR measurement** infers loss from backscattered light without cutting the fiber, but is subject to those same dead-zone and backscatter-coefficient assumptions.
+
+**In use:** "OTDR says 0.28 dB on that splice, but it's close to the loss budget's edge — confirm it with a cutback or independent power-meter reading before we sign off." **Common misuse:** treating an OTDR-reported loss value as equally authoritative as a cutback or power-meter reading in all cases.


### PR DESCRIPTION
Rubric score: 18/18

## Resolution rationale

Applied the granularity test to photonics-engineer, the closest candidate. photonics-engineer's Decision framework, Tools & methods, and Worked example are all design-and-analysis oriented: it owns beam-propagation design (ABCD/Gaussian-beam calculators, Zemax/Code V lens prescriptions), derives coupling-lens specs and link-budget margins from first principles, and its worked example is a design memo issued to a program lead. A Photonics Technician (17-3029.08) instead builds, aligns, tests, and troubleshoots photonic devices and production equipment against a released spec — analogous to how aerospace-engineering-technician (build/instrument/test/inspect against an engineer's drawing) differs from aerospace-engineer (owns the design/analysis) in this same repo. Following photonics-engineer's guidance would give a technician wrong tools (Zemax lens-design software vs. production alignment/test fixtures, OTDR/beam-profiler measurement procedures vs. design calculators) and wrong decision framework (verify build/alignment against a spec and disposition deviations to an engineer, vs. derive and close a design from first principles) — the counterfactual and non-derivability tests both fail at the content level, but the granularity gap (technician execution vs. engineer design/certification) is real and has a clean parent among the candidates, exactly mirroring the existing aerospace-engineer/aerospace-engineering-technician split. Slug follows the repo's `<domain>-engineering-technician`-style and `<domain>-technician` naming pattern (e.g., automotive-engineering-technician, validation-engineer siblings); photonics-technician is consistent with O*NET's own title 'Photonics Technicians' and the parent slug photonics-engineer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `photonics-technician` role (leaf of `photonics-engineer`) focused on build, alignment, and test execution per IEC 61300-3-35, GR-468-CORE, and ANSI/ESD S20.20. Updates README/ROADMAP counts and maps O*NET `17-3029.08`.

- **New Features**
  - Added `roles/photonics-technician` with `SKILL.md`, `references/playbook.md`, `references/red-flags.md`, and `references/vocabulary.md`.
  - Registered in `data/roles.json` (O*NET `17-3029.08`, parent `photonics-engineer`, `spec: 2`, status active, jurisdiction `us`).
  - Updated `README.md` and `ROADMAP.md` counts and linked `17-3029.08` to `photonics-technician`.

<sup>Written for commit 0094d406150a8befa5e93753d67f2f075dd69632. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

