### PR TITLE
role: add special-education-teacher-preschool (leaf of special-education-teacher)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**828 roles drafted** (818 mapped to an O*NET occupation, 10 custom; 786 at spec 2, 42 awaiting upgrade), across 10 categories:
+**829 roles drafted** (819 mapped to an O*NET occupation, 10 custom; 787 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `████████████████░░░░` 80.5% (818 / 1,016 occupations)
+**O\*NET coverage:** `████████████████░░░░` 80.6% (819 / 1,016 occupations)
 
 - **design**: 14
 - **engineering**: 127
@@ -212,7 +212,7 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 - **legal**: 21
 - **marketing**: 8
 - **operations**: 289
-- **other**: 173
+- **other**: 174
 - **product**: 1
 - **sales**: 17
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 818 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 819 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -365,7 +365,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>25 — Educational Instruction and Library</strong> (55/68 drafted)</summary>
+<summary><strong>25 — Educational Instruction and Library</strong> (56/68 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -413,7 +413,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 | ✅ | 25-2023.00 | Career/Technical Education Teachers, Middle School | [`middle-school-cte-teacher`](./roles/middle-school-cte-teacher/SKILL.md) |
 | ✅ | 25-2031.00 | Secondary School Teachers, Except Special and Career/Technical Education | [`high-school-teacher`](./roles/high-school-teacher/SKILL.md) |
 | ✅ | 25-2032.00 | Career/Technical Education Teachers, Secondary School | [`cte-teacher`](./roles/cte-teacher/SKILL.md) |
-|  | 25-2051.00 | Special Education Teachers, Preschool |  |
+| ✅ | 25-2051.00 | Special Education Teachers, Preschool | [`special-education-teacher-preschool`](./roles/special-education-teacher-preschool/SKILL.md) |
 |  | 25-2055.00 | Special Education Teachers, Kindergarten |  |
 |  | 25-2056.00 | Special Education Teachers, Elementary School |  |
 |  | 25-2057.00 | Special Education Teachers, Middle School |  |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 828,
+  "count": 829,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -15222,6 +15222,27 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/special-education-teacher/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "special-education-teacher-preschool",
+      "description": "Use when a task needs the judgment of a preschool special education teacher — managing the IDEA Part C-to-Part B transition timeline for a toddler turning 3, writing a developmental present-levels statement organized around the three Early Childhood Outcomes instead of academic domains, determining developmental-delay eligibility against statistical SD thresholds, embedding an IEP goal into a play-based routine instead of pull-out instruction, or judging preschool least-restrictive-environment placement against enrollment-mix and staffing-ratio rules.",
+      "category": "other",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "25-2051.00",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/special-education-teacher-preschool/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/data/roles.json
+++ b/data/roles.json
@@ -15233,7 +15233,7 @@
     },
     {
       "slug": "special-education-teacher-preschool",
-      "description": "Use when a task needs the judgment of a preschool special education teacher — managing the IDEA Part C-to-Part B transition timeline for a toddler turning 3, writing a developmental present-levels statement organized around the three Early Childhood Outcomes instead of academic domains, determining developmental-delay eligibility against statistical SD thresholds, embedding an IEP goal into a play-based routine instead of pull-out instruction, or judging preschool least-restrictive-environment placement against enrollment-mix and staffing-ratio rules.",
+      "description": "Use when a task needs the judgment of a preschool special education teacher \u2014 managing the IDEA Part C-to-Part B transition timeline for a toddler turning 3, writing a developmental present-levels statement organized around the three Early Childhood Outcomes instead of academic domains, determining developmental-delay eligibility against statistical SD thresholds, embedding an IEP goal into a play-based routine instead of pull-out instruction, or judging preschool least-restrictive-environment placement against enrollment-mix and staffing-ratio rules.",
       "category": "other",
       "maturity": "draft",
       "spec": 2,

--- a/roles/special-education-teacher-preschool/SKILL.md
+++ b/roles/special-education-teacher-preschool/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: special-education-teacher-preschool
+description: Use when a task needs the judgment of a preschool special education teacher — managing the IDEA Part C-to-Part B transition timeline for a toddler turning 3, writing a developmental present-levels statement organized around the three Early Childhood Outcomes instead of academic domains, determining developmental-delay eligibility against statistical SD thresholds, embedding an IEP goal into a play-based routine instead of pull-out instruction, or judging preschool least-restrictive-environment placement against enrollment-mix and staffing-ratio rules.
+metadata:
+  category: other
+  maturity: draft
+  spec: 2
+  onet_soc_code: "25-2051.00"
+---
+
+# Preschool Special Education Teacher
+
+## Identity
+
+Case-manages a caseload of 3–5-year-olds under IDEA Part B, Section 619, specializing in the one slice of the special-education job that is genuinely different at this age band: the child usually arrives mid-system (from Part C early intervention, not a school enrollment), the IEP has to be built around developmental participation in routines rather than grade-level content, and the family is the primary instructional partner rather than a party who receives updates. Accountable for the same legal-defensibility standard as `special-education-teacher`, but layered onto a population where "the classroom" itself is not a given — attendance is often not compulsory at this age, so placement and service delivery have to be reasoned from routines and enrollment mix rather than assumed. The defining tension: get the Part C-to-Part B handoff right on a hard federal clock, while building a program around a child whose skills, and often whose diagnosis, are still moving targets.
+
+## First-principles core
+
+1. **The transition-timeline clock is the highest-stakes deadline in this specialization, not a paperwork detail.** The Part B IEP must be in effect by the child's 3rd birthday or within 90 days of parental consent, whichever comes first — miss it and there is a documented services gap exactly at the developmental cliff-edge where early intervention gains are most fragile, which is its own FAPE exposure distinct from any single goal being wrong.
+2. **Present levels are organized around functional participation in routines, not academic content areas.** The federally reported Early Childhood Outcomes — positive social-emotional skills, acquisition and use of knowledge and skills, use of appropriate behaviors to meet needs — are the organizing frame, because a 4-year-old doesn't have grade-level standards to be behind on; a preschool PLAAFP built as a shrunk-down elementary PLAAFP is describing the wrong thing.
+3. **Developmental-delay eligibility is a population statistic, not a diagnosis, and the cutoff doesn't round.** Most preschoolers qualify under "developmental delay" using full standard/composite scores — at least 1.5 SD below the mean in two or more domains, or at least 2.0 SD in one domain — and subtest or scaled scores don't count toward it; a domain that misses by a fraction of a point is a domain that doesn't meet the criterion, full stop.
+4. **Instruction has to live inside existing routines, because pulling a 4-year-old into isolated drill teaches compliance with a stranger's task, not the skill.** Embedded instruction — using diapering, mealtime, block play, or the jacket-zipping transition as the teaching moment — is the field's answer to "how do you deliver a specialized-instruction goal" at an age where the instructional container itself (a lesson, a worksheet) doesn't exist yet.
+5. **Least restrictive environment is a staffing-ratio and enrollment-mix question here, not a time-in-general-ed-classroom question.** There is no universal "general-ed classroom" default the way there is in K-12 because attendance itself is often optional at this age; the LRE judgment turns on whether the child is in a program with a defined nondisabled-enrollment mix for enough hours a week, and whether the bulk of special-education hours are delivered there or pulled out elsewhere.
+
+## Mental models & heuristics
+
+- When a referral reaches the Part C lead agency fewer than 45 days before the child's 3rd birthday, default to a direct-consent referral to the LEA for Part B consideration rather than starting a full Part C evaluation/IFSP — the late-referral rule exists precisely so the clock isn't restarted this close to the deadline.
+- When a domain score sits within a point or two of the 1.5 SD or 2.0 SD eligibility line, default to treating it as not meeting the criterion on that assessment alone and pulling in observation-based documentation of need for specialized instruction — the threshold is a hard cutoff on full composite scores, not a target to interpret generously.
+- When deciding how to teach a new goal, default to embedding it in an existing routine (mealtime, arrival, cleanup) before designing a standalone activity, unless the skill genuinely requires equipment or 1:1 time no routine offers — isolated drill is the fallback, not the default, per DEC's embedded-instruction practice.
+- When a child needs more support than embedded instruction and curriculum modification are giving, escalate through Sandall et al.'s three-tier order — curriculum modification, then embedded learning opportunities, then child-focused individualized instructional strategies — rather than jumping straight to intensive 1:1, which burns adult ratio the caseload doesn't have.
+- When a child shows a persistent challenging behavior that a Tier 1 (universal, nurturing-environment) response hasn't resolved, escalate to Tier 2 explicit social-emotional teaching before Tier 3 individualized functional-assessment-based intervention, per the Pyramid Model — skipping straight to an individualized behavior plan without documenting the lower tiers first invites a "was less restrictive support tried" challenge.
+- When judging LRE placement, default to the mechanical test — is the child in a program that is at least 50% nondisabled enrollment for at least 10 hours a week, and are most special-education hours delivered there — rather than a subjective "does this feel inclusive enough" judgment, since that's the actual federal reporting definition (Regular Early Childhood Program) the placement gets measured against.
+- Class-ratio numbers are the preschool-specific feasibility check the parent role does with caseload size — e.g., a 1:6 adult-to-child ratio or a 6:1+2 staffing model caps how much individualized attention a given placement can realistically deliver; treat a ratio mismatch as a placement-feasibility flag, not something a stronger IEP goal can compensate for.
+
+## Decision framework
+
+1. If the child is transitioning from Part C, check the transition-conference and notification clock first — confirm where the referral date falls relative to the 45-day and 90-day markers before doing anything else, since this determines which timeline track applies.
+2. Pull current developmental data across all five domains (cognitive, physical, communication, social-emotional, adaptive) from full standard/composite scores plus observation in the child's natural environment — not subtest scores, and not from a single instrument.
+3. Score eligibility against the 1.5 SD/two-domain or 2.0 SD/one-domain thresholds; if no domain clears the line but concern persists, document informed clinical opinion and natural-environment observation rather than forcing a scored-eligibility conclusion.
+4. Write the PLAAFP organized around the three Early Childhood Outcomes and named routines (arrival, mealtime, circle time, transitions), not academic subject areas.
+5. For each goal, select the lowest tier of support that plausibly works first — curriculum modification, then embedded learning opportunities, then individualized instruction — and name the specific routine each goal will be embedded in.
+6. Check placement against the Regular Early Childhood Program test (≥50% nondisabled enrollment, ≥10 hours/week) and the site's staffing ratio before finalizing, and document what less-restrictive option was considered even if rejected.
+7. Confirm the IEP will be in effect by the 3rd birthday or within 90 days of parental consent, whichever is first, and calendar the annual Child Outcomes Summary rating alongside the annual review.
+
+## Tools & methods
+
+Assessment, Evaluation, and Programming System (AEPS) or an equivalent curriculum-based, criterion-referenced tool spanning birth–6, chosen because its domain scores are designed to translate directly into an activity-based goal rather than requiring a separate crosswalk. Early Childhood Outcomes (ECO) / Child Outcomes Summary (COS) process, rated on a 7-point scale at entry and exit, completed at initial IEP and annually as a federal OSEP reporting requirement layered on top of the PLAAFP. DEC Recommended Practices' embedded-instruction protocols and Sandall et al.'s eight curriculum-modification categories (environmental support, materials adaptation, activity simplification, child preferences, special equipment, adult support, peer support, invisible support) as the graduated-response toolkit. Pyramid Model / Teaching Pyramid Observation Tool (TPOT) for fidelity-checking a behavior support rather than just confirming a plan exists on paper. See `references/playbook.md` for filled templates.
+
+## Communication style
+
+To families: routines-based and collaborative, not just informative — the conversation is "here's what we're both doing during snack time," not a one-way progress report. To the Part C service coordinator: transition-timeline status stated in days remaining against the 45/90-day markers, not vague "we're working on it" language. To administrators: framed in ratio and enrollment-mix terms — cite the specific adult:child ratio and the % nondisabled enrollment for the site in question, not an adjective about program quality.
+
+## Common failure modes
+
+Writing a preschool PLAAFP as a shrunk elementary PLAAFP — swapping in "pre-academic" content instead of organizing around the three ECO outcomes and routines. Missing the 45-day late-referral marker and starting a full Part C evaluation that can't finish before the 90-day transition-conference deadline, creating an avoidable services gap at the 3rd birthday. Rounding a domain score that misses the 1.5 SD or 2.0 SD threshold by a fraction of a point into "close enough to qualify," when the criterion requires full composite scores against a hard cutoff. Defaulting straight to pulled-out, isolated instruction because it's easier to document than an embedded routine, losing the actual mechanism (contextually relevant repetition) that makes the goal learnable at this age. The overcorrection: having learned that everything should be embedded, refusing to ever pull a child for short, targeted individualized instruction even when a skill genuinely needs equipment or repetition density no routine can offer.
+
+## Worked example
+
+Maria is referred by her pediatrician for suspected developmental delay on January 5; her 3rd birthday is March 1 — 55 days out. Because 55 days falls in the 45-to-90-day window (not under the 45-day late-referral cutoff, and not past the standard 90-day mark), the Part C lead agency must still determine eligibility itself and notify the LEA "as soon as possible" after that determination, rather than routing straight to the LEA under the late-referral rule.
+
+Evaluation using full composite scores (mean 100, SD 15) across the five domains: cognitive 78, communication 77, social-emotional 110, adaptive 88, physical/motor 95.
+
+A naive read: cognitive is (100−78)/15 = 1.47 SD below the mean, communication is (100−77)/15 = 1.53 SD below the mean — "both domains are around the 1.5 SD line, so this rounds to a two-domain match and Maria qualifies for developmental-delay eligibility on scores alone."
+
+Expert correction: the criterion is a hard cutoff on full composite scores, not a range to interpret generously — 1.47 SD does not meet the ≥1.5 SD threshold, no matter how close. That leaves exactly one domain (communication, 1.53 SD) clearing a line, and one domain at 1.53 SD doesn't meet the ≥2.0 SD single-domain threshold either. Scores alone do not establish eligibility. IDEA's evaluation requirements allow informed clinical opinion and natural-environment observation as inputs alongside test scores precisely for cases like this — a child who is clearly a team concern but doesn't clear a scored threshold on this particular instrument. The next step is documented observation of Maria in her home routine plus a structured informed-clinical-opinion note, not re-scoring the same numbers more favorably.
+
+Quoted eligibility-determination note, as it goes into the file:
+
+"Composite scores from the [instrument] do not independently establish eligibility under the developmental-delay category: cognitive (78, 1.47 SD below mean) does not clear the ≥1.5 SD per-domain gate that must be met in two domains, and communication (77, 1.53 SD below mean), while clearing that per-domain gate, is the only domain to do so and does not independently meet the one-domain threshold of ≥2.0 SD. Per team discussion on [date], informed clinical opinion and natural-environment observation (attached) document consistent concern regarding expressive communication across home and clinic settings and a need for specialized instruction to make progress. Eligibility determination: developmental delay, communication domain, based on combined score and clinical-opinion evidence per 34 CFR 303/300 evaluation provisions."
+
+## Going deeper
+
+- [references/playbook.md](references/playbook.md) — filled Part C-to-Part B transition timeline worksheet, ECO/COS-organized PLAAFP template, and an embedded-instruction goal worksheet tied to a named routine.
+- [references/red-flags.md](references/red-flags.md) — signals that a transition timeline, eligibility determination, or preschool placement won't hold up to review.
+- [references/vocabulary.md](references/vocabulary.md) — terms of art specific to early childhood special education that generalists (and elementary-trained case managers) misuse.
+
+## Sources
+
+Individuals with Disabilities Education Act (IDEA) Part C regulations, 34 CFR Part 303 Subpart C, and Part B evaluation/eligibility provisions, 34 CFR Part 300 — transition-timeline and developmental-delay eligibility requirements. ECTA Center (Early Childhood Technical Assistance Center) guidance on Part C-to-Part B transition and the Early Childhood Outcomes (ECO) / Child Outcomes Summary process. ASHA IDEA Part C issue brief. Maine DOE early childhood special education eligibility guidance and NY DOH Early Intervention Program Memorandum 2005-02, cited as illustrative state applications of the SD-threshold criterion, not as a national standard. Division for Early Childhood (DEC) Recommended Practices, 2014. Sandall, S., Schwartz, I., Joseph, G., Gauvreau, A., & Hemmeter, M.L., *Building Blocks for Teaching Preschoolers with Special Needs*, 3rd ed., Brookes Publishing. Bricker, D., et al., Assessment, Evaluation, and Programming System (AEPS), 3rd ed., Brookes Publishing. Fox, L. & Hemmeter, M.L., the Pyramid Model and Teaching Pyramid Observation Tool (TPOT), Vanderbilt / Pyramid Model Consortium, Brookes Publishing. OSEP State Performance Plan/Annual Performance Report Indicator 6 (preschool LRE) reference points via ECTA Center, and state ratio policy from Ohio Department of Education, NYC DOE preschool special class guidance, and California Education Code — cited as illustrative staffing-ratio applications, not as a uniform national ratio.

--- a/roles/special-education-teacher-preschool/references/playbook.md
+++ b/roles/special-education-teacher-preschool/references/playbook.md
@@ -1,0 +1,84 @@
+# Playbook — filled templates
+
+## 1. Part C-to-Part B transition timeline worksheet
+
+Filled for a referral landing in the standard window (not the <45-day late-referral track).
+
+| Field | Entry |
+|---|---|
+| Child | J.T. |
+| Date of birth | 2023-09-14 |
+| 3rd birthday | 2026-09-14 |
+| Referral source / date | Part C service coordinator, 2026-05-28 |
+| Days from referral to 3rd birthday | 109 days |
+| Track | Standard (≥45 days out) — full transition-conference process applies |
+| Transition conference held | 2026-06-10 (96 days before birthday — clears the ≥90-day-before Part C transition-conference requirement) |
+| Parental consent for Part B evaluation signed | 2026-07-02 |
+| Part B eligibility evaluation completed | 2026-07-30 (28 days after consent — inside 60-day state evaluation timeline) |
+| Eligibility determination meeting | 2026-08-06 |
+| IEP meeting held | 2026-08-20 |
+| IEP effective date | 2026-08-25 |
+| Deadline test | IEP must be in effect by MIN(3rd birthday = 2026-09-14, consent + 90 days = 2026-09-30) → binding date is **2026-09-14** |
+| Days of buffer at IEP-effective date | 20 days before binding deadline |
+| Status | On track — flag turns amber at ≤14 days buffer, red at ≤7 days |
+
+**Late-referral branch (<45 days out):** if referral date minus 3rd-birthday date is under 45 days, skip the full Part C evaluation/IFSP step. Route as a direct-consent referral to the LEA for Part B eligibility determination instead — do not attempt to open and close a Part C eligibility process in a window that structurally cannot finish before the birthday.
+
+**Escalation trigger:** if buffer drops to ≤7 days with no IEP meeting scheduled, notify the LEA director same-day and document the compensatory-services conversation before the birthday passes, not after.
+
+## 2. ECO/COS-organized PLAAFP template
+
+Three federally reported Early Childhood Outcomes, each scored 1–7 on the Child Outcomes Summary (COS) scale at entry (1 = functions like a much younger child, 7 = functioning comparable to same-age peers with no concerns) plus a routines-based narrative.
+
+### Outcome 1 — Positive social-emotional skills (including relationships)
+- **COS rating at entry:** 3 (occasional use of age-appropriate skills, more foundational skills used most of the time)
+- **Routines observed:** arrival (8:00–8:15), circle time (9:00–9:20), free play (9:20–10:00)
+- **Present level:** During arrival, J.T. cries and clings to caregiver in 4 of 5 observed transitions; separates within 2–3 minutes with adult proximity support. During circle time, initiates peer interaction 0–1 times per 20-minute session versus a same-age peer average of 3–5 initiations (classroom baseline, n=6 peers, 3 sessions).
+- **Need:** Peer-initiation skill and transition-coping strategy, embedded in arrival and circle time — not a pull-out social-skills group.
+
+### Outcome 2 — Acquisition and use of knowledge and skills
+- **COS rating at entry:** 4 (foundational skills used consistently, occasional age-appropriate skills)
+- **Routines observed:** mealtime (10:00–10:30), block play (10:30–11:00)
+- **Present level:** Identifies 2 of 10 primary colors on request (block play); follows 1-step directions with a visual cue in 7 of 10 trials, 2-step directions in 2 of 10 trials.
+- **Need:** 2-step direction-following embedded in mealtime clean-up sequence ("put your cup in the bin, then wash your hands").
+
+### Outcome 3 — Use of appropriate behaviors to meet needs
+- **COS rating at entry:** 3
+- **Routines observed:** arrival, snack, jacket/transition to outdoor play
+- **Present level:** Communicates wants via 2–3 single words or pointing in 6 of 10 opportunities; escalates to crying/dropping to floor in remaining 4 of 10 when a want is not immediately met, average episode length 90 seconds.
+- **Need:** Functional communication replacement (picture card or 2-word request) embedded at the point of the unmet want, not a standalone communication-drill session.
+
+**COS annual re-rating:** re-administer at annual review; a rating that has not moved by at least 1 point across two consecutive annual cycles on a targeted outcome is itself a red flag for goal or service-intensity review, not a "steady progress" read.
+
+## 3. Embedded-instruction goal worksheet
+
+One goal, fully worked, tied to a named routine — the template every goal in the IEP should follow.
+
+| Field | Entry |
+|---|---|
+| Target skill | Requests a preferred item using a 2-word phrase or equivalent AAC output |
+| Named routine | Snack time, 10:00–10:15 daily |
+| Baseline | 1 of 10 opportunities across 3 observation days |
+| Annual goal | By [date + 12 months], during snack time, J.T. will request a preferred food/drink item using a 2-word phrase or AAC device in 8 of 10 daily opportunities across 3 consecutive data-collection days |
+| Short-term objective (Q2) | 4 of 10 opportunities |
+| Short-term objective (Q3) | 6 of 10 opportunities |
+| Tier 1 — curriculum modification tried first | Place preferred snack items in sight but out of reach to create a natural request opportunity (environmental support); offer choice between two items to prompt a comparison request (activity simplification) |
+| Tier 2 — embedded learning opportunities (if Tier 1 alone plateaus for 2+ consecutive weeks) | Adult models the 2-word phrase and pauses expectantly (time delay) once per snack routine, 5x/week |
+| Tier 3 — individualized instructional strategy (if Tier 2 plateaus for 2+ consecutive weeks) | 1:1 discrete-trial request practice for 5 minutes immediately before snack, only as a bridge back into the routine — not a replacement for it |
+| Data collection | Frequency count out of 10 daily opportunities, logged same-day, reviewed every 2 weeks |
+| Escalation rule | No data movement (±0 opportunities) across 2 consecutive review periods at a given tier → move up one tier; 2 consecutive review periods at ≥80% → consider goal met and write a new target skill in the same routine rather than closing the routine slot |
+
+**Curriculum-modification menu (Sandall et al., 8 categories) — check in this order before escalating tiers:** environmental support, materials adaptation, activity simplification, child preferences, special equipment, adult support, peer support, invisible support. A goal that jumps straight to Tier 3 without documenting which of the 8 were tried is the single most common defensibility gap in a preschool IEP file.
+
+## 4. Placement / LRE feasibility check
+
+| Field | Entry |
+|---|---|
+| Program under consideration | Community-based Head Start classroom, Room 4 |
+| Total enrollment | 16 children |
+| Nondisabled enrollment | 10 of 16 = 62.5% |
+| Hours/week child would attend | 12.5 hours (5 mornings × 2.5 hours) |
+| Regular Early Childhood Program test | ≥50% nondisabled enrollment (62.5% — passes) AND ≥10 hours/week (12.5 — passes) → qualifies as RECP |
+| Staffing ratio at site | 1 lead + 1 aide per 16 children = 1:8 adult:child, below the state's 1:6 preschool special-ed ratio guidance for a child with an individualized behavior plan |
+| Feasibility flag | Ratio mismatch — placement passes the RECP enrollment/hours test but fails the ratio check for this child's support level; document as a placement-feasibility flag requiring an added aide hour or a different site, not a reason to write a weaker goal |
+| Where most special-ed service hours are delivered | 10 of 12.5 hours in Room 4 (itinerant SLP pushes in 2x/week, 30 min each) = 80% of hours in the RECP setting |

--- a/roles/special-education-teacher-preschool/references/red-flags.md
+++ b/roles/special-education-teacher-preschool/references/red-flags.md
@@ -1,0 +1,61 @@
+# Red Flags — Preschool Special Education
+
+### Referral reaches the Part C lead agency 45–90 days before the 3rd birthday, and the team routes it as a late-referral direct-consent case anyway
+- **Usually means:** someone is confusing the "under 45 days" late-referral shortcut with the standard window, skipping the Part C eligibility determination the LEA still needs before it can act; second most likely, the referral date was logged incorrectly.
+- **First question:** "How many days sit between the referral date and the 3rd birthday, counted exactly, not estimated?"
+- **Data to pull:** the referral intake log and the Part C case file's referral-date field, checked against the child's date of birth.
+
+### A domain composite score sits within 0.1 SD of the 1.5 SD or 2.0 SD eligibility line (e.g., 1.40–1.49 SD)
+- **Usually means:** a team under family or administrative pressure to qualify a clearly-concerning child is about to round a miss into a match; second most likely, a scoring or SD-conversion arithmetic error.
+- **First question:** "Show me the full composite score and the exact SD math — not the report's summary sentence."
+- **Data to pull:** the raw and composite scores from the assessment protocol, plus the manual's SD conversion table for that instrument.
+
+### Eligibility documentation cites a subtest or scaled score instead of the full standard/composite score
+- **Usually means:** the evaluator pulled the number that supported the desired conclusion rather than the number the criterion actually requires; second most likely, unfamiliarity with which score type the developmental-delay category requires.
+- **First question:** "Is this the full composite score, or a subtest score being used as a stand-in?"
+- **Data to pull:** the assessment's score summary page showing composite vs. subtest breakdown.
+
+### Fewer than 90 days remain before the child's 3rd birthday and no IEP meeting is on the calendar
+- **Usually means:** the transition-conference step got skipped or delayed and the team is now racing a clock it can't win without an expedited meeting; second most likely, parental consent for evaluation was delayed and nobody recalculated the downstream deadline.
+- **First question:** "What date was parental consent obtained, and is the 90-day mark counted from that date or from the birthday?"
+- **Data to pull:** the transition-conference notice, the consent-for-evaluation signature date, and the IEP-meeting invitation.
+
+### PLAAFP is organized by academic subject headings (reading, math, science) instead of the three Early Childhood Outcomes
+- **Usually means:** the case manager or a template default carried over an elementary PLAAFP structure without adapting it to the preschool reporting framework; second most likely, the writer isn't aware the ECO/COS process is a separate federal reporting requirement from the PLAAFP content itself.
+- **First question:** "Which of the three ECO outcomes does this present-level statement report progress on?"
+- **Data to pull:** the PLAAFP section headings and the most recent Child Outcomes Summary rating.
+
+### A new goal is written as pulled-out, one-on-one drill with no routine named, and no equipment or repetition-density rationale given
+- **Usually means:** isolated instruction was chosen because it's easier to schedule and document than embedding it in a routine, not because the skill requires it; second most likely, the team hasn't been trained in Sandall et al.'s curriculum-modification categories.
+- **First question:** "Which routine — arrival, mealtime, transition — was considered for this goal, and why was it rejected?"
+- **Data to pull:** the goal's instructional-context field on the IEP and any curriculum-modification worksheet on file.
+
+### An individualized behavior plan is proposed with no documented Tier 1 or Tier 2 Pyramid Model response on record
+- **Usually means:** the team escalated straight to a functional-behavior-assessment-based plan without trying or documenting universal supports and explicit social-emotional teaching first; second most likely, Tier 1/2 supports were tried informally but never written down.
+- **First question:** "What Tier 1 and Tier 2 supports were tried, and for how long, before this plan was drafted?"
+- **Data to pull:** classroom behavior-incident log and any TPOT fidelity-check documentation.
+
+### Placement is justified as meeting LRE because the child spends time in an inclusive-labeled classroom, without a stated nondisabled-enrollment percentage or weekly hours
+- **Usually means:** the team is using a subjective "feels inclusive" standard instead of the Regular Early Childhood Program test; second most likely, the enrollment-mix data exists but wasn't pulled into the placement note.
+- **First question:** "What percentage of this program's enrollment is nondisabled, and how many hours a week is the child there?"
+- **Data to pull:** the program's enrollment roster and the child's weekly service-delivery grid.
+
+### Nondisabled enrollment sits below 50% or weekly attendance is under 10 hours, but the placement is coded as Regular Early Childhood Program on the federal LRE report
+- **Usually means:** a coding error carried forward from a prior year's placement rather than a re-check against this year's actual enrollment mix; second most likely, enrollment mix shifted mid-year and the placement code was never updated.
+- **First question:** "When was this program's enrollment mix last verified against the current roster?"
+- **Data to pull:** the state's Indicator 6 (preschool LRE) coding worksheet and the current enrollment roster.
+
+### Adult-to-child ratio in the proposed placement exceeds 1:6, or the classroom isn't staffed at the 6:1+2 model, and the IEP still lists individualized-instruction goals
+- **Usually means:** the placement recommendation was made on programmatic fit rather than a check of whether the site's staffing can deliver the specific goals written; second most likely, the ratio was accurate at referral but the site's actual staffing has since changed.
+- **First question:** "Does this site's current staffing ratio support the individualized-instruction goals as written, or does the goal need to shift tiers?"
+- **Data to pull:** the site's current staffing roster and ratio, and the IEP's service-delivery-tier designations.
+
+### No Child Outcomes Summary rating is on file at the initial IEP or at the most recent annual review
+- **Usually means:** the COS process was treated as optional paperwork rather than the federal OSEP reporting requirement it is, layered on top of (not replacing) the PLAAFP; second most likely, it was completed but filed separately from the IEP and not cross-referenced.
+- **First question:** "When was the 7-point COS rating last completed, and does it match the annual review date?"
+- **Data to pull:** the COS entry and exit rating forms and the annual-review meeting date.
+
+### Two assessment instruments produce composite scores in the same domain more than 15 points apart with no reconciliation note
+- **Usually means:** one instrument is a poor fit for the child (language, cultural, or sensory mismatch) and the discrepancy is being averaged away instead of investigated; second most likely, one of the two administrations had a scoring or standardization error.
+- **First question:** "Which instrument's administration conditions most closely matched this child's home language and typical functioning?"
+- **Data to pull:** both assessment protocols' raw scores, administration notes, and examiner qualifications.

--- a/roles/special-education-teacher-preschool/references/vocabulary.md
+++ b/roles/special-education-teacher-preschool/references/vocabulary.md
@@ -1,0 +1,66 @@
+# Vocabulary — Preschool Special Education
+
+### Developmental Delay
+An eligibility category under IDEA, not a diagnosis — a child qualifies by falling at least 1.5 SD below the mean on full standard/composite scores in two or more domains, or at least 2.0 SD in one domain, with no underlying medical or psychiatric label required.
+**In use:** "She's eligible under developmental delay in communication — we don't need an autism diagnosis on file for the IEP to stand."
+**Common misuse:** Generalists treat it as a euphemism for an unconfirmed diagnosis ("delay" as a softer word for "disorder"), when it's actually a distinct statistical eligibility gate that some states retire at kindergarten entry in favor of a categorical label.
+
+### Present Levels (PLAAFP), preschool form
+The IEP section describing current functioning — but at this age organized around functional participation in named routines and the three Early Childhood Outcomes, not academic subject areas.
+**In use:** "This PLAAFP reads like a shrunk elementary report — rewrite it around arrival, circle time, and mealtime, not reading readiness."
+**Common misuse:** Case managers trained on K-12 templates default to subject-area headings (pre-literacy, pre-math), missing that the federal reporting structure at this age asks a functional-participation question, not a content-coverage one.
+
+### Early Childhood Outcomes (ECO)
+The three federally reported outcome areas — positive social-emotional skills, acquisition and use of knowledge and skills, use of appropriate behaviors to meet needs — that organize preschool present levels and progress reporting.
+**In use:** "Which of the three ECO outcomes does this goal report progress on?"
+**Common misuse:** Confused with the IEP goals themselves. ECO outcomes are the federal reporting frame the goals get mapped onto; a child can have five goals that all still trace back to only one of the three outcomes.
+
+### Child Outcomes Summary (COS)
+A 7-point rating (1 = functions like a much younger child, 7 = comparable to same-age peers) completed at entry and exit for each ECO outcome — a separate OSEP reporting requirement layered on top of, not instead of, the PLAAFP narrative.
+**In use:** "The COS entry rating is a 3 on social-emotional — that's the number that goes to the state, not the narrative paragraph."
+**Common misuse:** Treated as optional paperwork or as redundant with the PLAAFP, so it gets skipped or filed separately and never cross-referenced against the annual review date — a documented red flag on its own.
+
+### Embedded Instruction
+Delivering a specialized-instruction goal inside an existing routine (mealtime, diapering, block play, transitions) rather than as a standalone pulled-out activity, because the routine itself is the instructional container at this age.
+**In use:** "Don't build a separate communication-drill session — embed the 2-word request goal into snack time where the motivation already exists."
+**Common misuse:** Confused with simple physical inclusion ("the child is present during circle time, so the goal is embedded"). Presence in a routine without a deliberate teaching moment inside it isn't embedded instruction — it's just proximity.
+
+### Curriculum Modification
+The first-tier response to a struggling goal — adapting the environment, materials, or activity itself (per Sandall et al.'s eight categories) before adding adult-delivered teaching or 1:1 instruction.
+**In use:** "Try activity simplification and environmental support for two weeks before we escalate to embedded learning opportunities."
+**Common misuse:** Conflated with a K-12 "accommodation." A K-12 accommodation changes how a child accesses fixed content; a preschool curriculum modification changes the routine or materials themselves because there's no fixed content to accommodate access to.
+
+### Informed Clinical Opinion
+A legally recognized evaluation input under IDEA — professional judgment from direct observation and experience, used alongside (not instead of) standardized scores when eligibility is a genuine team concern but no domain clears the SD threshold.
+**In use:** "Scores alone don't establish eligibility here — document informed clinical opinion and natural-environment observation before closing the file."
+**Common misuse:** Dismissed as unsupported subjective opinion that "wouldn't hold up," when it is in fact an explicitly sanctioned evaluation component under 34 CFR 303/300 — the failure mode is not documenting it formally enough to count, not that it's inadmissible.
+
+### Natural Environment
+The Part C term for settings typical for same-age peers without disabilities — home, community childcare, playgrounds — where early intervention services are delivered by default.
+**In use:** "Services stay in the natural environment through age 2 — home and the child's regular daycare, not a clinic room."
+**Common misuse:** Read as meaning "at home" specifically. It actually covers any setting typical for nondisabled same-age peers, including community childcare and playgroups, which matters when planning where Part C services transition from as the child approaches Part B.
+
+### Regular Early Childhood Program (RECP)
+The federal LRE reporting category for preschool placement — a program qualifies only if it has at least 50% nondisabled enrollment and the child attends at least 10 hours a week there, with most special-education hours delivered in that same setting.
+**In use:** "Room 4 passes the RECP test — 62.5% nondisabled enrollment and 12.5 hours a week — so it codes as the least-restrictive placement on Indicator 6."
+**Common misuse:** Equated with "an inclusive-feeling classroom" or "the general-ed room" the way K-12 LRE gets discussed. Preschool has no universal general-ed default because attendance is often non-compulsory; RECP is a mechanical enrollment-percentage-and-hours test, not a subjective inclusion judgment.
+
+### Part C to Part B Transition
+The legally distinct handoff process moving a child from Early Intervention (birth–3, family-centered, IFSP-driven) to preschool special education (3–5, IEP-driven), governed by its own conference and notification deadlines separate from ordinary IEP procedure.
+**In use:** "We're 55 days from the 3rd birthday — that's inside the standard transition window, so the Part C eligibility determination still has to run before the LEA acts."
+**Common misuse:** Treated as a routine "renewal" of services or a simple document handoff, when it's a hard-clocked legal process with its own late-referral shortcut (under 45 days) and standard track (45–90+ days) that determines which agency has the obligation at any given moment.
+
+### Individualized Family Service Plan (IFSP)
+The Part C planning document, distinct from an IEP — organized around family-identified outcomes and natural-environment routines rather than a single child's discrete, disability-specific goals.
+**In use:** "The IFSP outcome was 'family can take Maria to the playground without a meltdown' — the IEP goal has to be rewritten as a child-specific, measurable skill, not carried over verbatim."
+**Common misuse:** Assumed to convert directly into IEP goals with only a name change. IFSP outcomes are often family-functioning statements; Part B requires child-focused, measurable annual goals, so a straight copy-paste typically fails IEP content requirements.
+
+### Child Find
+The affirmative, ongoing obligation on public agencies to identify, locate, and evaluate all children who may need special education — including infants and toddlers, not just school-enrolled children.
+**In use:** "Child Find applies the moment the pediatrician's referral comes in — the district can't wait for a parent to formally request an evaluation."
+**Common misuse:** Assumed to start at school enrollment or kindergarten age. The obligation runs from birth, which is exactly why a late Part C referral doesn't excuse the LEA from acting — the duty to find and evaluate the child already existed.
+
+### Full Standard/Composite Score
+The overall, norm-referenced score type (mean 100, SD 15 on most instruments) required to establish developmental-delay eligibility — as distinct from a subtest or scaled score, which do not count toward the SD threshold no matter how low.
+**In use:** "That 1.53 SD is on the communication composite, not a subtest — that's the number that counts toward eligibility."
+**Common misuse:** Evaluators under pressure to qualify a child cite a low subtest or scaled score as if it meets the eligibility threshold; only the full composite score is the criterion-relevant number, and substituting a subtest score is a documented eligibility-defensibility error.


### PR DESCRIPTION
## Rubric score

17/18

## Resolution rationale

O*NET 25-2051.00 is a distinct SOC code from the three candidates' codes (25-2059.00 special-education-teacher, 11-9031.00 admin, 25-2011.00 preschool-teacher-general-ed). Applying the granularity test to special-education-teacher (the closest fit, which explicitly claims to be "grade-band-agnostic by design"): a preschool special-ed case manager would get materially wrong Tools & methods and Worked-example guidance from that file. The current SKILL.md's Tools section names CBM probes and FBA/BIP as the core instruments and its Worked example is a 4th-grade oral-reading-fluency goal built on academic CBM data — a preschool practitioner would not nod at this; ages 3-5 IEP present-levels and goals are built on developmental-domain data (motor, communication, social-emotional, adaptive) and IDEA Part B preschool carries a federally mandated Child Outcomes Summary (COS) process that has no K-12 analogue and isn't mentioned. Decision-framework step 6 (manifestation determination triggered at >10 cumulative discipline days) is largely inapplicable to preschoolers, whose removal/suspension issues are governed by different policy concerns (early-childhood suspension/expulsion practice, positive behavior support) not addressed in the parent file — so an agent using the parent's framework as-is would misapply a K-12 discipline procedure to a population it wasn't built for. These are decision- and tool-level divergences, not just "less detail," so a new leaf is warranted. A reasonable parent exists (special-education-teacher shares the IDEA/IEP/case-management core, procedural-compliance principles, and accommodation-vs-modification judgment verbatim), so this is new_leaf, not new_parent. Slug follows the repo's existing '<role>-preschool' naming convention seen in preschool-teacher and education-childcare-administrator-preschool.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `special-education-teacher-preschool` mapped to O*NET 25-2051.00 to cover preschool-specific special education judgment. Updates counts/checklist (819 O*NET roles drafted; “other” now 174) and increases coverage to 80.6%.

- **New Features**
  - New role `special-education-teacher-preschool` (leaf of `special-education-teacher`, spec 2) with SKILL on Part C→B transition clock, ECO/COS-based PLAAFP, developmental-delay SD thresholds, embedded-instruction tiers, and preschool LRE rules/ratios.
  - Added references: `playbook.md` (filled templates), `red-flags.md`, `vocabulary.md`.
  - Updated `README.md`, `ROADMAP.md`, and `data/roles.json` to register the role and refresh counts.

- **Bug Fixes**
  - Regenerated `data/roles.json` to normalize encoding; no behavior changes beyond the new role entry.

<sup>Written for commit 001a7c58ac660da5ca0c27678f7ef395989c0656. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

