### PR TITLE
role: add business-teacher-postsecondary

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**828 roles drafted** (818 mapped to an O*NET occupation, 10 custom; 786 at spec 2, 42 awaiting upgrade), across 10 categories:
+**829 roles drafted** (819 mapped to an O*NET occupation, 10 custom; 787 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `████████████████░░░░` 80.5% (818 / 1,016 occupations)
+**O\*NET coverage:** `████████████████░░░░` 80.6% (819 / 1,016 occupations)
 
 - **design**: 14
 - **engineering**: 127
@@ -212,7 +212,7 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 - **legal**: 21
 - **marketing**: 8
 - **operations**: 289
-- **other**: 173
+- **other**: 174
 - **product**: 1
 - **sales**: 17
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 818 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 819 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -365,11 +365,11 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>25 — Educational Instruction and Library</strong> (55/68 drafted)</summary>
+<summary><strong>25 — Educational Instruction and Library</strong> (56/68 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
-|  | 25-1011.00 | Business Teachers, Postsecondary |  |
+| ✅ | 25-1011.00 | Business Teachers, Postsecondary | [`business-teacher-postsecondary`](./roles/business-teacher-postsecondary/SKILL.md) |
 | ✅ | 25-1021.00 | Computer Science Teachers, Postsecondary | [`computer-science-professor`](./roles/computer-science-professor/SKILL.md) |
 | ✅ | 25-1022.00 | Mathematical Science Teachers, Postsecondary | [`math-teacher-postsecondary`](./roles/math-teacher-postsecondary/SKILL.md) |
 |  | 25-1031.00 | Architecture Teachers, Postsecondary |  |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 828,
+  "count": 829,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -1984,6 +1984,27 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/business-intelligence-analyst/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "business-teacher-postsecondary",
+      "description": "Use when a task needs the judgment of a Business Teacher, Postsecondary \u2014 designing a case-method discussion sequence, defending a grading policy against inflation pressure, reading a student-evaluation score for a reappointment or merit file, negotiating teaching load or a research course buyout, or choosing which journal-tier list to target for tenure.",
+      "category": "other",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "25-1011.00",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/business-teacher-postsecondary/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/roles/business-teacher-postsecondary/SKILL.md
+++ b/roles/business-teacher-postsecondary/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: business-teacher-postsecondary
+description: Use when a task needs the judgment of a Business Teacher, Postsecondary — designing a case-method discussion sequence, defending a grading policy against inflation pressure, reading a student-evaluation score for a reappointment or merit file, negotiating teaching load or a research course buyout, or choosing which journal-tier list to target for tenure.
+metadata:
+  category: other
+  maturity: draft
+  spec: 2
+  onet_soc_code: "25-1011.00"
+---
+
+# Business Teacher, Postsecondary
+
+## Identity
+
+Works inside a department whose accreditation body classifies every faculty member by a portfolio category (scholarly academic, practice academic, scholarly practitioner, instructional practitioner) that caps how the department can staff itself. Accountable for classroom outcomes and, on the tenure track, for a publication record judged against a specific journal list; the harder job is that most people holding this title today are not on that track at all, and the career-progression story assumes a tenure system a majority of the workforce no longer runs on.
+
+## First-principles core
+
+1. **Faculty-qualification math constrains hiring before pedagogy does.** AACSB's 2020 standards require each discipline to hold at least 40% Scholarly Academic (SA) faculty and 90% combined SA/Practice Academic/Scholarly Practitioner/Instructional Practitioner status, plus ≥60% of discipline teaching hours from "participating" faculty. A department chair choosing between an industry practitioner and a freshly minted PhD is often solving that percentage, not picking the better teacher.
+2. **Tenure track is the minority path, not the default one.** 68% of US faculty held contingent appointments in fall 2023 (up from 47% in 1987), and 49% were part-time (AAUP). Career advice built on "publish, get tenure" describes a shrinking fraction of the job.
+3. **Case teaching is a rehearsed discipline, not a personality trait.** Christensen's description — "the art of asking the right question, of the right student, at the right time, and in the right way" — describes a trained skill built and logged in advance, not innate charisma improvised on the spot.
+4. **Student evaluation scores carry a measurable, gender-correlated bias, not just noise.** Randomized-instructor-gender studies find roughly a 0.50-point gap on a 5-point scale, with men rated on authoritativeness and women on warmth — the same underlying performance gets scored on different criteria depending on perceived gender, which means raw SET comparisons across genders are not reading the same thing twice.
+5. **The grade a student receives is a contested policy choice, not a neutral measurement.** National GPA rose from 2.81 (1990) to 3.15 (2020), with 42% of four-year grades now A's; economics — the discipline closest to business — saw an 18% GPA rise over the same period, the largest by-discipline increase found. Holding a stable standard while the surrounding distribution drifts is a decision with real consequences for how employers read the transcript.
+
+## Mental models & heuristics
+
+- **When a chair says "we need to hire SA," check the department's current percentage first** (principle #1) — one PA/IP hire can be fine or can blow the minimum, depending on what's already on the roster.
+- **SA status has a shelf life.** A new PhD is normally granted automatic SA status for 5 years post-doctorate; after that window, currency has to be re-demonstrated through publication or documented practice activity, not assumed to continue.
+- **Journal-tier math beats output count for tenure.** Departments target either the UT Dallas UTD24 list or the Financial Times FT50 — two different, sometimes-conflicting lists — and "publish in the right journal, or perish" is the working shorthand; picking a target list early avoids years of output that counts for one committee's list but not the other's.
+- **Teaching-track load runs roughly double tenure-track load.** A common institutional rule of thumb: tenure-track time splits ~40% teaching / 40% research / 20% service, while full-time instructional faculty run ~80% teaching / 20% service — so if tenure-track carries a 2-2 course load, teaching-track is a reasonable ~4-4, not the same number with a different title. [heuristic — needs practitioner check; cited as an institutional rule of thumb, not a universal standard]
+- **Field sets the adjunct pay floor.** Business, STEM, and law adjuncts average roughly $75/hour versus ~$48/hour in humanities and social science (AAUP 2024-25 economic status data) — a real number to bring into a per-course rate negotiation, not a guess.
+
+## Decision framework
+
+1. **Classify the decision first**: is this a pedagogy call inside your own remit, a faculty-qualification/accreditation compliance question that belongs to the chair, or a compensation/load question governed by the appointment letter? Many disputes stall because they're argued as one when they're actually another.
+2. **For a new or revised course, build the discussion architecture before the reading list** — the sequence of questions and the students they're aimed at (see playbook.md §1 for a filled example).
+3. **Before adjusting a grading curve or standard, pull the department's and your own section's GPA/A-rate history for the last 3-5 years** and compare both to the 2020 national baseline (3.15 GPA, 42% A) rather than to how the current class feels.
+4. **When an SET score arrives, apply the bias adjustment (principle #4) before benchmarking it against the department average**, and flag cross-gender comparisons explicitly in any file where the score is used for a personnel decision.
+5. **When negotiating load, rate, or a research buyout, anchor to comparable numbers** — the ~40/40/20 vs ~80/20 split, the field-specific adjunct rate, or a peer institution's per-credit schedule — rather than opening from an unanchored ask.
+6. **For a tenure-track publication plan, name the target list (UTD24 or FT50) explicitly with the committee** before investing years of output that may not count toward the list that matters.
+
+## Tools & methods
+
+- **Case-method discussion leadership** (Christensen Center for Teaching & Learning pedagogy): pre-built cold-call sequencing and question architecture, calibrated against real-time class response.
+- **AACSB faculty-qualification tracking** (principle #1): a running per-discipline count of SA/PA/SP/IP status, checked before any hiring or role-reclassification decision.
+- **SET-instrument design with anti-bias language**: rewriting evaluation-prompt wording per published intervention studies (principle #4) — a mitigation tool, not a scoring adjustment.
+- **Grade-distribution tracking against baseline** (decision framework step 3), run at grading-policy-setting time rather than only when a complaint arrives.
+- **Journal-tier list selection** (UTD24 or FT50) as an explicit, named research-planning artifact, not an implicit assumption.
+
+## Communication style
+
+To a department chair: percentages and named thresholds (AACSB SA/PA/SP/IP status, teaching-hour compliance, credit-hour load) — compliance language, not pedagogy language. To a reappointment or merit committee: SET scores stated with their bias-adjusted read (principle #4) and grade distribution against baseline, so no raw number stands alone. To students on grading: the standard being held and why, not an apology for a curve that didn't move. To peers on case teaching: the specific question sequence and where it was designed to flex, not a general description of "good discussion."
+
+## Common failure modes
+
+- **Giving tenure-track career advice by default** (principle #2) — miscalibrates what a given faculty member's next move should be.
+- **Reading an SET score at face value**, especially across a gender line, without applying the bias adjustment (principle #4) before a personnel conversation.
+- **Treating a rising class GPA as evidence of better teaching** without the baseline check (decision framework step 3).
+- **Overcorrection after learning the case method**: scripting every minute of every class with no room left for an unplanned teachable moment, which defeats the actual skill Christensen describes.
+- **Chasing publication output without naming a target list**, producing years of papers that satisfy neither the UTD24 nor the FT50 committee reading the file.
+
+## Worked example
+
+**Situation.** A third-year, tenure-track assistant professor (female) in a management department is preparing her third-year reappointment packet. Her SET average this year is 3.6/5.0 against a department average of 4.1/5.0. Her sections' average GPA is 3.05 with a 34% A-rate; the department average is 3.35 GPA with a 46% A-rate. The chair's note in the file: "SET below department average and grading noticeably harder than peers — a concern for reappointment."
+
+**Naive read.** Both numbers point the same direction: teaching quality below peers, and out of step on standards. A generalist reappointment letter would recommend a "teaching improvement plan" and softer grading to bring both numbers toward the department mean.
+
+**Expert reasoning.**
+
+*SET gap:* the documented instructor-gender bias in SET studies runs ~0.50 points on a 5-point scale. 3.6 + 0.50 = 4.10 — that reconciles exactly with the department average of 4.1. The entire gap is within the range the bias literature would predict from gender alone; there is no residual gap left to explain by teaching quality.
+
+*Grade gap:* the department's 3.35 GPA sits 0.20 above the 2020 national four-year average of 3.15 — consistent with continued grade-inflation drift beyond even that national figure. Her 3.05 sits only 0.10 below the 2020 national average and well above the 1990 national average of 2.81. She is not an outlier low grader against any external benchmark; the department is the outlier high one.
+
+**Deliverable (reappointment memo, as filed):**
+
+> **Re: Third-year reappointment — teaching and grading record**
+>
+> SET average of 3.6/5.0 is 0.5 points below the department's 4.1/5.0. Published randomized-instructor-gender research finds an instructor-gender SET bias of approximately 0.5 points on a 5-point scale. Adding that offset back (3.6 + 0.5 = 4.1) accounts for the entire observed gap; there is no residual difference in this record attributable to teaching quality.
+>
+> Section GPA of 3.05 (34% A) is 0.30 below the department's 3.35 (46% A) but only 0.10 below the 2020 national four-year average of 3.15 (42% A), and well above the 1990 national average of 2.81. The department's average, not this record, is the one running ahead of the national baseline.
+>
+> **Recommendation:** evaluate this record against bias-adjusted SET and against the national grade-distribution baseline rather than the unadjusted department averages, and adopt anti-bias evaluation-prompt language department-wide next cycle — published intervention studies show this raises ratings for female instructors specifically with no change for male instructors.
+
+The point made to the committee: a 0.5-point SET gap and a 0.30-GPA gap look like two problems pointing the same direction, but one fully reconciles with a documented, quantified bias and the other reconciles with the department's own drift above a national baseline — neither is evidence against this instructor.
+
+## Going deeper
+
+- [references/playbook.md](references/playbook.md) — load when designing a case-discussion sequence, setting a grading-policy calendar, or drafting a load/buyout negotiation.
+- [references/red-flags.md](references/red-flags.md) — load when a reappointment, merit, or accreditation-compliance file needs a quick smell test.
+- [references/vocabulary.md](references/vocabulary.md) — load when a term in an AACSB, AAUP, or journal-ranking conversation needs the practitioner meaning, not the dictionary one.
+
+## Sources
+
+- AACSB, *2020 Business Accreditation Standards* — SA/PA/SP/IP faculty-qualification categories, 40%/90% thresholds, ≥75%/≥60% participating-faculty teaching-hour thresholds, 5-year SA currency window.
+- AAUP, "Data Snapshot: Tenure and Contingency in US Higher Education, Fall 2023" — 68% contingent, 49% part-time, and the 1987 comparison figures.
+- AAUP, 2024-25 Annual Report on the Economic Status of the Profession — business/STEM/law vs. humanities/social-science adjunct hourly-pay differential (~$75 vs. ~$48).
+- C. Roland Christensen, Louis B. Barnes, Abby J. Hansen, *Teaching and the Case Method* (Harvard Business School Press); HBS Christensen Center for Teaching & Learning — case-method discussion-leadership description and named seminars.
+- Springer, *Journal of Academic Ethics* (2024) and related PMC meta-analyses — ~0.50-point instructor-gender SET bias magnitude and the authoritativeness/warmth scoring-criteria split.
+- UT Dallas Naveen Jindal School of Management, *UTD Top 100 Business School Research Rankings* (UTD24 list); Financial Times FT50 list — competing journal-tier lists used in tenure decisions.
+- University of Kansas School of Business teaching-load policy; general institutional teaching-load guidance (~40/40/20 tenure-track vs. ~80/20 teaching-track split) — cited as an institutional rule of thumb, not a universal standard. [heuristic — needs practitioner check]
+- gradeinflation.com (Stuart Rojstaczer national GPA dataset) and BestColleges 2024 research summary — 1990-2020 national GPA and A-rate trend, by-discipline economics figure.
+- No direct business-teacher-postsecondary practitioner has reviewed this file yet — flag corrections or gaps via PR.

--- a/roles/business-teacher-postsecondary/references/playbook.md
+++ b/roles/business-teacher-postsecondary/references/playbook.md
@@ -1,0 +1,127 @@
+# Business Teacher, Postsecondary — Playbook
+
+Filled templates for the five recurring artifacts this role produces. Populate the tables in place; do not restate the reasoning already covered in `SKILL.md`.
+
+## 1. Case-discussion board plan
+
+Built before class, not improvised in it. Five-column plan for an 80-minute session on a standard HBS-style case (here: a pricing decision case, second-year MBA).
+
+| Time | Question | Target student(s) | Anticipated response | Fallback move |
+|---|---|---|---|---|
+| 0:00–0:08 | "Take 60 seconds — what decision does [protagonist] have to make by Friday?" cold call on a student who has not spoken in 3 classes | Row 14, back-left (rotating cold-call list, not volunteers) | Restates the case facts, not the decision | If facts-only: "That's what happened — what does she have to *decide*?" one re-ask, then open to the row |
+| 0:08–0:20 | "Lay out the three pricing options on the board with the margin math for each" | Row 3 (assigned pre-class as board-scribe) | Gets 2 of 3 margins right, misses fixed-cost allocation | Planted teachable moment: let the board math sit wrong for 90 seconds, then ask "does anyone's number disagree with the board?" |
+| 0:20–0:35 | "Who's against Option B and why?" — deliberate polling, not sequential | Whole-section hand count, then 2 opposing cold calls | Section splits roughly 60/40 | If split is 95/5: reassign 3 pre-briefed students to argue the minority position (case-method "devil's advocate" seed, disclosed after class ends, never during) |
+| 0:35–0:55 | "What would your VP say if margin fell 200bps next quarter under Option B?" | Student who argued *for* B | Defends on volume, ignores channel-partner reaction | Bring in the channel-conflict paragraph from p.11 of the case only if nobody surfaces it unprompted by 0:45 |
+| 0:55–1:15 | Free discussion, instructor steps back, tracks board only | Whichever hands go up | — | If discussion stalls >90 seconds: reintroduce the 0:08 board math and ask what changed |
+| 1:15–1:20 | "What actually happened, and what's the one number that made the real decision?" | Cold call on someone who hasn't spoken | — | If nobody names the number: instructor states it, flags as the takeaway |
+
+**Design rule:** every question row names a target student *category* (row/rotation/pre-assigned), never "ask the class" — that is what makes this a rehearsed architecture rather than improv. The 0:55–1:15 block is the only deliberately unscripted stretch; it exists precisely so an unplanned teachable moment has room to happen.
+
+**Cold-call rotation log (excerpt, kept per section per term):**
+
+| Week | Student | Called on | Volunteered same week |
+|---|---|---|---|
+| 3 | J. Alvarez | Yes | No |
+| 3 | R. Chen | No | Yes |
+| 4 | J. Alvarez | No | No |
+| 5 | J. Alvarez | Yes | No |
+
+Threshold: a student unreached by cold call for 4+ consecutive sessions moves to the top of next week's rotation regardless of the day's plan.
+
+## 2. AACSB faculty-qualification tracker
+
+Refreshed every hiring cycle and before any accreditation self-study checkpoint. Department: Management (9 FTE).
+
+| Faculty | Terminal degree year | Status | SA expiry | Currency activity on file |
+|---|---|---|---|---|
+| Faculty A | 2019 (PhD) | SA | 2024 | — (still in window) |
+| Faculty B | 2016 (PhD) | SA → lapsed | 2021 | None filed — reclassify to IP pending 2 peer-reviewed submissions or documented consulting hours |
+| Faculty C | 2011 (DBA) | SP | n/a | 40 hrs/yr executive-education delivery, logged |
+| Faculty D | industry, no terminal degree | PA | n/a | 120 hrs/yr client advisory, logged |
+| Faculty E | 2022 (PhD) | SA | 2027 | — |
+| Faculty F | industry, no terminal degree | IP | n/a | Teaching-only appointment, no research/practice currency required |
+| Faculty G | 2015 (PhD) | IP | n/a | SA currency lapsed >5 yrs ago, reclassified, no new filing since |
+| Faculty H | industry, no terminal degree | PA | n/a | 80 hrs/yr client advisory, logged |
+| Faculty I | industry, no terminal degree | PA | n/a | 60 hrs/yr executive-education delivery, logged |
+
+**Threshold check run against this table:**
+- SA count: A, B, E = 3 of 9 = 33% → **below the 40% discipline floor**. Faculty B is still counted here because the reclassification to IP hasn't been finalized; if it is finalized without a replacement SA hire, the count drops to 2 of 9 (22%). Action: either fast-track Faculty B's currency documentation or the next open line must be SA, not PA/IP, regardless of who interviews best.
+- SA+PA+SP+IP combined: 9 of 9 = 100% → clears the 90% combined floor with margin.
+- Participating-faculty teaching-hour share: pull separately from the course-assignment sheet; combined status alone does not certify this.
+
+**Decision rule:** run this table *before* posting a req, not after a preferred candidate is identified — the percentage should shape the job ad's required qualifications, not get reverse-justified around a hire already in mind.
+
+## 3. Grading-policy calendar and GPA audit
+
+Run once per academic year, before syllabus finalization for the following fall.
+
+| Year | Section GPA | Section A-rate | Dept. GPA | Dept. A-rate | National 4-yr GPA (Rojstaczer) |
+|---|---|---|---|---|---|
+| 2021 | 3.02 | 33% | 3.28 | 44% | 3.11 |
+| 2022 | 3.04 | 33% | 3.31 | 45% | 3.13 |
+| 2023 | 3.06 | 34% | 3.33 | 45% | 3.14 |
+| 2024 | 3.05 | 34% | 3.35 | 46% | 3.15 |
+
+**Step sequence:**
+1. Pull the instructor's own 3–5 year trend first — flat or slow drift is normal; a jump of ≥0.10 GPA year-over-year with no curriculum or rubric change is the trigger for step 2.
+2. Compare instructor trend to department trend over the same window — department moved +0.07 in 3 years here; instructor moved +0.03. Instructor is *not* the outlier.
+3. Compare both to the current national baseline (3.15 / 42% A, 2020 figure, re-benchmark when a newer national dataset is published).
+4. If the instructor sits ≥0.20 below the department **and** below the national baseline: document a rationale (rubric, cohort composition) before a chair conversation happens, not after.
+5. If the department sits ≥0.15 above the national baseline for 2+ consecutive years with no explanation on file: that is a department-level standards question, not raised as an individual instructor's problem.
+6. Any grading-policy change (curve, rubric weight shift, +/- grading adoption) gets logged in this same table with the term it took effect, so the next year's comparison isn't confounded by an untracked policy change.
+
+## 4. SET bias-adjustment worksheet
+
+Applied before any SET score is used in a reappointment, merit, or annual-review conversation.
+
+```
+Raw SET (5-point scale):            ______
+Documented instructor-gender bias:  0.50 (apply if instructor is a woman; literature finds
+                                      no comparable offset needed for a male instructor's score)
+Adjusted SET = Raw + 0.50 (if applicable):  ______
+Department average (unadjusted):    ______
+Gap after adjustment:               Adjusted SET − Dept average = ______
+```
+
+**Interpretation thresholds:** [heuristic — needs practitioner check; not sourced to a specific study, treat as a working convention]
+- Gap after adjustment within ±0.15 → treat as noise; no action.
+- Gap after adjustment 0.15–0.35 → note in file as "within normal section-to-section variance," cite once, move on.
+- Gap after adjustment >0.35 → warrants a specific, named cause (course level, section time slot, first-time prep) before any teaching-quality conclusion is drawn.
+- **Never apply the offset in the direction that would penalize a male instructor's score** — the published effect is a bias correction for a documented scoring asymmetry, not a symmetric adjustment.
+
+## 5. Journal-tier list decision fork
+
+Made once, explicitly, in year 1 of a tenure clock — not implicitly by whatever gets submitted first.
+
+| Factor | Choose UTD24 | Choose FT50 |
+|---|---|---|
+| Sub-field | Marketing, management, accounting, MIS-heavy | Finance, economics-adjacent, international business |
+| Department's stated committee standard | Confirm which list the P&T committee actually cites in the last 3 approved cases | Same check — this overrides personal preference |
+| Overlap journals (count toward either) | *Journal of Marketing*, *Journal of Finance*, *Accounting Review*, *MIS Quarterly* | Same four — confirm they appear on both lists in the current year's edition |
+| Non-overlap example | *Journal of Consumer Research* (UTD24-only) | *Review of Finance* (FT50-only) |
+
+**Step sequence:**
+1. Pull the department's last 3 successful tenure/promotion files and note which list each cited.
+2. If the committee has used both inconsistently, raise it explicitly at the year-1 mentoring meeting — get the answer in writing, not inferred.
+3. Map every planned working paper to a target journal on the chosen list before submission, not after a rejection.
+4. Re-check the fit annually — list membership changes edition to edition; a journal that counted in year 1 may not in year 4.
+
+## 6. Load, rate, and buyout negotiation ladder
+
+Opening position, two fallbacks, and a walk-away, anchored to named comparables — never opened unanchored.
+
+**Scenario: tenure-track faculty requesting a one-course teaching buyout to complete a grant-funded project.**
+
+| Position | Ask | Anchor cited |
+|---|---|---|
+| Opening | Buyout at 1/4 of annual base salary for one 3-credit course release | A 2-2 annual load = 2 semesters × 2 courses = 4 courses/year; one course release = 1/4 of that load |
+| Fallback 1 | Buyout at 1/8 of base, plus one course counted as "service" (grant admin) instead of pure release | If the department flags budget constraint |
+| Fallback 2 | No buyout this year; banked into next year's load as a 1-1 semester instead of 2-2 | If no current-year funds exist at all |
+| Walk-away | Decline the grant-timeline compression; propose a later grant milestone date instead | If none of the above is offered |
+
+**Comparables to cite, not invent** (see SKILL.md Mental models for the reasoning behind each — restated here only as the specific figures to plug in):
+- Teaching-track vs tenure-track load ratio (SKILL.md Mental models, teaching-track-load bullet).
+- Field-specific adjunct hourly floor (SKILL.md Mental models, adjunct-pay-floor bullet), for converting a course release into an equivalent per-course dollar figure.
+- Peer-institution per-credit-hour overload rate, pulled from the most recent CBA or peer-institution posting — always cite a specific figure from a specific document, never "market rate."
+
+**Rule:** state the anchor in the same sentence as the ask ("a 1/4 buyout, consistent with a 2-2 annual load") — an ask without a stated anchor reads as a preference, not a position.

--- a/roles/business-teacher-postsecondary/references/red-flags.md
+++ b/roles/business-teacher-postsecondary/references/red-flags.md
@@ -1,0 +1,61 @@
+# Red Flags — Business Teacher, Postsecondary
+
+### SET score gap ≥0.5 points (5-point scale) below department average, cross-gender comparison
+- **Usually means:** the documented instructor-gender SET bias (~0.5 pts) accounts for some or all of the gap, not a teaching-quality difference; second most likely is a genuinely low-enrollment or first-time-prep section dragging the average.
+- **First question:** is this a cross-gender comparison, and does adding the ~0.5-point offset back to the raw score reconcile it with the department average?
+- **Data to pull:** department SET averages broken out by instructor gender for the last 3 years, the raw SET distribution for the section in question, and the evaluation-prompt wording currently in use.
+
+### Department SA (Scholarly Academic) share under 40% in a single discipline
+- **Usually means:** a chair is about to force a hire or reclassification to hit the AACSB floor, not responding to an actual teaching gap; second most likely is that several SA-status faculty are approaching their 5-year currency expiration simultaneously.
+- **First question:** what is the exact current SA percentage from the most recent AACSB filing, and does the proposed hire change it at all?
+- **Data to pull:** the discipline's faculty roster tagged SA/PA/SP/IP with current-status dates, and the most recent AACSB Table 15-1 or equivalent self-study exhibit.
+
+### Combined SA/PA/SP/IP share under 90% overall
+- **Usually means:** the department is at or below AACSB's combined floor and a specific faculty member's status lapse is the proximate cause; second most likely is an unreported retirement or departure that hasn't been backfilled in the compliance count.
+- **First question:** which named faculty member's qualification status is closest to expiring or already lapsed?
+- **Data to pull:** per-faculty status expiration dates and the department's participating-faculty teaching-hour report for the current term.
+
+### A faculty member's SA status more than 5 years past doctorate with no publication in that window
+- **Usually means:** automatic SA currency has expired and reclassification to PA/SP is required unless documented practice activity substitutes; second most likely is an unfiled or unreviewed practice-activity log that would restore currency.
+- **First question:** what is the exact date the 5-year automatic SA window closes, and what specific activity is on file to re-demonstrate currency?
+- **Data to pull:** PhD conferral date, publication CV since conferral, and any documented practice-activity or continuing-education log submitted to the department.
+
+### Participating-faculty teaching-hour share under 60% in a discipline
+- **Usually means:** the department is near or below AACSB's participating-faculty hour threshold independent of the SA/PA headcount math; second most likely is heavy reliance on adjuncts classified as "supporting" rather than "participating."
+- **First question:** what fraction of this discipline's credit hours this term were taught by participating- vs. supporting-status faculty?
+- **Data to pull:** credit-hour-by-instructor-status report for the discipline for the current and prior term.
+
+### Section or department A-rate rising more than 5 percentage points year-over-year with no curriculum change
+- **Usually means:** the grading standard drifted (looser curve, easier assignments) rather than teaching or student quality improving; second most likely is a genuine shift in section composition (e.g., more upper-level majors self-selecting in).
+- **First question:** what changed in assignment design, curve policy, or exam difficulty between the two terms being compared?
+- **Data to pull:** 3-5 year section-level GPA/A-rate history and a syllabus/assignment-weighting diff across the two terms.
+
+### Department average GPA sitting more than 0.2 above the 2020 national four-year baseline of 3.15
+- **Usually means:** the department itself is the outlier running ahead of national grade-inflation trends, not any single instructor being measured against it; second most likely is a discipline-specific effect (e.g., a service course with unusually lenient grading norms).
+- **First question:** has anyone benchmarked the department average against the national and discipline-specific baseline, or only measured individual instructors against the department mean?
+- **Data to pull:** the national GPA/A-rate trend dataset (e.g., gradeinflation.com), and the department's own 5-year GPA/A-rate history.
+
+### Contingent or part-time faculty member given tenure-track career or publication advice
+- **Usually means:** tenure-track norms are being misapplied to someone inside the 68%-contingent majority whose appointment doesn't carry a research expectation; second most likely is genuine ambiguity in the appointment letter about research/service split.
+- **First question:** what does this person's actual appointment letter say about research and service expectations?
+- **Data to pull:** the appointment letter, contract type (full-time instructional, part-time adjunct, tenure-track), and the person's participating-faculty classification.
+
+### Teaching-track course load proposed at the same count as tenure-track (e.g., 2-2)
+- **Usually means:** a title or contract change occurred without an actual load adjustment, undermining the ~80/20 teaching/service split the role is supposed to carry versus tenure-track's ~40/40/20; second most likely is a transitional term where load hasn't caught up to the new appointment type yet.
+- **First question:** what is this institution's documented teaching/research/service split for this specific appointment type, and does the proposed load match it?
+- **Data to pull:** the institutional teaching-load policy document and comparable-role load history for the last 3 years.
+
+### Adjunct rate offered below roughly $48/hour for a business course
+- **Usually means:** the rate was anchored to a generic or humanities benchmark instead of the AAUP field-specific business/STEM/law figure (~$75/hour); second most likely is a stale rate schedule that hasn't been updated against the current AAUP report.
+- **First question:** what is this institution's peer-group hourly rate specifically for business, STEM, or law adjuncts, not a blended average across all fields?
+- **Data to pull:** the current AAUP Annual Report on the Economic Status of the Profession and peer-institution per-credit-hour schedules.
+
+### Multi-year publication record with no journal-tier list named to the committee
+- **Usually means:** the candidate has been producing output that may satisfy neither the UTD24 nor the FT50 list, risking a tenure denial on a list-mismatch technicality rather than a quality shortfall; second most likely is a committee that hasn't formally recorded which list governs this candidate's file.
+- **First question:** has the candidate and the committee named UTD24 or FT50 in writing as the governing list for this review?
+- **Data to pull:** the candidate's publication list cross-classified against both the UTD24 and FT50 rankings, and any committee memo naming the target list.
+
+### SET score entered into a reappointment or merit file with no bias annotation
+- **Usually means:** the raw number will be read at face value by a committee unfamiliar with the ~0.5-point instructor-gender bias literature; second most likely is that the annotation exists elsewhere but wasn't carried into this specific file.
+- **First question:** has the ~0.5-point bias offset been noted alongside the raw score for any cross-gender comparison in this file?
+- **Data to pull:** the draft personnel file, and department SET averages broken out by instructor gender for the comparison period.

--- a/roles/business-teacher-postsecondary/references/vocabulary.md
+++ b/roles/business-teacher-postsecondary/references/vocabulary.md
@@ -1,0 +1,107 @@
+# Vocabulary — Business Teacher, Postsecondary
+
+Terms practitioners use in a specific, load-bearing sense that a generalist reader tends to flatten into its everyday meaning. Load when an AACSB, AAUP, or journal-ranking conversation needs the practitioner meaning, not the dictionary one.
+
+### Participating faculty
+
+AACSB's designation for faculty whose ongoing intellectual contributions and engagement with the discipline are current enough to count toward the ≥60% teaching-hour threshold — a status tied to demonstrated activity, not to full-time employment status.
+
+**In use:** "She's full-time, but her participating status lapsed last year — her hours don't count toward the discipline's 60% floor until she files a new currency activity."
+
+**Misuse note:** Generalists treat "participating faculty" as a synonym for "full-time faculty" or "faculty who show up to meetings." A full-time instructor can be non-participating, and a part-time adjunct with an active consulting practice can be participating — the term tracks demonstrated currency, not employment category or attendance.
+
+### Currency (faculty qualification currency)
+
+The AACSB requirement that a faculty member's SA/PA/SP/IP status be actively re-earned through publication or documented practice activity within a rolling window, not permanently conferred at hire.
+
+**In use:** "His SA currency expires in 2025 — he needs a publication or a documented consulting log on file before then, or he reclassifies to IP automatically."
+
+**Misuse note:** Generalists assume a PhD confers permanent "qualified" status, the way a law license doesn't expire for inactivity. Currency is a clock that resets only with fresh, documented activity — a faculty member can go quiet for five years and lose status even though the degree itself never changes.
+
+### SA / PA / SP / IP (faculty-qualification categories)
+
+AACSB's four portfolio buckets — Scholarly Academic, Practice Academic, Scholarly Practitioner, Instructional Practitioner — that classify every faculty member for accreditation-compliance counting, each with different qualifying activity and different threshold math (40% SA per discipline, 90% combined).
+
+**In use:** "We can hire the industry practitioner, but only if it doesn't drop our SA percentage below 40% in this discipline — check the math before the search committee falls in love with the candidate."
+
+**Misuse note:** Generalists read these as a quality ranking (SA = "better," IP = "lesser") when they are a compliance classification describing a different qualifying pathway, not a hierarchy of teaching or scholarly ability. A department can — and by design should — staff a mix; an all-SA department can itself violate other AACSB balance expectations.
+
+### Cold call (case method)
+
+A pre-assigned, rotation-tracked question directed at a specific student chosen before class, as part of a designed discussion architecture — not a random, put-someone-on-the-spot gotcha.
+
+**In use:** "J. Alvarez is due for a cold call this week — she's gone four sessions without being reached, and the rotation log says she's next regardless of today's lesson plan."
+
+**Misuse note:** Generalists picture cold-calling as spontaneous intimidation improvised in the moment. In case-method practice it is logged, rotated, and planned days in advance against a tracked list — the opposite of spontaneous, and abandoning the rotation to "keep students on their toes" defeats its actual design purpose.
+
+### Teachable moment (planted vs. organic)
+
+In case-method design, a deliberately engineered gap or wrong answer built into the discussion plan (e.g., letting incorrect board math sit for 90 seconds before probing it) as distinct from an unplanned moment the instructor recognizes and follows in real time.
+
+**In use:** "The board-math error at 0:08–0:20 is planted — we let it sit, then ask who disagrees. The 0:55–1:15 block is the only genuinely open stretch, reserved for whatever comes up organically."
+
+**Misuse note:** Generalists hear "teachable moment" and assume pure improvisation, then either over-script every minute or claim credit for spontaneity in a moment that was actually planted. A strong session plan names which is which in advance.
+
+### Journal-tier list (UTD24 / FT50)
+
+One of two specific, named, competing journal-ranking lists (UT Dallas's UTD24 or the Financial Times FT50) that a business school's tenure and promotion committee cites as the governing standard for what "counts" — chosen explicitly, in writing, rather than assumed.
+
+**In use:** "Confirm with the committee now whether this file is being read against UTD24 or FT50 — three of the four journals on your CV only clear one of the two lists."
+
+**Misuse note:** Generalists treat "top journal" as a single, obvious, universally agreed category. The two lists disagree on real, high-quality journals (a paper in *Journal of Consumer Research* counts on UTD24 but not FT50), so a candidate can accumulate a strong publication record that satisfies neither committee's actual list if the list was never named up front.
+
+### Tenure clock
+
+The fixed, contractually defined number of years (commonly six, with a review typically at year three) before a mandatory up-or-out tenure decision — a deadline, not a general sense of "seniority building up over time."
+
+**In use:** "The buyout would compress two years of the tenure clock into one grant cycle — that's the actual constraint, not just 'she's busy.'"
+
+**Misuse note:** Generalists use "tenure clock" loosely to mean accumulating experience or good standing. It is a hard deadline with a specific stop-the-clock mechanism (parental leave, documented hardship) that has to be formally invoked — informally "being understanding" about someone being busy does not pause it.
+
+### Course buyout
+
+A negotiated exchange of teaching-release time for salary or grant funds, priced against a specific fraction of annual base salary (commonly 1/4 for one course under a 2-2 load, since 2-2 = 4 courses/year) — a budget transaction with a named formula, not simply "getting time off."
+
+**In use:** "The grant will fund a one-course buyout at 1/4 of her base — that's the standard conversion for a 2-2 load, not a number we're inventing for this case."
+
+**Misuse note:** Generalists hear "buyout" and think of severance or an exit package. In this context it means the opposite — the faculty member stays and keeps the appointment, and only the teaching assignment for that term is reduced, funded by an explicit dollar figure tied to the load fraction it replaces.
+
+### Course load notation (e.g., "2-2," "4-4")
+
+Shorthand for the number of courses taught per term across an academic year (2 courses in fall, 2 in spring), used to compare appointment types — not a raw hours-per-week figure.
+
+**In use:** "Tenure-track here runs 2-2; full-time instructional faculty run roughly 4-4 — so a teaching-track hire carrying the same 2-2 as tenure-track is already underloaded relative to that appointment type's norm."
+
+**Misuse note:** Generalists read "2-2" as a light load in absolute terms without knowing what it's being compared against — the same notation format hides a large difference in what fraction of the job teaching represents across appointment types.
+
+### SET (Student Evaluation of Teaching) bias adjustment
+
+The practice of applying a documented, quantified offset (~0.5 points on a 5-point scale, favoring perceived-male instructors) to a raw student evaluation score before using it in a personnel decision — a correction with a specific direction and magnitude, not a general "consider context" caveat.
+
+**In use:** "Her raw SET is 3.6; add the 0.5-point documented offset and it reconciles exactly with the department average of 4.1 — there's no residual gap left to attribute to teaching quality."
+
+**Misuse note:** Generalists treat "evaluations have some bias" as a vague hedge applied symmetrically or skipped entirely. Applying it in the opposite direction, to a same-gender comparison, or without a number turns a quantified correction into an unfalsifiable excuse.
+
+### Grade drift vs. grade inflation
+
+"Drift" describes a department's or discipline's multi-year GPA trend measured against its own history and a national baseline; "inflation" is the specific, contested claim that the drift reflects loosened standards rather than improved student performance or cohort composition — practitioners keep the measurement and the causal claim separate.
+
+**In use:** "The department's GPA moved from 3.28 to 3.35 over three years — that's the drift. Whether that's inflation depends on whether assignment rigor or cohort selection changed, which we haven't checked yet."
+
+**Misuse note:** Generalists use the two terms interchangeably, treating any upward GPA movement as proof of loosened standards. A practitioner reports the drift number against a named baseline first and treats "inflation" as a separate, evidence-requiring claim about cause, not a synonym for the trend itself.
+
+### Reappointment vs. tenure review
+
+Two distinct, differently governed personnel events for a tenure-track faculty member — a periodic (often third-year) continuation check against progress-to-date, versus the terminal up-or-out decision at the end of the tenure clock — with different evidentiary standards and different stakes.
+
+**In use:** "This is a third-year reappointment file, not a tenure file — the standard is 'making satisfactory progress,' not 'meets the full bar,' and the committee should be evaluating it as such."
+
+**Misuse note:** Generalists conflate the two and either panic over a reappointment file as if it were a terminal denial, or treat a tenure file with the lighter "progress" standard a reappointment review actually uses — misreading which standard applies changes what evidence is even relevant.
+
+### Practice activity (currency-qualifying)
+
+Documented, logged professional engagement (consulting hours, executive-education delivery, industry board service) that substitutes for publication in maintaining PA/SP/IP qualification currency — activity that must be specifically logged and dated, not just generally "staying involved in industry."
+
+**In use:** "He has 120 hours of client advisory work logged this year — that's what's keeping his PA status current, not the fact that he mentions his old consulting job in class."
+
+**Misuse note:** Generalists assume any real-world business background counts indefinitely. AACSB currency requires activity within the current review window, documented and dated — a faculty member's impressive 20-year-old career doesn't substitute for a currency log with nothing filed in the last few years.


### PR DESCRIPTION
Rubric score: 18/18

## Resolution rationale

Business Teachers, Postsecondary (O*NET 25-1011.00) covers case-method instruction in management/marketing/finance/accounting/business law at 4-year and graduate business programs, governed by AACSB (or ACBSP) accreditation standards, with credentialing ties (CPA exam pass rates for accounting tracks, CFA/PMP alignment for finance/ops tracks) and pedagogy (Harvard-style case method, business-plan/consulting capstones with real firms) that none of the three candidates cover. career-technical-education-teacher-postsecondary is the closest structural analog (accountability-indicator-driven, credential-backward-mapped) but is scoped to Perkins V-funded trade/health-science shop-and-lab programs (NIMS/ASE/NOCTI credentials, OSHA shop safety, work-based-learning hour logs) — a business faculty member is not Perkins-funded, has no shop/lab safety-compliance floor, and backward-maps to CPA/AACSB assurance-of-learning standards rather than industry skill checklists. communications-teacher-postsecondary (basic-course speech pedagogy, PRCA-24, rhetorical criticism) and criminal-justice-teacher-postsecondary (crime-rate methodology, IRB Subpart C, ride-along liability) share no decision framework, tool, or failure mode overlap at all. Applying the counterfactual/non-derivability tests to granularity: an agent given the CTE candidate would misapply Perkins 4S1/3S1 indicators and NIMS/ASE credential mapping to a discipline that isn't Perkins-eligible and doesn't have third-party skill-exam blueprints in the same sense — wrong guidance, not just less detail. No reasonable parent exists among the three candidates, so this should be a new top-level leaf/parent role rather than nested under any of them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new role for Business Teachers, Postsecondary (O*NET 25-1011.00) with a full spec and references, and updates counts/coverage to reflect the new role. This increases O*NET coverage and fills a gap in the Educational Instruction and Library category.

- **New Features**
  - Added `roles/business-teacher-postsecondary/SKILL.md` plus references: `playbook.md`, `red-flags.md`, `vocabulary.md`.
  - Registered role in `data/roles.json` (`slug`: `business-teacher-postsecondary`, spec 2, status active, `us`).
  - Updated `README.md` totals: 829 roles drafted (819 O*NET mapped); O*NET coverage 80.6% (819/1,016); `other` category now 174.
  - Updated `ROADMAP.md`: progress 819/1016; Educational Instruction and Library 56/68; marked 25-1011.00 as drafted with link.

<sup>Written for commit 518805fd6e974fdb1788028628faf693d946a1b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

