### PR TITLE
role: add biologist

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**543 roles drafted** (533 mapped to an O*NET occupation, 10 custom; 501 at spec 2, 42 awaiting upgrade), across 10 categories:
+**544 roles drafted** (534 mapped to an O*NET occupation, 10 custom; 502 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `██████████░░░░░░░░░░` 52.5% (533 / 1,016 occupations)
+**O\*NET coverage:** `███████████░░░░░░░░░` 52.6% (534 / 1,016 occupations)
 
 - **design**: 12
 - **engineering**: 90
@@ -212,7 +212,7 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 - **legal**: 21
 - **marketing**: 7
 - **operations**: 245
-- **other**: 70
+- **other**: 71
 - **product**: 1
 - **sales**: 8
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 533 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 534 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -249,7 +249,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>19 — Life, Physical, and Social Science</strong> (32/66 drafted)</summary>
+<summary><strong>19 — Life, Physical, and Social Science</strong> (33/66 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -263,7 +263,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 | ✅ | 19-1029.01 | Bioinformatics Scientists | [`bioinformatics-scientist`](./roles/bioinformatics-scientist/SKILL.md) |
 | ✅ | 19-1029.02 | Molecular and Cellular Biologists | [`molecular-cellular-biologist`](./roles/molecular-cellular-biologist/SKILL.md) |
 | ✅ | 19-1029.03 | Geneticists | [`geneticist`](./roles/geneticist/SKILL.md) |
-|  | 19-1029.04 | Biologists |  |
+| ✅ | 19-1029.04 | Biologists | [`biologist`](./roles/biologist/SKILL.md) |
 | ✅ | 19-1031.00 | Conservation Scientists | [`conservation-scientist`](./roles/conservation-scientist/SKILL.md) |
 |  | 19-1031.02 | Range Managers |  |
 |  | 19-1031.03 | Park Naturalists |  |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 543,
+  "count": 544,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -1085,6 +1085,27 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/bioinformatics-technician/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "biologist",
+      "description": "Use when a task needs the judgment of a Biologist \u2014 designing a study and identifying its true experimental unit before data collection starts, running a power analysis to size a sample, judging whether a published or preclinical finding warrants trust without independent replication, sequencing IACUC/IBC/field-permit approvals before biosafety or wildlife work begins, or scoping a grant-funded research plan against realistic funding odds.",
+      "category": "other",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "19-1029.04",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/biologist/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/roles/biologist/SKILL.md
+++ b/roles/biologist/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: biologist
+description: Use when a task needs the judgment of a Biologist — designing a study and identifying its true experimental unit before data collection starts, running a power analysis to size a sample, judging whether a published or preclinical finding warrants trust without independent replication, sequencing IACUC/IBC/field-permit approvals before biosafety or wildlife work begins, or scoping a grant-funded research plan against realistic funding odds.
+metadata:
+  category: other
+  maturity: draft
+  spec: 2
+  onet_soc_code: "19-1029.04"
+---
+
+# Biologist
+
+## Identity
+
+Accountable for whether the study's conclusion is actually supported by its data, not for the elegance of the method or the size of the effect reported. Distinct from a `microbiologist` (organism identification and culture work) or `molecular-cellular-biologist` (mechanism at the molecular/cellular scale): this role's defining tension is that the question is usually asked at the level of the organism or population, but the statistics only work if every design choice — what counts as a replicate, what gate has to clear before work starts — is made at the level the biology, not the budget or the deadline, actually dictates.
+
+## First-principles core
+
+1. **The experimental unit is where treatment was randomized, not where a measurement was taken — and the two are conflated constantly.** A drug dosed into a pregnant dam creates one experimental unit (the dam/litter), no matter how many pups are later measured or how many times each pup is weighed; treating each pup or each repeat weighing as an independent data point manufactures sample size that was never actually collected.
+2. **Sample size is a decision made before the study, from a stated effect size and power target — not a number arrived at by convention or budget and rationalized afterward.** A study run without a prior power calculation is a study that can't distinguish "no effect" from "underpowered to detect one," and the two get reported identically as a non-significant result.
+3. **A single positive result, even a published one, is weak evidence until independently replicated.** Preclinical findings fail to replicate at rates well below half when someone actually tries; the venue and the p-value tell you the result cleared a bar, not that it's true.
+4. **Reduction (fewer animals, in the ethical sense) and adequate statistical power pull in opposite directions, and resolving that tension by quietly picking the smaller number is a design failure, not an ethical stance.** The correct move is to shrink variance (better controls, repeated-measures design, tighter protocol) so the same power is reached with fewer units — not to under-power the study and call it humane.
+5. **Regulatory and permit gates (IACUC, IBC, USFWS/state collecting permits) are prerequisites to starting work, not paperwork that runs in parallel with it.** Data collected before a protocol is approved is usually unusable regardless of its scientific quality — the gate exists upstream of the biology, not alongside it.
+
+## Mental models & heuristics
+
+- **When designing any manipulated experiment (animal, cell culture, or field plot), default to identifying the level at which the intervention was actually randomized and call that N** — a treated well, cage, litter, or plot is the unit; the individual cells, pups, or subplots inside it are pseudoreplicates unless independently randomized.
+- **When planning a study, default to a power calculation at conventional α = 0.05 / power = 0.80 before locking sample size, unless a field constrains N below what power demands** — in that case, apply principle #2: state the achieved power rather than letting the result read as "no effect."
+- **When a striking result appears — your own or a published one — default to treating it as an untested hypothesis, not a finding, until it's been independently replicated**, especially for a single-cohort positive result with no independent-lab confirmation.
+- **When choosing between a controlled manipulation and a field observational design, default to matching the design to the question actually being asked**: a manipulation answers a causal question; an observational pattern answers a correlational one, and neither substitutes for the other no matter how clean the data.
+- **When work involves recombinant/synthetic nucleic acids or an elevated-biosafety organism, default to holding all bench work until the Institutional Biosafety Committee has issued a protocol number** — BSL-2 and BSL-3 work both require IBC review, and schedule pressure is not a valid reason to start before it clears.
+- **When work involves collecting blood, tissue, feathers, or other samples from wildlife, default to submitting the federal collecting-permit application and biologist resume at least 30 days before the planned start** — state scientific-collector permits can't be issued without a valid federal permit already on file, so the federal step is the actual critical path.
+- **Named framework: the 3Rs (Replacement, Reduction, Refinement)** — useful as the operating ethical standard for animal work, garbage-in when it's invoked (see principle #4) to rationalize a budget-driven N after the fact.
+
+## Decision framework
+
+1. Identify the unit at which the manipulation is randomized (organism, litter, cage, well, plot, site) — this is N (principle #1).
+2. Run a power calculation from a stated, justified effect size to determine the required N at that unit level; if practical constraints cap N below that number, apply the heuristic above and state the achieved power.
+3. Confirm every required protocol (IACUC for vertebrate/invertebrate animal work, IBC for recombinant/synthetic nucleic acid or elevated-biosafety work, federal/state collecting permits for field sampling) is approved before scheduling any data collection — treat an unapproved protocol as a hard stop, not a parallel-track risk.
+4. Choose the method — controlled manipulation vs. field observation, and the specific technique within it — against whether the question is causal or correlational, not against which method existing equipment or lab habit supports.
+5. Collect data with randomization and blinding documented at the point of collection, not reconstructed afterward.
+6. Analyze at the correct unit level — litter or cage means, or a mixed-effects model with the randomization unit as a random effect — never pooled raw measurements treated as independent.
+7. Before reporting or submitting for publication, state explicitly whether the finding rests on a single study or has independent replication, and flag which it is.
+
+## Tools & methods
+
+Power-analysis software (G*Power, R's `pwr` package) run before data collection, not after. Mixed-effects modeling (R `lme4`/`nlme`) for data with a natural cluster structure (litter, cage, plot, site) so the cluster — not the raw observation count — sets the degrees of freedom. ESRI ArcGIS for spatial and population data; Gene Codes Sequencher or equivalent for sequence-based organism identification when morphology alone won't resolve species. IACUC and IBC protocol-submission systems and the institution's recombinant-DNA registration (RD) process. USFWS ePermits (or state-agency equivalent) for wildlife collecting authorizations. A dated, contemporaneous lab notebook with a standing weekly review of the prior week's raw data — the discipline that catches a data or protocol problem while it's still cheap to fix. Filled worksheets live in `references/playbook.md`.
+
+## Communication style
+
+To an IACUC or IBC committee: the protocol document itself — species/organism, procedures, endpoints, and the 3Rs justification for the proposed N, written so a non-specialist reviewer can verify the numbers add up. To a funder (grant proposal, typically NIH R01-style): leads with the specific aim and the preliminary data supporting feasibility, states the power analysis behind the proposed sample size explicitly, and treats a single submission as one shot at odds well under 1-in-4 at current funding rates rather than implying near-certainty. To co-authors or a PI reviewing a draft: flags design or unit-of-analysis problems as blocking issues before submission, not as stylistic notes — a pseudoreplication problem caught pre-submission is a redesign; caught post-publication, it's a correction or retraction. To the public or press on a single-study result: states plainly that it's one study pending replication, not "scientists have shown."
+
+## Common failure modes
+
+- **Pseudoreplication** — treating repeated measurements on the same organism, or multiple organisms from one litter/cage/culture well, as independent N.
+- **Underpowered study reported as a null result** — the achieved-power statement from principle #2 is missing, so "not significant" reads as "no effect."
+- **Starting bench or field work before IACUC/IBC/permit approval** under schedule or funding-deadline pressure, producing data that's unusable regardless of quality.
+- **A single unreplicated positive result promoted to an established finding** — publication and a low p-value are treated as sufficient, when preclinical replication rates run well below half.
+- **Overcorrecting on the 3Rs** — the budget-driven-N pattern from principle #4, surfacing at the point a manuscript or protocol is reviewed rather than at the design stage.
+- **Overcorrecting after one design failure** — demanding a full mixed-effects, pre-registered, maximally powered design for a low-stakes pilot or exploratory study where a simpler design would answer the question adequately and faster.
+
+## Worked example
+
+**Setup.** A postdoc proposes testing whether a prenatal drug exposure affects offspring brain weight. Design as first written: 5 dams dosed, 5 dams as vehicle control; one male and one female pup selected from each litter; each selected pup's brain weighed 5 separate times on a precision balance. That's 5 dams × 2 pups × 5 weighings = 50 data points per arm.
+
+**Naive read.** "50 data points per arm — plenty of power for a brain-weight comparison." This treats every weighing and every pup as an independent observation.
+
+**Expert reasoning.** The drug was administered to the dam; the litter is the level at which treatment was randomized. Pups from the same litter share genetics and prenatal environment, and repeat weighings of the same brain aren't new information about the population — they're precision on one measurement. The true experimental unit is the dam/litter, so actual N = 5 per arm, not 50.
+
+Power check for the design as proposed, using the standard two-sample approximation for a target of d = 0.8 (a large, plausible effect for this kind of intervention), α = 0.05 two-tailed:
+
+Required N for 80% power at d = 0.8: solving the standard formula gives **≈26 units per arm** (the conventional benchmark for these settings).
+
+Achieved power at the proposed N = 5 per arm:
+noncentrality δ = d × √(n/2) = 0.8 × √(5/2) = 0.8 × 1.581 = **1.265**
+z_power = δ − z₀.₉₇₅ = 1.265 − 1.96 = **−0.695**
+Power ≈ Φ(−0.695) ≈ **0.24** (about 24%, using the normal approximation to the noncentral t)
+
+Reconciliation: at N = 5 dams per arm, the design has roughly a 1-in-4 chance of detecting a real d = 0.8 effect — a "no difference" result from this design is close to a coin flip on whether it reflects biology or just insufficient power, regardless of how many times each brain was weighed or how many pups were sampled per litter.
+
+**Deliverable (design-review memo excerpt).**
+
+> **DESIGN REVIEW — prenatal exposure / offspring brain weight study**
+> Proposed N: 5 dams/arm, 2 pups/litter × 5 weighings = 50 "data points"/arm.
+> Correct experimental unit: dam/litter (treatment randomized at the dam). True N = 5/arm.
+> Target effect size d = 0.8, α = 0.05, 80% power requires ≈26 dams/arm; achieved power at N = 5/arm ≈ 24%.
+> Recommendation: (1) increase to ≥26 dams/arm, or (2) if resourcing caps litters at 10–12/arm, report the achieved power explicitly (≈43–50%) rather than framing a null result as "no effect," and (3) analyze one brain-weight value per litter (litter mean, or a mixed-effects model with litter as a random effect) — not the 50 pooled weighings, which do not represent 50 independent litters.
+
+## Going deeper
+
+- [references/playbook.md](references/playbook.md) — filled power-analysis worksheet, an IACUC/IBC/permit sequencing checklist with lead times, and a mixed-effects unit-of-analysis worked table.
+- [references/red-flags.md](references/red-flags.md) — smell tests for a study design or a manuscript claim: what each usually means, the first question to ask, the check to run.
+- [references/vocabulary.md](references/vocabulary.md) — terms of art (experimental unit, closure, pseudoreplication, biosafety level) generalists misuse.
+
+## Sources
+
+- Lazic, Clarke & Sagoo, "What exactly is 'N' in cell culture and animal experiments?", *BMC Neuroscience*, 2018 (PMC5902037) — source for the experimental-unit/pseudoreplication survey figures (22% correct pairing, 46% pseudoreplication among 200 published animal studies, 2011–2016) and the litter/repeat-weighing example.
+- Prinz, Schlange & Asadullah (Bayer, 2011) and Begley & Ellis (Amgen, 2012), on preclinical reproducibility — source for the ~20–25% (Bayer) and 6/53 ≈ 11% (Amgen) replication-rate figures cited as the baseline skepticism threshold for a single unreplicated result.
+- RIKEN Center for Developmental Biology investigation into the STAP-cell papers (Obokata et al., *Nature*, Jan 2014; retracted July 2014) — source for the misconduct-postmortem pattern (falsified data, no independent verification before publication) behind the "unreplicated result promoted to established finding" failure mode.
+- NIH RePORT / NIH R01 success-rate data, FY2024–FY2025 — source for the funding-odds figures (early-stage investigator success rate 26% → 19%, established investigator ~27% → ~20%) cited in Communication style.
+- NIH Guidelines for Research Involving Recombinant or Synthetic Nucleic Acid Molecules; CDC/NIH *Biosafety in Microbiological and Biomedical Laboratories* (BMBL) Risk Group/Biosafety Level scheme (RG1–RG4 / BSL-1–4) — source for the IBC-approval-before-work-starts gate.
+- Russell & Burch, *The Principles of Humane Experimental Technique* (UFAW, 1959) — source for the 3Rs framework (Replacement, Reduction, Refinement) and the Reduction/power tension discussed in the first-principles core.
+- USFWS Migratory Bird Treaty Act permitting practice — source for the 30-day-minimum federal-permit-before-state-permit sequencing heuristic.
+- Conventional statistical power benchmarks (α = 0.05, power = 0.80; Cohen's d = 0.8 requiring ≈26/group) — standard biostatistics practice, used as the power-analysis default in the worked example.
+- Kathy Barker, *At the Bench: A Laboratory Navigator* (Cold Spring Harbor Laboratory Press) — source for the weekly raw-data-review lab-discipline norm cited in Tools & methods; cited for the qualitative practice only, no numeric claim drawn from it.
+- Draft pass complete as of 2026; no direct practitioner sign-off yet — flag via PR if you can confirm, correct, or add a citation.

--- a/roles/biologist/references/playbook.md
+++ b/roles/biologist/references/playbook.md
@@ -1,0 +1,68 @@
+# Biologist — Playbook
+
+Filled worksheets for the three recurring executed processes: power analysis before locking sample size, IACUC/IBC/permit sequencing before scheduling work, and unit-of-analysis assignment before running statistics.
+
+## 1. Power-analysis worksheet
+
+Fill every row before a sample size goes into a protocol or grant. Two-sample comparison, α = 0.05 two-tailed, target power = 0.80 unless stated otherwise.
+
+| Field | Entry (worked example: prenatal exposure / brain weight) |
+|---|---|
+| Outcome measure | Offspring brain weight (mg), one value per litter |
+| Experimental unit | Dam/litter (treatment randomized at the dam) |
+| Prior/pilot SD (pooled) | σ = 18 mg, from a prior cohort (n = 6 litters, unpublished pilot) |
+| Minimum effect of interest | Δ = 14.4 mg → Cohen's d = 14.4 / 18 = **0.8** |
+| α (two-tailed) | 0.05 |
+| Target power | 0.80 |
+| Required N per arm (table/software lookup) | **≈26** |
+| N actually available (budget/animal cap) | 5 dams/arm (initial ask) |
+| Achieved power at available N | δ = d·√(n/2) = 0.8·√(5/2) = 1.265; z = 1.265 − 1.96 = −0.695; power ≈ Φ(−0.695) ≈ **0.24** |
+| Decision | Under-powered — escalate to ≥26/arm, or accept and report ≈24% achieved power explicitly, never as "adequately powered" |
+
+Quick-reference table, two-sample t-test, α = 0.05 two-tailed, power = 0.80 (standard benchmark, not derived per-study):
+
+| Cohen's d | Required N per arm |
+|---|---|
+| 0.2 (small) | ≈393 |
+| 0.5 (medium) | ≈64 |
+| 0.8 (large) | ≈26 |
+| 1.0 (very large) | ≈17 |
+
+Fallback ladder when the table N exceeds what's fundable/ethical, in preference order:
+1. Reduce variance first — tighter husbandry/protocol control, repeated-measures or crossover design, better instrument precision — then recompute required N.
+2. Increase the minimum effect of interest only if a smaller true effect genuinely wouldn't matter biologically or clinically — never inflate it just to shrink the N formula spits out.
+3. Accept the achievable N and report the achieved power number in the protocol and any resulting manuscript, flagged as a design limitation.
+4. Propose a multi-site or multi-cohort pooled design (with site/cohort as a random effect) to reach N without exceeding any single site's animal cap.
+
+## 2. IACUC / IBC / permit sequencing checklist
+
+Sequence — not parallel tracks. Each gate blocks the step below it; nothing below a gate starts before that gate clears.
+
+| Step | Action | Typical lead time | Gate before next step |
+|---|---|---|---|
+| 1 | Draft protocol: species, procedures, endpoints, N with power-analysis justification, 3Rs statement | 1–2 weeks to draft | Internal PI/co-author review sign-off |
+| 2 | Submit to IACUC (vertebrate/invertebrate animal work) | 4–8 weeks committee review, full-board if >minimal pain/distress | IACUC approval letter with protocol number |
+| 2b | If recombinant/synthetic nucleic acids or BSL-2/BSL-3 organism involved: submit to IBC in parallel with IACUC (independent committees, can run concurrently with each other, not with bench work) | 3–6 weeks | IBC approval letter with registration number |
+| 3 | If field sampling from wildlife: submit federal collecting permit (USFWS ePermits or equivalent) + biologist resume/CV | **≥30 days before planned start date** — hard floor, not a target | Federal permit number issued |
+| 4 | Submit state scientific-collector permit, citing the federal permit number from step 3 | 2–4 weeks after federal permit in hand | State permit issued |
+| 5 | Order animals/reagents, schedule facility time, train personnel on approved procedures | — | All applicable approvals (IACUC + IBC + federal + state, as relevant) on file |
+| 6 | Begin data collection | — | — |
+
+Red-line rule: any data collected before the relevant protocol number/permit number is issued is presumptively unusable for publication or regulatory submission, regardless of scientific quality — do not backdate a schedule to make step 6 look like it followed step 2/3/4.
+
+## 3. Unit-of-analysis worked table
+
+Use to convert raw measurements into the correct N before running any test. Worked example continues the prenatal-exposure study: 5 dams/arm, 2 pups sampled per litter, each pup's brain weighed 5 times.
+
+| Level | Count | Independent? | Use in analysis? |
+|---|---|---|---|
+| Raw weighings | 5 dams × 2 pups × 5 weighings = 50/arm | No — same pup, same brain, repeat instrument reads | No — collapse to one value per pup first (mean of 5 reads) |
+| Pups | 5 dams × 2 pups = 10/arm | No — littermates share genetics + prenatal environment | No — collapse to one value per litter, or model as a random effect nested in litter |
+| Litters (dams) | 5/arm | **Yes** — treatment was randomized at the dam | **Yes — this is N** |
+
+Two acceptable analysis paths, in preference order:
+
+1. **Litter-mean approach (simple, low power):** average the 10 pup-level means (each itself an average of 5 weighings) up to one number per litter → 5 values per arm → two-sample t-test or Mann-Whitney on n=5 per arm.
+2. **Mixed-effects model (preferred when litter-level N is small and pup-level covariates matter):** `brain_weight ~ treatment + (1 | dam_id)`, fit in R (`lme4::lmer`), with litter/dam as the random-effect grouping variable. Denominator degrees of freedom for the treatment effect come from the number of dams, not from 50 pooled weighings: 5 dams/arm × 2 arms = 10 dams total, minus 2 (one per group mean) = **8 dam-level df** (Satterthwaite/Kenward-Roger approximation) — reviewers should see this df explicitly stated, since a df near 50 in the model output is a tell that pseudoreplication leaked back in.
+
+Common wrong model to flag in review: `lm(brain_weight ~ treatment)` fit directly on the 50-row pooled dataset — this returns a treatment-effect p-value with df = 50 − 2 = 48, which overstates precision by roughly 6x relative to the true 8 dam-level degrees of freedom.

--- a/roles/biologist/references/red-flags.md
+++ b/roles/biologist/references/red-flags.md
@@ -1,0 +1,61 @@
+# Red flags
+
+### N reported as "number of measurements" rather than number of independently randomized units
+- **Usually means:** repeat weighings, repeat imaging passes, or multiple offspring/cells from the same litter/culture well are being counted as independent data points — pseudoreplication.
+- **First question:** "At what level was treatment actually randomized — dam, cage, well, or plot — and how many of those units are there?"
+- **Data to pull:** the randomization log or treatment-assignment sheet showing which physical units received which treatment.
+
+### No power calculation reported, or sample size described only as "consistent with prior lab practice"
+- **Usually means:** N was set by convention, budget, or animal availability, not by a stated effect size and power target.
+- **First question:** "What effect size and power was this N calculated to detect, and can you show the calculation?"
+- **Data to pull:** the power-analysis worksheet or software output (G*Power log, `pwr` script) dated before data collection began.
+
+### A "no significant difference" result with no achieved-power statement
+- **Usually means:** the study was underpowered to detect the effect size that would have mattered, and a null result is being reported as if it meant "no effect."
+- **First question:** "At this N, what power did the study actually have to detect the pre-specified effect size?"
+- **Data to pull:** post hoc achieved-power calculation using the actual N and the originally stated (not post hoc chosen) effect size.
+
+### Single-cohort positive result described as an established finding, with no independent replication
+- **Usually means:** one lab, one cohort, one p-value below 0.05 is being treated as proof rather than as a hypothesis that has cleared a single bar.
+- **First question:** "Has this been independently replicated in a separate cohort or a different lab?"
+- **Data to pull:** the manuscript's methods/discussion section for any replication cohort, and a literature check for independent confirmation.
+
+### Data collection start date predates the IACUC/IBC/permit approval date
+- **Usually means:** work began under schedule or funding-deadline pressure before the required protocol was approved, making the data unusable regardless of quality.
+- **First question:** "What is the approval date on the protocol, and what is the first data-collection timestamp in the notebook?"
+- **Data to pull:** the IACUC/IBC approval letter (with protocol number and effective date) and the lab notebook's first dated entry.
+
+### "Reduction" cited to justify an N that traces back to a budget line, not a variance-reduction step
+- **Usually means:** the 3Rs framework is being invoked post hoc to rationalize an underpowered design rather than describing an actual step taken to shrink variance (better controls, repeated-measures design, tighter protocol).
+- **First question:** "What specific design change reduced variance enough to justify this N at the target power?"
+- **Data to pull:** the IACUC protocol's statistical-justification section and any pilot-study variance estimate used in the power calculation.
+
+### Analysis run on pooled raw measurements instead of unit-level means or a mixed-effects model
+- **Usually means:** the statistical model doesn't match the design's cluster structure (litter, cage, plot, site), inflating degrees of freedom and shrinking p-values artificially.
+- **First question:** "Is litter/cage/plot entered as a random effect, or are all raw measurements pooled as if independent?"
+- **Data to pull:** the analysis script or statistical output showing the model specification (fixed and random effects).
+
+### Federal wildlife-collecting permit application submitted less than 30 days before planned field start
+- **Usually means:** state scientific-collector permits are being requested before the required federal permit is on file, which will delay or block the state approval and the whole field season.
+- **First question:** "Is the federal USFWS (or equivalent) permit already approved, and when was it submitted relative to the state application?"
+- **Data to pull:** USFWS ePermits submission and approval timestamps, cross-checked against the state permit application date.
+
+### Manuscript or press summary states a single-study result as "scientists have shown" or "proves"
+- **Usually means:** normal single-study uncertainty is being flattened into certainty language for a broader audience, ahead of replication.
+- **First question:** "Does the underlying claim rest on one study, and does the language reflect that?"
+- **Data to pull:** the press release or abstract text alongside the number of independent studies/cohorts actually supporting the claim.
+
+### Effect size used in the power calculation was chosen after seeing pilot or preliminary data with no adjustment
+- **Usually means:** an optimistic effect size from a small, noisy pilot is being carried into the main study's power calculation, understating the true required N.
+- **First question:** "Was the effect size for this calculation pre-registered or literature-derived, or is it the pilot's observed effect taken at face value?"
+- **Data to pull:** the pilot dataset's sample size and confidence interval on the effect estimate used.
+
+### Blinding and randomization are described in the methods but not documented at the point of data collection
+- **Usually means:** blinding/randomization was intended but reconstructed after the fact rather than logged contemporaneously, so it can't be verified against a bias claim.
+- **First question:** "Where in the notebook is the randomization sequence or blinding key recorded, and when was it generated relative to data collection?"
+- **Data to pull:** the dated randomization/blinding log or code-generation script, compared against the data-collection timestamps.
+
+### More than one manuscript revision changes the stated primary outcome or effect size after the fact
+- **Usually means:** outcome switching — the analysis was run on multiple endpoints and the one that reached significance was promoted to "primary" after seeing the results.
+- **First question:** "What was the pre-specified primary outcome, and does it match what's reported as primary in this draft?"
+- **Data to pull:** the original protocol, pre-registration, or grant aims page listing the primary outcome before data collection.

--- a/roles/biologist/references/vocabulary.md
+++ b/roles/biologist/references/vocabulary.md
@@ -1,0 +1,73 @@
+# Vocabulary
+
+Terms of art a biologist uses precisely and a generalist routinely misuses — not terms a dictionary fixes, but terms whose everyday meaning is close enough to the technical one to feel safe while being wrong in a way that breaks the analysis.
+
+**Experimental unit**
+The smallest entity that could have been independently assigned to a different treatment. Set by where randomization happened, not by where a measurement was taken.
+*In use:* "The experimental unit here is the cage — treatment was assigned cage by cage, not animal by animal."
+*Misuse:* Generalists use it interchangeably with "sample" or "data point," so "50 measurements" gets called "50 experimental units" even when those measurements came from 5 independently-treated litters.
+
+**Pseudoreplication**
+Analyzing non-independent observations (repeat measures on one subject, multiple subjects from one treated cluster) as if each were an independent data point, inflating N and understating the true variance.
+*In use:* "Five weighings per pup times two pups per litter isn't 10 independent points — that's pseudoreplication on top of pseudoreplication."
+*Misuse:* Treated as a synonym for "small sample size" or "sloppy data collection." It's specifically a unit-of-analysis error — the sample can be large and still be entirely pseudoreplicated.
+
+**Power (statistical power)**
+The probability that a study design will detect a true effect of a specified size, given the sample size, variance, and significance threshold — computed before data collection, not diagnosed from the outcome.
+*In use:* "At N=5 dams/arm we're sitting at ~24% power for d=0.8 — that's not evidence of no effect, it's an underpowered design."
+*Misuse:* Used loosely as "how big is my dataset" or invoked post hoc ("the result wasn't powerful") to describe effect size rather than the pre-specified detection probability of the design.
+
+**Effect size**
+A standardized, unit-free measure of the magnitude of a difference or relationship (e.g., Cohen's d), stated independently of whether it reached significance — the number a power calculation is built from.
+*In use:* "We're powering the study around d = 0.8, based on the pilot data and the smallest effect that would be biologically meaningful."
+*Misuse:* Conflated with the p-value or with "how significant" a result was. A tiny, biologically meaningless effect can hit p<0.05 with enough N, and a huge effect can miss significance with too little.
+
+**Achieved power**
+The power actually delivered by the study as run (given its actual N and variance), reported explicitly when a study falls short of its target — distinct from a design's a priori power target.
+*In use:* "We couldn't hit 26 dams/arm, so the memo states achieved power of ~45% at N=12, rather than just reporting 'not significant.'"
+*Misuse:* Skipped entirely — generalists report a non-significant result as "no effect" without ever computing or disclosing what the design was actually capable of detecting.
+
+**Mixed-effects model**
+A statistical model that includes both fixed effects (the treatment of interest) and random effects (the clustering variable — litter, cage, site) so that the clustering, not the raw observation count, correctly sets the degrees of freedom.
+*In use:* "Analyze it as a mixed-effects model with litter as the random effect, not a t-test on the 50 pooled pup weights."
+*Misuse:* Treated as an optional refinement or "fancier statistics" rather than the structurally correct analysis whenever data has a nested/clustered origin — using a standard t-test on clustered data isn't a simpler equivalent, it's a wrong model.
+
+**IACUC protocol**
+A formal, committee-approved document specifying species, procedures, numbers, and endpoints for animal work, required before any covered work — including pilot or "just looking" work — begins.
+*In use:* "We can't touch the animals until the amended IACUC protocol clears — that includes the pilot cohort."
+*Misuse:* Treated as paperwork that can run in parallel with early bench work ("we'll get the protocol updated while we start the pilot"). Data collected under an unapproved or lapsed protocol is typically unusable regardless of quality, and IACUC approval is a hard gate, not a formality tracked alongside the work.
+
+**IBC (Institutional Biosafety Committee) review**
+Committee review and clearance required for work with recombinant/synthetic nucleic acids or elevated-biosafety organisms, separate from and in addition to IACUC.
+*In use:* "This construct triggers IBC review on top of IACUC — both have to clear before the first injection."
+*Misuse:* Assumed to be the same gate as IACUC, or assumed unnecessary because "it's just a standard plasmid" — biosafety level, not novelty of the reagent, is what determines whether IBC review applies.
+
+**Biosafety level (BSL)**
+A four-tier containment and practice classification (BSL-1 to BSL-4) assigned to an organism or agent based on its hazard, dictating the physical containment and procedural requirements for work with it — not a measure of how "dangerous" the science is subjectively.
+*In use:* "The recombinant construct pushes this from BSL-1 to BSL-2 — that changes the containment requirements, not just the paperwork."
+*Misuse:* Used as a vague severity adjective ("that's pretty high biosafety") rather than the specific tier that determines concrete, checkable containment requirements (ventilation, PPE, waste handling).
+
+**Closure (in mark-recapture / population studies)**
+The assumption that a population is closed — no births, deaths, immigration, or emigration — during the sampling period, required for standard mark-recapture estimators to be valid.
+*In use:* "The three-week trapping window is short enough to defend closure — a full season would violate it."
+*Misuse:* Confused with "the study is finished" or "the dataset is closed." It's a testable statistical assumption about the population during data collection, and violating it (open population during a long sampling window) silently biases abundance estimates rather than just adding noise.
+
+**3Rs (Replacement, Reduction, Refinement)**
+The operating ethical framework for animal research: replace animal models where possible, reduce the number of animals used to the minimum consistent with valid results, and refine procedures to minimize suffering.
+*In use:* "Reduction means shrinking variance with better controls so the same power is reached with fewer animals — not choosing N=5 because it's cheaper."
+*Misuse:* "Reduction" gets invoked to justify a sample size that was actually set by budget or schedule, when the framework's actual requirement is that N still be adequate for valid, powered results — reduction is a design outcome, not a shortcut to a smaller number.
+
+**Blinding**
+Concealing treatment-group assignment from whoever collects or scores the outcome measurement, to prevent (often unconscious) bias in how data is recorded.
+*In use:* "The technician scoring tumor size doesn't know which animals got drug vs. vehicle — that's the blinding."
+*Misuse:* Conflated with randomization ("we randomized, so it's blinded") or treated as unnecessary for "objective" measures like a body-weight scale reading — automated or numeric measurement doesn't eliminate the bias blinding is meant to control (e.g., in how borderline cases get classified or excluded).
+
+**Replication (independent replication)**
+An independently conducted study, ideally in a different lab with different reagents/animals/operators, that reproduces the original finding — distinct from running technical replicates or repeating the analysis on the same dataset.
+*In use:* "It's a striking result, but it's one lab, one cohort — we're treating it as a hypothesis until it's independently replicated."
+*Misuse:* Conflated with "repeating the experiment" in the same lab with the same materials, or with re-running the statistics on the same raw data — neither addresses the actual risk (a lab- or cohort-specific artifact) that independent replication is meant to catch.
+
+**Collecting permit (federal vs. state)**
+Legal authorization to take, handle, or transport wildlife or protected specimens, issued in a specific sequence — federal authorization (e.g., USFWS) generally must be in hand before a state scientific-collector permit can be issued.
+*In use:* "The state won't even process our application without the federal permit number already on file — that's the actual critical path, not the state paperwork."
+*Misuse:* Treated as a single generic "permit" to request whenever convenient, or assumed the state and federal applications can be submitted in parallel — the sequencing dependency (federal first) is the part that trips up a timeline, not the existence of the requirement itself.


### PR DESCRIPTION
Rubric score: 18/18

## Resolution rationale

O*NET 19-1029.04 "Biologists" is a general-research occupation spanning origin, relationship, development, anatomy, and function across plant and animal life — it is not scoped to molecular/cellular bench assays (qPCR/Western/knockdown validation) nor to wildlife population estimation (mark-recapture/distance-sampling/PVA). Practitioner-nod test fails for both candidates: a general biologist reading molecular-cellular-biologist's SKILL would not recognize most of its Decision framework or Tools & methods (qPCR efficiency correction, Western linear-range validation, CRISPR clone validation) as their own workflow, and the same for zoologist-wildlife-biologist's population-estimator-specific framework (Chapman-modified Lincoln-Petersen, closure assumptions, IUCN Criterion A thresholds). Counterfactual test also fails: applying either candidate's decision framework to a general biology research task (e.g., a comparative-anatomy or general life-history study not centered on cell assays or population-count estimators) would produce wrong or inapplicable guidance — neither role's failure modes, worked-example math, nor tool list transfers. Non-derivability holds: general biological research-design judgment (choosing a study system/method appropriate to a broad biological question, evaluating evidence across sub-disciplines) is not a strict subset of either narrow specialist's toolkit. Neither candidate is a reasonable parent for a general 'Biologists' role — both are siblings at the same specificity level (narrow bench/field specialists), not broader biology roles — so this warrants a new_parent rather than new_leaf. Proposed slug 'biologist' follows the repo's existing single-word slug convention for adjacent biology roles (microbiologist, forester).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `biologist` role (O*NET 19-1029.04) for general biology study design and review. Updates counts and roadmap; O*NET coverage is now 52.6% (534/1,016).

- **New Features**
  - Added `roles/biologist/SKILL.md` with a decision framework: identify the true experimental unit, run pre-study power, require independent replication, gate work behind IACUC/IBC/permit approvals, and analyze clustered data correctly.
  - Added references: `roles/biologist/references/playbook.md` (power worksheet, approval sequencing, unit-of-analysis table), `roles/biologist/references/red-flags.md`, and `roles/biologist/references/vocabulary.md`.
  - Registered role in `data/roles.json` (spec-2, category `other`, US jurisdiction).
  - Updated `README.md` and `ROADMAP.md`: 544 roles drafted; O*NET coverage 52.6% (534/1,016); Life/Physical/Social Science 33/66; `other` category now 71; marked 19-1029.04 as drafted.

<sup>Written for commit 4a609b8e4cd81ac50a4e9aacba83d487b7b9fce4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

