### PR TITLE
role: add chemistry-teacher-postsecondary

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**828 roles drafted** (818 mapped to an O*NET occupation, 10 custom; 786 at spec 2, 42 awaiting upgrade), across 10 categories:
+**829 roles drafted** (819 mapped to an O*NET occupation, 10 custom; 787 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `████████████████░░░░` 80.5% (818 / 1,016 occupations)
+**O\*NET coverage:** `████████████████░░░░` 80.6% (819 / 1,016 occupations)
 
 - **design**: 14
 - **engineering**: 127
@@ -212,7 +212,7 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 - **legal**: 21
 - **marketing**: 8
 - **operations**: 289
-- **other**: 173
+- **other**: 174
 - **product**: 1
 - **sales**: 17
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 818 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 819 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -365,7 +365,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>25 — Educational Instruction and Library</strong> (55/68 drafted)</summary>
+<summary><strong>25 — Educational Instruction and Library</strong> (56/68 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -378,7 +378,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 | ✅ | 25-1042.00 | Biological Science Teachers, Postsecondary | [`biology-professor`](./roles/biology-professor/SKILL.md) |
 | ✅ | 25-1043.00 | Forestry and Conservation Science Teachers, Postsecondary | [`forestry-conservation-teacher-postsecondary`](./roles/forestry-conservation-teacher-postsecondary/SKILL.md) |
 | ✅ | 25-1051.00 | Atmospheric, Earth, Marine, and Space Sciences Teachers, Postsecondary | [`geoscience-professor`](./roles/geoscience-professor/SKILL.md) |
-|  | 25-1052.00 | Chemistry Teachers, Postsecondary |  |
+| ✅ | 25-1052.00 | Chemistry Teachers, Postsecondary | [`chemistry-teacher-postsecondary`](./roles/chemistry-teacher-postsecondary/SKILL.md) |
 | ✅ | 25-1053.00 | Environmental Science Teachers, Postsecondary | [`environmental-science-professor`](./roles/environmental-science-professor/SKILL.md) |
 | ✅ | 25-1054.00 | Physics Teachers, Postsecondary | [`physics-teacher-postsecondary`](./roles/physics-teacher-postsecondary/SKILL.md) |
 | ✅ | 25-1061.00 | Anthropology and Archeology Teachers, Postsecondary | [`anthropology-archaeology-professor`](./roles/anthropology-archaeology-professor/SKILL.md) |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 828,
+  "count": 829,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -2404,6 +2404,27 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/chemist/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "chemistry-teacher-postsecondary",
+      "description": "Use when a task needs the judgment of a Postsecondary Chemistry Teacher \u2014 redesigning a gen-chem or organic course to cut DFW rates, writing or auditing a lab-safety/Chemical Hygiene Plan response, curving an exam against ACS National Norms, drafting an undergrad/grad research mentoring compact, adjudicating a suspected contract-cheating case, or reviewing a degree track against ACS CPT certification requirements.",
+      "category": "other",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "25-1052.00",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/chemistry-teacher-postsecondary/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/roles/chemistry-teacher-postsecondary/SKILL.md
+++ b/roles/chemistry-teacher-postsecondary/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: chemistry-teacher-postsecondary
+description: Use when a task needs the judgment of a Postsecondary Chemistry Teacher — redesigning a gen-chem or organic course to cut DFW rates, writing or auditing a lab-safety/Chemical Hygiene Plan response, curving an exam against ACS National Norms, drafting an undergrad/grad research mentoring compact, adjudicating a suspected contract-cheating case, or reviewing a degree track against ACS CPT certification requirements.
+metadata:
+  category: other
+  maturity: draft
+  spec: 2
+  onet_soc_code: "25-1052.00"
+---
+
+# Postsecondary Chemistry Teacher
+
+## Identity
+
+Accountable for two things that pull against each other in the same semester: keeping a chemical laboratory a place students survive and learn in, and keeping the failure/withdrawal rate from quietly filtering students — disproportionately first-generation and underrepresented ones — out of the major before they get a real shot at it.
+
+## First-principles core
+
+1. **A lab-safety decision is never advisory — it is the one call in the job with a documented criminal precedent.** The 2008 death of UCLA research assistant Sheri Sangji during a tert-butyllithium transfer led to Cal/OSHA fines, four felony charges against the supervising professor, and a standing requirement that safety-inspection deficiencies be corrected within 48 hours. "Be safety-conscious" is not a policy; a written Chemical Hygiene Plan enforced through Recognize-Assess-Minimize-Prepare (RAMP) is.
+2. **DFW rate, not the grade curve, is the real instrument reading on course design.** Nationally just under 30% of first-semester gen-chem students earn a D, F, or W; of those, 49% change majors and roughly 80% of that group leaves STEM entirely. A course that "covers the material" while running a 30%+ DFW rate is filtering students, not teaching them.
+3. **ACS program certification is a tiered bar, not a checklist.** The Committee on Professional Training (CPT) separates critical requirements for approval (400 clock hours of classroom chemistry, 500 of formal lab, five ABIOP foundation courses) from normal expectations and markers of excellence — treating the third tier as mandatory over-builds a program while under-resourcing what actually gates approval.
+4. **A pedagogical technique's published win is conditional on what it actually changed, not on citing the study.** Flipped-classroom organic sections have shown both a jump to 77% average with fewer withdrawals, and, at another institution, no improvement at all over two prior traditional-format years — the difference was whether class time was restructured into active engagement or lecture was merely relocated to video.
+5. **Mentoring a research student is two separate agreements, not one relationship.** The day-to-day working terms — communication cadence, independence level, lab-meeting participation — belong in a mentoring compact; long-term career direction belongs in an Individual Development Plan. Collapsing them into one undocumented "checking in" leaves both underspecified.
+
+## Mental models & heuristics
+
+- **When a DFW rate sits at or above 20% in a required gateway course, or has risen more than 5 points year over year, default to stacking active learning, a core-concepts curriculum, low-stakes assessment, and direct instructor intervention together (the four-lever bundle)** — the one documented case that reached a ~5% DFW rate combined all four; any single lever alone is not shown to get there.
+- **When evaluating POGIL for organic or gen chem, default to 3–6 student teams and expect broad satisfaction (fewer than 8% negative in a 1,000+-student, 7-institution survey), but flag it separately for English-language learners** — a 2024 study found POGIL creates its own engagement barrier for that group, so "the literature likes it" is not a blanket clearance.
+- **When someone proposes flipping a lecture course, ask what specifically moves into class time before crediting the idea** — if the answer is "the same lecture, just watched at home first," expect the "reality check" result (no improvement), not the 77%-average result.
+- **When curving a gen-chem final, curve against the ACS Exams Institute's National Norms percentile bands (roughly 80th–100th = A, 60th–79th = B, 40th–59th = C, 20th–39th = D, 0th–19th = F) after deselecting weak items** — this is a reproducible technique, not an arbitrary distribution fit to the room.
+- **When staffing multi-section gen-chem or lab sequences, plan around a contingent-labor base rate, not a tenure-line default** — nationally, non-tenure-track faculty are roughly 70–73% of postsecondary instructional positions [heuristic — needs practitioner check; no chemistry-department-specific figure located].
+- **When an exam is delivered remotely or hybrid, treat a question answered on a file-sharing site inside the live exam window as the forensic signal, not answer similarity alone** — STEM contract-cheating requests rose 196% comparing pre- and post-shift-to-remote exam periods, and the timing of the post relative to the exam clock is what similarity-checking software misses.
+- **When starting a new research mentee, run the compact/IDP split (First-principles core #5) through CIMER's "Entering Mentoring" and "Entering Research" curricula** — the standard trained-facilitator materials for running each conversation, not a single generic onboarding chat.
+
+## Decision framework
+
+1. **Screen for a live safety question first.** If hazard exposure is possible, apply RAMP and check the Chemical Hygiene Plan before any instructional or scheduling decision proceeds — a lab session does not run on a deficiency that hasn't been corrected.
+2. **Name the actual metric before proposing a fix.** For a course-design question, pull the DFW rate and the downstream major-switch rate, not the section-average grade, so the diagnosis targets attrition rather than optics.
+3. **Locate the decision on the CPT tier structure.** Ask whether the requirement in question is a critical approval gate (clock hours, course coverage) or a discretionary marker of excellence, so effort isn't spent hitting a non-binding bar while a binding one slips.
+4. **Choose the intervention with a named mechanism, and state what changes in the room.** Prefer the four-lever bundle (Mental models above) over a repackaging move, and be explicit about which of those levers is actually being pulled.
+5. **Separate the mentoring conversation from the career conversation** when a research-supervision issue surfaces, and diagnose which document (compact vs. IDP) is actually missing or being violated before treating it as a personality conflict.
+6. **Corroborate any integrity concern with a timing or process signal**, not similarity alone, before escalating to an academic-integrity case.
+7. **Document the rationale at the tier it belongs to** so adjunct and GTA staff inherit a defensible standard rather than an instructor's ad hoc call.
+
+## Tools & methods
+
+- RAMP (see vocabulary.md) layered under a written, currently-dated Chemical Hygiene Plan — the operative safety-risk method, distinct from CPT curriculum requirements.
+- ACS Exams Institute National Norms with item selection/deselection to re-derive a local percentile-to-letter curve.
+- POGIL-structured team activities (3–6 students) for gateway and organic sections.
+- ACS Committee on Professional Training self-study and tiered-requirement review for degree-track certification.
+- A written mentoring compact plus a separate IDP, run through CIMER's "Entering Mentoring" (mentor-facing) and "Entering Research" (mentee-facing) curricula.
+
+## Communication style
+
+To a CPT reviewer or department chair: precise clock-hour and course-count figures against the tier structure (First-principles core #3), not aspirational language about program quality. To colleagues discussing a DFW problem: leads with the rate and who it falls on — nonwhite, lower-SES, non-native-English-speaking, transfer, and first-generation students disproportionately — before the aggregate number. To a research mentee: name which of the two conversations (compact or IDP) is happening before starting it. To administration on a safety deficiency: a correction deadline and the RAMP status, not a general expression of concern.
+
+## Common failure modes
+
+- **Overcorrection on the four-lever bundle:** having learned that partial adoption underperforms, mandating all four levers for every gateway section regardless of what the baseline packet (playbook.md Step 1) actually shows is missing — turning a targeted fix (e.g., the section is missing only low-stakes assessment) into an unnecessary full-course overhaul.
+- **Overcorrection on the CPT tier structure:** having learned that markers of excellence are discretionary, refusing to invest in any of them even when all critical and normal rows are already met and resourcing exists — treating the tier as a ban rather than a priority order.
+- **Overcorrection on RAMP:** applying full incident-level risk-assessment paperwork to routine, previously-vetted procedures with no new hazard, rather than reserving RAMP's depth for a genuinely new or changed procedure.
+- **Overcorrection on the compact/IDP split:** treating "two separate documents" as a mandate for two separate meetings scheduled months apart, rather than two documents that can be drafted in the same sitting once the mentee relationship starts — confusing document separation with a scheduling requirement.
+- Assuming every DFW spike is a course-design problem and skipping the section-to-section spread check (playbook.md Step 1), missing an instructor- or cohort-specific cause the aggregate rate hides.
+- Escalating an academic-integrity suspicion straight to pulling exam-window timestamps before confirming a triggering similarity or behavioral flag exists at all — running an evidentiary step that isn't warranted yet.
+
+## Worked example
+
+**Setup.** Four sections of first-semester gen chem, 240 students total, DFW rate 31% last year (74 students earned D, F, or W). A newly hired adjunct proposes flipping all four sections next term, citing a JCE study showing flipped organic sections averaging 77% versus a lower traditional-format control.
+
+**Naive read.** Adopt the flip across all four sections next term; the published number is positive, and it is low-cost to implement (assign the same lecture as pre-recorded video, keep in-class time otherwise unchanged).
+
+**Expert reasoning.** The 77% result and the "reality check" null result differ on exactly one variable: whether class time was restructured into active engagement or lecture was simply relocated to video with no other change. This proposal, as stated, only relocates the lecture — it is closer to the null-result condition. Quantify the cost of treating a relocation as a fix: at the current 31% DFW rate, 74 of 240 students fail, withdraw, or drop below passing; nationally 49% of DFW students change majors (≈36 of the 74), and roughly 80% of those leave STEM entirely (≈29 students). A relocation-only flip that doesn't move the DFW rate leaves that attrition chain intact. The documented path to material DFW reduction is the four-lever bundle — one institution's DFW fell from over 30% to about 20% adopting it, and the best documented case reached roughly 5%. Recommend piloting the full bundle in one section before rolling out a lecture-relocation-only flip to all four.
+
+**Deliverable — memo to the department chair.** "Recommend against a straight flip of all four gen-chem sections next term as proposed. The cited 77%-average result comes from sections that restructured class time into active engagement; the proposal in front of us relocates the same lecture to video without changing in-class activity, which matches the condition that produced no improvement in a comparable study. At our current 31% DFW rate, roughly 74 of this year's 240 students will fail, withdraw, or drop below passing; national data puts 49% of those switching majors and about 80% of that group leaving STEM — call it 29 students a section-level tweak needs to actually move. Propose piloting the full four-lever bundle in one section this fall, tracking DFW rate against the other three sections as a control, before committing all four sections to a flip next year."
+
+## Going deeper
+
+- [Playbook](references/playbook.md) — course-redesign and DFW-triage sequencing, safety-incident response checklist, and the ACS CPT tier worksheet.
+- [Red flags](references/red-flags.md) — smell tests for course, lab, and integrity problems: what each usually means, the first question to ask, the data to pull.
+- [Vocabulary](references/vocabulary.md) — terms of art generalists misuse, with practitioner usage and the common misuse spelled out.
+
+## Sources
+
+- ACS Committee on Professional Training, *ACS Guidelines and Evaluation Procedures for Bachelor's Degree Programs* (2023) — source for the 400/500 clock-hour figures, five-ABIOP-course requirement, and the critical/normal/excellence tier structure.
+- Sheri Sangji case: consolidated account (Wikipedia), C&EN "10 years after Sheri Sangji's death," and Science/AAAS retrospective — source for the fine, felony charges, and UCLA's 48-hour correction requirement.
+- Robert H. Hill & David C. Finster, *Laboratory Safety for Chemistry Students* — origin of the RAMP framework; ACS Committee on Chemical Safety, *Safety in Academic Chemistry Laboratories* (8th ed.) — reinforces RAMP as field standard alongside a written Chemical Hygiene Plan.
+- *Journal of Chemical Education*, "What Moves the Needle on DFW Rates and Student Success in General Chemistry? A Quarter-Century Perspective" (2023), and *Science Advances* "hyperpersistent zone" study (2020) — source for national DFW rate, the ~30%-to-~20%-to-~5% progression, the 49%/80% major-switch figures, and the disproportionate-impact framing.
+- *Journal of Chemical Education*, "A Review of Research on Process Oriented Guided Inquiry Learning" (2020) and JCE POGIL implementation studies (2013, 2024) — source for team-size, the 7-institution/1,000+-survey satisfaction figure, and the 2024 English-language-learner caveat.
+- ACS Exams Institute (uwm.edu/acs-exams) National Norms documentation — source for the percentile-to-letter-grade curving convention.
+- AAUP, *Background Facts on Contingent Faculty Positions*; CCSSE, *Bringing Part-Time Faculty Into Focus*; GAO-18-49 — source for the ~70–73% contingent-faculty figure (cross-discipline, not chemistry-specific).
+- Springer, *International Journal for Educational Integrity*, "Contract cheating by STEM students through a file sharing website: a Covid-19 pandemic perspective" (2021) — source for the 196% contract-cheating request increase and the exam-window timing signal.
+- *Journal of Chemical Education* flipped-classroom organic chemistry studies (2017, 2024) including the "reality check" null-result study — source for both the 77%-average result and the contradicting negative result.
+- CIMER (Center for the Improvement of Mentored Experiences in Research); NASEM, *The Science of Effective Mentorship in STEMM* — source for the mentoring-compact/IDP distinction and the "Entering Mentoring"/"Entering Research" curricula.
+- Enrichment pass complete as of 2026; no direct practitioner sign-off on the role definition as a whole — flag via PR if you can confirm, correct, or add a citation.

--- a/roles/chemistry-teacher-postsecondary/references/playbook.md
+++ b/roles/chemistry-teacher-postsecondary/references/playbook.md
@@ -1,0 +1,80 @@
+# Playbook — Postsecondary Chemistry Teacher
+
+Filled sequences for the three recurring executed processes: DFW-rate triage on a gateway course, a lab-safety-incident response, and an ACS CPT tier self-study pass. Populate the tables directly; do not restate the reasoning already in `SKILL.md`.
+
+## 1. DFW-triage sequence (gateway course redesign)
+
+Run this whenever a required course's DFW rate is at or above 20%, or has risen more than 5 points year over year.
+
+**Step 1 — Pull the baseline packet (before any redesign conversation).**
+
+| Metric | This course, last 3 terms | Trigger |
+|---|---|---|
+| DFW rate (D+F+W / enrolled) | 31%, 28%, 33% | ≥20% → proceed to Step 2 |
+| Major-switch rate among DFW students | not tracked locally; use national 49% as placeholder | flag if no local figure exists |
+| Withdrawal timing (median week) | week 9 of 15 | week ≤6 → assessment-timing problem; week ≥9 → cumulative-load problem |
+| Section-to-section DFW spread | 24%–38% across 4 sections | spread >10 points → instructor/section effect, not course-level |
+| Demographic breakdown (first-gen, URM, transfer vs. continuing) | first-gen DFW 41% vs. continuing 22% | gap >15 points → equity flag, escalate to Step 2 regardless of headline rate |
+
+**Step 2 — Classify the proposed fix before approving it.**
+
+| Proposed change | Classify as | Approve as-is? |
+|---|---|---|
+| Pre-recorded lecture + unchanged in-class time | Relocation (low-evidence) | No — pilot only, 1 section, DFW-tracked against control |
+| Pre-recorded lecture + in-class problem-solving/POGIL teams | Restructuring (evidence-backed) | Yes — full bundle candidate |
+| Curve adjustment only | Cosmetic | No — does not change DFW, reject or redirect to Step 3 |
+| Added office hours / supplemental instruction only | Partial lever | Conditional — pair with at least one more lever before crediting |
+
+**Step 3 — Assemble the four-lever bundle. Missing any two or more of these means don't claim the ~20% or ~5% DFW outcomes as the target.**
+
+1. Active learning restructuring of in-class time (not just video relocation)
+2. Core-concepts curriculum (trimmed to threshold concepts, not full historical topic list)
+3. Low-stakes formative assessment (weekly or more frequent, low point value)
+4. Direct instructor intervention on flagged students (contact within 2 weeks of first missed/failed assessment)
+
+**Step 4 — Pilot, don't roll out cold.**
+
+- One section runs the full bundle; remaining sections serve as control for one term minimum.
+- Decision gate at end of term: pilot DFW rate must beat control by ≥5 points to justify full rollout next year. Below that, revise the bundle implementation before scaling — do not scale on a null or marginal result.
+- Track median withdrawal week alongside DFW rate; a bundle that only delays withdrawal (pushes median from week 6 to week 10) without lowering the rate has not solved the problem.
+
+**Step 5 — Write the rollout memo only after Step 4's gate is met.** Template:
+
+> Pilot section ([N] students) ran [bundle components] for [term]. DFW rate: [pilot%] vs. [control%] control average, a [delta]-point reduction. Median withdrawal week: [X] vs. [Y]. Recommend [full rollout / revise-and-repilot] for [next term], with [specific staffing/training need] as the resourcing ask.
+
+## 2. Lab-safety-incident response checklist
+
+Trigger: any exposure, near-miss, spill above bench-scale, or a scheduled inspection finding a deficiency.
+
+| Step | Action | Deadline | Owner |
+|---|---|---|---|
+| 1 | Stop the procedure; secure the area; render first aid / call EHS emergency line | Immediate | Instructor of record present at time |
+| 2 | File incident report (or deficiency log entry) in the department EHS system | Within 24 hours | Instructor of record |
+| 3 | Cross-check the incident/deficiency against the current Chemical Hygiene Plan — is this a known hazard already covered, or a gap? | Within 24 hours | Instructor of record + department safety officer |
+| 4 | Correct the deficiency (equipment, SOP, PPE, training) | Within 48 hours (the standing UCLA-precedent benchmark) | Department safety officer |
+| 5 | If correction cannot be completed in 48 hours, suspend the affected procedure/section rather than run on an open deficiency | Immediate upon missing the 48-hour mark | Department chair |
+| 6 | Re-run RAMP (Recognize, Assess, Minimize, Prepare) on the corrected procedure before resuming | Before next scheduled use | Instructor of record |
+| 7 | Document closure: what was found, what changed, sign-off date | Within 5 business days of Step 1 | Department safety officer |
+
+**Escalation fork:** any incident involving a controlled substance, a reportable exposure (per institutional EHS threshold), or a repeat deficiency (same finding twice in 12 months) routes to the department chair and institutional EHS office in parallel with Step 2, not after.
+
+## 3. ACS CPT tier worksheet
+
+Use before a self-study submission or a curriculum-change proposal, to confirm effort is going to the binding tier first.
+
+| Tier | Requirement (fill with current program numbers) | Program status | Gap (if any) |
+|---|---|---|---|
+| Critical (approval gate) | ≥400 clock hours classroom chemistry | e.g., 412 hours | none |
+| Critical (approval gate) | ≥500 clock hours formal laboratory | e.g., 468 hours | −32 hours — must close before next self-study |
+| Critical (approval gate) | Five ABIOP foundation courses (Analytical, Biochemistry, Inorganic, Organic, Physical) covered | e.g., 4 of 5 (no standalone Analytical) | missing course — critical, not deferrable |
+| Normal expectation | Research experience requirement, seminar participation | e.g., met | none |
+| Normal expectation | Advising ratio, library/instrumentation access | e.g., met | none |
+| Marker of excellence | Undergraduate research publication rate, external funding involvement | e.g., partially met | non-binding — do not prioritize over the ABIOP gap above |
+
+**Decision rule:** any unmet Critical-tier row blocks certification regardless of how many Marker-of-excellence rows are exceeded. Resolve Critical gaps first; log Marker-of-excellence gaps as multi-year goals in the self-study narrative, not as urgent fixes.
+
+**Self-study submission order:**
+1. Confirm all Critical rows first — pull the registrar's clock-hour report and the current course catalog against the five ABIOP areas.
+2. Confirm Normal-expectation rows — advising ratios, library holdings, instrumentation inventory.
+3. Only then document Marker-of-excellence evidence (placement outcomes, funding, publication rates) as supporting narrative, not as a substitute for an unmet Critical row.
+4. Route the completed worksheet through the department chair before CPT submission; a Critical-tier gap discovered after submission is a certification risk, not a paperwork fix.

--- a/roles/chemistry-teacher-postsecondary/references/red-flags.md
+++ b/roles/chemistry-teacher-postsecondary/references/red-flags.md
@@ -1,0 +1,51 @@
+# Red flags — Postsecondary Chemistry Teacher
+
+### Gateway-course DFW rate at or above 20% for two consecutive terms
+- **Usually means:** the course is running on lecture-and-curve inertia rather than a designed intervention — most commonly a traditional-lecture format with high-stakes-only assessment, less often a genuine cohort/prep mismatch.
+- **First question:** which of the four levers — active learning, core-concepts curriculum, low-stakes formative assessment, direct instructor intervention — is actually present in this section, and which are missing?
+- **Data to pull:** section-by-section DFW rate for the last 3 terms, broken out by instructor and by delivery format (lecture-only vs. active-learning-flagged).
+
+### A safety-inspection deficiency still open past the 48-hour correction window
+- **Usually means:** either the deficiency was logged but not escalated to whoever controls the budget/schedule to fix it, or it was judged low-risk by someone without authority to make that call.
+- **First question:** who signed off on continuing lab operations past the 48-hour mark, and under what documented risk assessment?
+- **Data to pull:** the Chemical Hygiene Plan inspection log and the date-stamped correction record for the specific deficiency.
+
+### A flipped-classroom proposal where "flip" means recorded lecture, unchanged in-class time
+- **Usually means:** the proposer is citing the positive JCE result (77% average) without checking whether their own redesign matches its actual independent variable — restructured active engagement, not relocated video.
+- **First question:** what specifically happens in the room now that didn't happen before — not what moved out of the room?
+- **Data to pull:** the proposed class-time activity plan, compared line-by-line against the cited study's described in-class protocol.
+
+### An instructor grading a gen-chem final on a curve fit to the room's distribution
+- **Usually means:** the instructor is unaware of, or bypassing, the ACS Exams Institute National Norms percentile bands — often to avoid an uncomfortable number of D/F grades in a weak-performing section.
+- **First question:** was this exam scored against the National Norms percentile bands after weak-item deselection, or against this section's own distribution?
+- **Data to pull:** the ACS Exams Institute norm table for the specific exam form used, and the raw score-to-percentile mapping applied.
+
+### POGIL adopted department-wide with no disaggregation by student subgroup
+- **Usually means:** the department is relying on the aggregate satisfaction figure (under 8% negative, 1,000+-student survey) without checking the 2024 finding that POGIL creates a distinct engagement barrier for English-language learners.
+- **First question:** has anyone pulled satisfaction or performance data for ELL students separately from the aggregate?
+- **Data to pull:** end-of-term POGIL feedback surveys, filtered by ELL/international-student status if the registrar codes it.
+
+### Non-tenure-track instructors staffing at or above roughly 70–73% of gateway sections [heuristic — needs practitioner check; no chemistry-department-specific figure located]
+- **Usually means:** the department has drifted to the national contingent-labor base rate without a deliberate staffing decision — often because adjunct hiring is the path of least resistance for enrollment growth, not a chosen model.
+- **First question:** was this staffing ratio a planning decision, or the accumulated result of section-by-section hiring under enrollment pressure?
+- **Data to pull:** the department's instructional-staffing roster by rank for gateway and lab sections over the last 3 years.
+
+### A degree track short of the CPT critical-tier clock hours (400 classroom / 500 formal lab) or missing an ABIOP foundation course
+- **Usually means:** program effort went into CPT's normal-expectation or excellence-marker items — research opportunities, seminar series — while a critical approval gate went unaudited.
+- **First question:** does the current curriculum map actually total 400 classroom and 500 lab clock hours across the five ABIOP areas, counted course by course?
+- **Data to pull:** the degree-track curriculum map with clock-hour totals per course, cross-walked against the CPT self-study worksheet.
+
+### An exam answer found on a file-sharing site with a post timestamp inside the live exam window
+- **Usually means:** contract cheating via a file-sharing site — the timing signal (post during the exam clock) is the corroborating evidence that similarity-checking software alone won't surface.
+- **First question:** what is the exact timestamp of the post relative to the individual student's exam start and end time?
+- **Data to pull:** the LMS exam-session log (start/submit times for the student in question) and the file-sharing site's post timestamp/metadata.
+
+### A research mentee relationship running on undocumented "check-ins" past the first month
+- **Usually means:** the mentoring compact (day-to-day working terms) and the IDP (career direction) were never separated into two conversations, so neither is actually specified — surfaces later as a conflict that looks personal but is a missing-document problem.
+- **First question:** is there a written compact, a written IDP, or neither — and which one does the current friction actually trace to?
+- **Data to pull:** the mentee's file for a signed mentoring compact and IDP document; absence of either is the finding.
+
+### A department reporting an aggregate DFW number with no major-switch or STEM-attrition follow-up
+- **Usually means:** the course-design conversation is stopping at the optics-friendly aggregate rate instead of tracking where DFW students actually go (see First-principles core #2 in SKILL.md for the national major-switch/STEM-attrition figures this smell test is checking for).
+- **First question:** of this term's D/F/W students, how many have since changed major or dropped a STEM designation, tracked at 1 and 2 semesters out?
+- **Data to pull:** registrar major-change records for the DFW cohort, matched by student ID across the following two terms.

--- a/roles/chemistry-teacher-postsecondary/references/vocabulary.md
+++ b/roles/chemistry-teacher-postsecondary/references/vocabulary.md
@@ -1,0 +1,99 @@
+# Vocabulary
+
+Terms of art in postsecondary chemistry teaching, lab safety, and program administration, with the misuse a generalist commonly makes.
+
+### DFW rate
+
+The percentage of students in a course who earn a D, F, or W (withdrawal) — the standard course-attrition metric, distinct from the average grade or the pass rate.
+
+**In use:** "The section average looks fine at a B-minus, but the DFW rate is 31% — nearly a third of the roster isn't finishing with a passing, retained grade."
+
+**Common misuse:** Citing the average grade or the percentage of A/B grades as evidence a course is working, while the DFW rate — which captures the students actually being filtered out — goes unexamined.
+
+### RAMP (Recognize, Assess, Minimize, Prepare)
+
+The ACS-endorsed operational framework for lab safety decisions: recognize the hazard, assess the risk, minimize it through controls, and prepare for what happens if control fails — distinct from a Chemical Hygiene Plan, which is the written document RAMP operates under.
+
+**In use:** "RAMP says we prepare for a failure mode, not just minimize the routine risk — so we still need the blast shield even though the transfer procedure itself is low-risk."
+
+**Common misuse:** Treating RAMP as a synonym for "be careful" or general safety awareness, rather than a four-step method that has to be worked through explicitly for a specific procedure.
+
+### Chemical Hygiene Plan (CHP)
+
+The written, facility-specific, currently-dated document required under OSHA's Laboratory Standard that documents hazard controls, training, and correction procedures for a lab — the enforceable instrument RAMP is layered under.
+
+**In use:** "That's not a training gap to raise at the next meeting — it's a Chemical Hygiene Plan deficiency, and it needs to be corrected inside the standing 48-hour window."
+
+**Common misuse:** Treating a documented CHP deficiency as an informal to-do item rather than a compliance failure with a correction deadline — the distinction that follows directly from the post-Sangji regulatory precedent.
+
+### ACS National Norms (percentile bands)
+
+The ACS Exams Institute's national percentile-to-letter-grade conversion bands (roughly 80th–100th = A, 60th–79th = B, and so on), derived from item-level national performance data on a specific standardized exam form.
+
+**In use:** "We curve against National Norms after deselecting the two ambiguous items, not against however this particular room happened to perform."
+
+**Common misuse:** Treating "curving the exam" as fitting a bell curve to the class's own score distribution, rather than anchoring grades to the externally validated national percentile bands for that specific exam form.
+
+### ACS CPT tier structure (critical / normal / excellence)
+
+The Committee on Professional Training's three-level structure for degree-certification requirements: critical requirements are non-negotiable approval gates (clock hours, ABIOP course coverage), normal expectations are the standard bar, and markers of excellence are discretionary strengths — not a flat checklist where every item carries equal weight.
+
+**In use:** "The undergraduate research requirement is a marker of excellence, not a critical gate — don't reallocate lab-hour budget away from the 500-hour requirement to build it out."
+
+**Common misuse:** Treating all three tiers as equally mandatory, which leads to over-investing in discretionary strengths while a binding requirement — like clock hours — goes unmet.
+
+### POGIL (Process Oriented Guided Inquiry Learning)
+
+A specific structured pedagogy using 3–6 student teams working through designed activities with assigned roles, distinct from generic "group work" or "active learning" in the abstract.
+
+**In use:** "We're running POGIL, which means assigned team roles and a designed inquiry sequence — not just moving the desks into pods and calling it collaborative."
+
+**Common misuse:** Using "POGIL" as a loose synonym for any small-group activity, and citing the broad POGIL satisfaction literature without checking the 2024 finding that it creates a distinct engagement barrier for English-language learners.
+
+### Flipped classroom
+
+A course redesign where content delivery moves outside class time specifically so that class time can be restructured into active engagement — the mechanism is the in-class restructuring, not the act of pre-recording a lecture.
+
+**In use:** "Calling this a flip because the lecture is now a video doesn't tell me whether class time changed — what are students doing in the room now that they weren't doing before?"
+
+**Common misuse:** Treating "assign the lecture as video homework" as sufficient to count as a flipped classroom and to claim its published gains, when the studies showing no improvement describe exactly that — relocation without in-class restructuring.
+
+### Mentoring compact
+
+A written agreement covering the day-to-day working terms of a research relationship — communication cadence, independence level, lab-meeting expectations — distinct from an Individual Development Plan, which covers long-term career direction.
+
+**In use:** "The compact covers how often we meet and how much independent troubleshooting I expect before you escalate — the IDP is a separate conversation about where you want to be in five years."
+
+**Common misuse:** Treating one informal "let's check in" conversation as covering both documents, leaving working logistics and career planning both underspecified and undocumented.
+
+### Individual Development Plan (IDP)
+
+A separate document from the mentoring compact, focused on a research trainee's long-term career goals and the milestones toward them, produced through a distinct facilitated conversation (CIMER's "Entering Research" curriculum on the mentee-facing side).
+
+**In use:** "We haven't done an IDP conversation yet — the compact we signed only covers lab logistics, not where this fits in your career plan."
+
+**Common misuse:** Conflating the IDP with a syllabus, a project timeline, or the mentoring compact itself, rather than treating it as its own document produced through its own conversation.
+
+### ABIOP courses
+
+The five foundational subject areas — Analytical, Biochemistry, Inorganic, Organic, Physical chemistry — that ACS CPT certification requires a program to cover as part of its critical clock-hour requirements, not a suggested distribution.
+
+**In use:** "We're short on the inorganic ABIOP hours specifically — that's a critical-tier gap, not something the excellence-tier electives can offset."
+
+**Common misuse:** Treating ABIOP coverage as satisfied by rough topical overlap across existing courses, rather than checking it against the specific hour and course-count requirements CPT audits.
+
+### Contract cheating (exam-window timing signal)
+
+Academic-integrity violations involving outsourced answers, identified in a remote-exam context not by post-submission similarity alone but by whether a question appears on a file-sharing site during the live exam window — a timing signal similarity-detection software does not capture.
+
+**In use:** "The similarity score alone doesn't make the case — what makes it is that the question was posted to the file-sharing site four minutes after the exam opened."
+
+**Common misuse:** Building an academic-integrity case solely on answer-similarity percentages, without corroborating it against the timing of when a question appeared on an outside site relative to the exam clock.
+
+### Core-concepts curriculum
+
+A gateway-course redesign that reduces content to a smaller set of foundational ideas revisited with increasing depth, one specific lever in the documented DFW-reduction bundle — not a synonym for "simplifying" or "covering less material" in general.
+
+**In use:** "The core-concepts redesign is one of four levers in the bundle — swapping it in alone, without the active-learning and low-stakes-assessment pieces, isn't the same intervention the ~5%-DFW case used."
+
+**Common misuse:** Treating any content-trimming exercise as equivalent to the documented core-concepts approach, and expecting the same DFW result without also implementing the other three levers it was combined with.


### PR DESCRIPTION
## Rubric score

18/18

## Resolution rationale

Applying the granularity test to Decision framework/Tools/Worked example (not just depth): none of the three candidates transfer without giving actively wrong guidance to a chemistry-teacher-postsecondary practitioner. architecture-teacher-postsecondary's whole apparatus is NAAB Student Criteria, design-jury rubric calibration, and the NCARB AXP/ARE licensure pipeline — none of that exists in chemistry; a chemistry program is accredited by ACS (undergraduate program approval), not NAAB, and there is no analogous post-degree licensure exam a chemistry teacher advises students onto. business-teacher-postsecondary's decision framework runs on AACSB SA/PA/SP/IP faculty-qualification percentages and UTD24/FT50 journal-tier tenure lists and case-method pedagogy — a chemistry department's tenure case runs on ACS-journal/NSF-grant productivity and lab-based pedagogy, and AACSB categories don't apply at all, so following that framework would misdirect a chemistry chair's hiring/tenure math. career-technical-education-teacher-postsecondary's entire tool set (Perkins V 4S1 credential-attainment indicator, NIMS/NOCTI/ASE industry credentials, general-industry OSHA 1910 shop safety, advisory-committee curriculum veto) is built for trade/health-science programs judged by placement and third-party industry credentials — a bachelor's/grad-track chemistry program is not a Perkins V CTE program, isn't backward-mapped to NIMS/ASE blueprints, and its lab safety regime is OSHA's Laboratory Standard (29 CFR 1910.1450, Chemical Hygiene Plan) rather than the general-industry lockout/tagout/PPE standard cited there — a real, not cosmetic, safety-framework difference. Each of the three fails the counterfactual/non-derivability test as a parent: an agent following any of their frameworks would reach for the wrong accrediting body, wrong credentialing artifact, wrong safety regulation, and wrong tenure metric for a chemistry professor. The repo already treats postsecondary science/discipline teaching as its own granularity tier (physics-teacher-postsecondary, math-teacher-postsecondary, environmental-science-professor, geoscience-professor, health-sciences-professor, computer-science-professor, economics-teacher-postsecondary, history-teacher-postsecondary, political-science-professor, family-consumer-sciences-teacher-postsecondary, criminal-justice-teacher-postsecondary, communications-teacher-postsecondary, agricultural-sciences-professor, forestry-conservation-teacher-postsecondary, library-science-professor exist as siblings, not children of one another), confirming chemistry-teacher-postsecondary belongs as a new sibling top-level role (O*NET 25-1052.00), not nested under architecture/business/CTE teaching.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a first-class `chemistry-teacher-postsecondary` role (O*NET 25-1052.00) with a spec-2 skill profile and references so chemistry tasks get ACS/CPT-accurate guidance. Updates README/ROADMAP counts and O*NET coverage.

- **New Features**
  - Registered `chemistry-teacher-postsecondary` in `data/roles.json` with US jurisdiction.
  - Added `SKILL.md` with decision framework: RAMP + Chemical Hygiene Plan, DFW reduction bundle, ACS CPT tiering, ACS Exams National Norms, mentoring compact vs. IDP, POGIL/flipped checks, and a worked example.
  - Added references: playbook (DFW triage, safety-incident checklist, CPT worksheet), red flags, and vocabulary.
  - Updated README and ROADMAP: +1 role (829 total), O*NET coverage 80.6%, category and checklist entries marked complete.

<sup>Written for commit f1c751d228f8fd27bcbe22fbeb1080a60c021252. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

