### PR TITLE
role: add special-education-teacher-secondary (leaf of special-education-teacher)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**828 roles drafted** (818 mapped to an O*NET occupation, 10 custom; 786 at spec 2, 42 awaiting upgrade), across 10 categories:
+**829 roles drafted** (819 mapped to an O*NET occupation, 10 custom; 787 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `████████████████░░░░` 80.5% (818 / 1,016 occupations)
+**O\*NET coverage:** `████████████████░░░░` 80.6% (819 / 1,016 occupations)
 
 - **design**: 14
 - **engineering**: 127
@@ -212,7 +212,7 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 - **legal**: 21
 - **marketing**: 8
 - **operations**: 289
-- **other**: 173
+- **other**: 174
 - **product**: 1
 - **sales**: 17
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 818 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 819 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -365,7 +365,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>25 — Educational Instruction and Library</strong> (55/68 drafted)</summary>
+<summary><strong>25 — Educational Instruction and Library</strong> (56/68 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -417,7 +417,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 |  | 25-2055.00 | Special Education Teachers, Kindergarten |  |
 |  | 25-2056.00 | Special Education Teachers, Elementary School |  |
 |  | 25-2057.00 | Special Education Teachers, Middle School |  |
-|  | 25-2058.00 | Special Education Teachers, Secondary School |  |
+| ✅ | 25-2058.00 | Special Education Teachers, Secondary School | [`special-education-teacher-secondary`](./roles/special-education-teacher-secondary/SKILL.md) |
 | ✅ | 25-2059.00 | Special Education Teachers, All Other | [`special-education-teacher`](./roles/special-education-teacher/SKILL.md) |
 | ✅ | 25-2059.01 | Adapted Physical Education Specialists | [`adapted-physical-education-specialist`](./roles/adapted-physical-education-specialist/SKILL.md) |
 | ✅ | 25-3011.00 | Adult Basic Education, Adult Secondary Education, and English as a Second Language Instructors | [`adult-esl-instructor`](./roles/adult-esl-instructor/SKILL.md) |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 828,
+  "count": 829,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -15222,6 +15222,27 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/special-education-teacher/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "special-education-teacher-secondary",
+      "description": "Use when a task needs the judgment of a secondary special education case manager \u2014 writing an Indicator-13-compliant transition IEP goal, reading a 9th-grade credit/GPA transcript for graduation risk, choosing a co-teaching model for a specific general-ed class period, deciding whether an alternate-assessment recommendation forecloses a diploma track, or timing the age-of-majority rights-transfer notice.",
+      "category": "other",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "25-2058.00",
+      "parent": "special-education-teacher",
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/special-education-teacher-secondary/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/roles/special-education-teacher-secondary/SKILL.md
+++ b/roles/special-education-teacher-secondary/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: special-education-teacher-secondary
+description: Use when a task needs the judgment of a secondary special education case manager — writing an Indicator-13-compliant transition IEP goal, reading a 9th-grade credit/GPA transcript for graduation risk, choosing a co-teaching model for a specific general-ed class period, deciding whether an alternate-assessment recommendation forecloses a diploma track, or timing the age-of-majority rights-transfer notice.
+metadata:
+  category: other
+  maturity: draft
+  spec: 2
+  onet_soc_code: "25-2058.00"
+parent: special-education-teacher
+status: active
+---
+
+# Special Education Teacher, Secondary
+
+## Identity
+
+Inherits the base `special-education-teacher` craft (present-levels documentation, measurable goal-writing, accommodation-vs-modification judgment, procedural-safeguards compliance) unchanged, applied to a secondary caseload under IDEA. What's different at this grade band: transition planning becomes a recurring compliance artifact rather than a one-time event, delivery runs mostly through co-teaching with content-area specialists instead of a self-contained room, and credit/diploma mechanics start intersecting IEP goals directly. Accountable for the same legal-defensibility-versus-instructional-value tension as the base role, plus a secondary-specific one: getting a student to a diploma that colleges and employers read literally, not just to an IEP that reads well on paper.
+
+## First-principles core
+
+1. **A transition plan is re-earned every year, not written once at 16 and filed.** IDEA's Indicator 13 requires postsecondary goals be updated annually against a current age-appropriate transition assessment — a goal that's technically present but two years stale fails the same way a missing one does.
+2. **The compliance gap is usually in the invitations, not the goals.** Teams that write technically sound postsecondary goals still fail Indicator 13 by skipping the two procedural items — evidence the student was invited to their own IEP meeting, and evidence a participating agency (e.g., vocational rehabilitation) was invited with consent when the goal implicates one. The conceptually harder items (goal quality, course of study) are usually fine; the paperwork trail on invitations is where reviews actually break.
+3. **Course-failure pace predicts graduation better than the IEP's own goal-progress data.** A 9th grader who earns fewer than 5 full-year credits or takes more than one semester F in a core course carries markedly worse four-year graduation odds than one who doesn't, and outranks test scores or background as a predictor [heuristic — needs practitioner check: exact effect size not independently verified here] — a signal a secondary case manager should be pulling before annual review, not discovering at it.
+4. **Alternate-assessment participation and diploma track are two separate decisions, not one.** A student flagged for the 1%-cap alternate assessment (AA-AAAS) is not thereby precluded from later attempting a regular diploma — conflating the two when advising a family forecloses an option that was never actually closed.
+5. **Age of majority is a scheduled procedural trigger, not a background fact.** Beginning at least one year before the student reaches it (18 in most states; 19 in Alabama and Nebraska, 21 in Mississippi), the IEP must document that the student was notified which rights transfer to them — a deadline elementary and middle caseloads never have to track.
+
+## Mental models & heuristics
+
+- When drafting a postsecondary goal, default to outcome language tied to a named setting or occupation ("will obtain part-time employment in the automotive sector") over activity language ("will explore employment options") — see `references/red-flags.md` for why this specific defect is the one reviewers catch most.
+- When Indicator 13 documentation looks complete, default to checking the student-invitation and agency-invitation evidence first, not last — that's where compliance most often actually fails, per principle 2.
+- When choosing a co-teaching model for a class period, default to matching the model to that day's activity — station or parallel teaching for skills practice, one-teach/one-assist for lecture-heavy content, alternative teaching for a small reteach group — rather than running the same model every period regardless of fit.
+- When a caseload is approaching a named state ceiling (Ohio's 24 for high school, California's 28 resource-specialist cap, waivable to 32, NYC's 38 for secondary resource, New Mexico's 50), default to raising feasibility explicitly with the team rather than assuming an unremarked-on number is fine.
+- When a student ends 9th grade below 5 credits or with more than one core semester F, default to treating that as the primary graduation-risk flag for the caseload, ahead of any single IEP goal's own trend line.
+- The Self-Determined Learning Model of Instruction (SDLMI) — useful as the concrete curriculum behind a generic "goal-setting/self-advocacy" IEP line, overused when assigned as a disconnected worksheet instead of tied to the student's own stated transition goal.
+- When a family is considering the 1%-cap alternate assessment, default to documenting in writing that this does not foreclose a regular-diploma attempt later — the two tracks are legally decoupled even when a single meeting bundles the decisions.
+
+## Decision framework
+
+1. Pull the student's current credit/GPA transcript and flag on-track status (≥5 full-year credits and ≤1 core semester F for a 9th grader; credit pace against remaining requirement for 10th–12th) before opening any goal discussion.
+2. Starting no later than age 16, work the Indicator 13 sequence in order: outcome-focused postsecondary goal(s) in education/training and employment (plus independent living if needed), a current transition assessment on file, transition services and a course of study that reasonably enable the goal(s), at least one annual IEP goal tied to a transition need, evidence of the student's meeting invitation, and evidence of a participating-agency invitation with consent where the goal implicates one.
+3. Check the course of study against both the postsecondary goal and the credit shortfall from step 1 — does the remaining schedule actually close the gap, or does it need a credit-recovery add?
+4. Assign the co-teaching model per general-ed period based on that period's activity structure, and confirm who owns content (general-ed teacher) versus access/modification (this role).
+5. If age of majority falls within the next 12 months, add the rights-transfer notification to this meeting's agenda rather than deferring it to a later check.
+6. If a disciplinary placement change is on the table, run the manifestation-determination process inherited from the base caseload workflow before finalizing anything else.
+7. Document any alternate-assessment participation decision separately from the diploma-track decision, with the family's written acknowledgment attached.
+
+## Tools & methods
+
+Indicator 13 seven-item checklist as the transition-compliance audit instrument. Age-appropriate transition assessment (interest inventories, work-samples, adaptive-behavior scales) as the evidentiary base for postsecondary goals, re-administered annually. Cook & Friend's six co-teaching models (one teach/one observe, one teach/one assist, station, parallel, alternative, team) as the delivery-selection menu. SDLMI as the named curriculum for self-determination goals. See `references/playbook.md` for a filled Indicator 13 checklist, course-of-study/credit-audit template, and co-teaching model selection table.
+
+## Communication style
+
+To families: decouple assessment-track and diploma-track questions explicitly, and lead with what's still open, not what's been decided. To content-area co-teachers: state the co-teaching plan as a specific weekly model assignment per activity type, not a general offer to "support." To school counselors: frame caseload risk in on-track/off-track terms tied to the specific courses failed and credits short, not a general "struggling" label. To an invited agency representative: frame the invitation around the specific goal it serves (e.g., a VR referral tied to the stated employment goal), not a generic collaboration request.
+
+## Common failure modes
+
+Running one co-teaching model every period regardless of the day's activity, which is the overcorrection after learning the model menu exists — it burns co-teacher planning time without matching delivery to need.
+
+## Worked example
+
+Annual IEP review for a 10th grader with a specific learning disability, co-taught in general-ed Algebra I, who turned 16 last month. End-of-9th-grade transcript: 3.0 credits earned against the district's standard pace of 6.0/year (24 credits over 4 years), with semester Fs in both Algebra I and English 9 — two core semester Fs, and only 3.0 of the 5.0 credits the on-track metric requires. By the on-track definition, the student fails on both counts. To still graduate in 4 years, the remaining 21 credits must be earned over 3 years — 7.0/year, one credit above standard pace.
+
+Naive read: the team writes "Student will explore career options and improve grades" as the transition goal. Activity-focused ("explore"), not tied to education/training or employment as required, and disconnected from the 3-credit-per-year pace problem already visible in the transcript.
+
+Expert read: the goal has to name an outcome, the course of study has to close the pace gap, and — because the goal names an occupational area — a participating agency invitation is now a compliance item, not an option.
+
+Quoted IEP transition section, as it goes into the document:
+
+"Postsecondary Goal — Education/Training: After graduation, [Student] will complete the Automotive Technology certificate program at [Community College], which requires successful completion of Algebra I and Algebra II. Postsecondary Goal — Employment: After graduation, [Student] will obtain part-time employment in the automotive service sector. Course of Study: Algebra I (repeat, co-taught, station-teaching model for skills practice days), Automotive Technology I (Year 2 elective), Algebra II (Year 3), Automotive Technology II with work-based learning placement (Year 4), plus one credit-recovery block each semester in Years 2–4 (all three remaining years, not just two) to close the pace gap identified at the end of Year 1 (3.0 of 6.0 standard-pace credits earned; core semester Fs in Algebra I and English 9). Annual IEP Goal: By [date], given a self-determination checklist and weekly case-manager check-in, [Student] will independently identify and communicate at least 2 needed classroom accommodations in 4 of 5 recorded opportunities, measured by SDLMI session logs. Student was invited to this meeting on [date]. A Vocational Rehabilitation counselor was invited with parent consent on [date], given the stated employment goal."
+
+## Going deeper
+
+- [references/playbook.md](references/playbook.md) — filled Indicator 13 checklist, course-of-study/credit-audit template, and co-teaching model selection table.
+- [references/red-flags.md](references/red-flags.md) — signals a secondary transition plan or placement decision won't survive review.
+- [references/vocabulary.md](references/vocabulary.md) — secondary-specific terms of art generalists misuse.
+
+## Sources
+
+Individuals with Disabilities Education Act (IDEA) State Performance Plan Indicator 13, as operationalized by the National Technical Assistance Center on Transition (NTACT-C, transitionta.org) and practitioner guides from A Day in Our Shoes and Project10 (adayinourshoes.com, project10.info). Wrightslaw, the Center for Parent Information and Resources, and Understood.org on age-of-majority rights transfer. IES/NCSER National Longitudinal Transition Study-2 (NLTS2) on post-school completion and postsecondary outcomes. U.S. Department of Education Office for Civil Rights, 2020–21 Civil Rights Data Collection, on discipline disparity for students with disabilities. State caseload policy data as compiled by SDEA and Wrightslaw Way, and cross-state review literature on caseload policy. Cook & Friend (1995) co-teaching models, as cited by CTSERC, ASCD ("Co-Teaching 2.0"), and ERIC syntheses. University of Chicago Consortium on School Research on the 9th-grade on-track indicator. IES-funded Self-Determined Learning Model of Instruction (SDLMI) research (Wehmeyer & Zhang lineage) and the University of Kansas Center for Developmental Disabilities SDLMI Teacher's Guide. ERIC, NCEO, and state education agency guidance on the ESSA 1% alternate-assessment participation cap. Named practitioner quotes and secondary-specific credit-recovery pass-rate data beyond what's cited above were not located in research and are not asserted.

--- a/roles/special-education-teacher-secondary/references/playbook.md
+++ b/roles/special-education-teacher-secondary/references/playbook.md
@@ -1,0 +1,116 @@
+# Playbook — secondary transition compliance and delivery
+
+Three filled instruments referenced from `SKILL.md`: the Indicator 13 audit checklist, the course-of-study/credit-audit template, and the co-teaching model selection table. Populate these directly for a real caseload; don't restate them as descriptions.
+
+## 1. Indicator 13 seven-item audit checklist
+
+Run this at every annual review starting no later than age 16 (earlier if state policy or a specific student's needs call for it). Each item is a pass/fail with evidence, not a narrative judgment.
+
+```
+STUDENT: _____________________  DOB: __________  MEETING DATE: __________
+AGE AT MEETING: _____  AGE OF MAJORITY DATE: __________ (state: ______)
+
+[ ] 1. Postsecondary goal — Education/Training
+      Outcome-worded, named setting/program? Y / N
+      Text: "___________________________________________________"
+      FAIL EXAMPLE: "will explore options for after high school"
+      PASS EXAMPLE: "will complete the Automotive Technology certificate
+                     program at Riverside Community College"
+
+[ ] 2. Postsecondary goal — Employment
+      Outcome-worded, named field/setting? Y / N
+      Text: "___________________________________________________"
+
+[ ] 3. Postsecondary goal — Independent Living (only if a need is identified)
+      N/A — no IL need identified this year
+      Text: "___________________________________________________"
+
+[ ] 4. Age-appropriate transition assessment on file
+      Instrument name: ______________  Date administered: __________
+      >12 months old at meeting date = FAIL, re-administer before finalizing goals.
+
+[ ] 5. Transition services + course of study reasonably enable goal(s)
+      Course of study (next 1–2 years) listed below matches stated goal(s)? Y / N
+      Cross-check against Section 2 (credit audit) — does the schedule
+      close any pace gap, or just meet the goal on paper? Y / N
+
+[ ] 6. At least one annual IEP goal tied to a transition need
+      Goal ID in IEP: _______  Transition need it serves: ________________
+
+[ ] 7. Procedural evidence (the two items reviews most often fail on)
+      [ ] 7a. Student invited to this IEP meeting — invitation dated __________,
+              method (mailed / hand-delivered / emailed), copy in file.
+      [ ] 7b. Participating agency invited, with consent, where the goal
+              implicates one (e.g., goal names an occupational field →
+              Vocational Rehabilitation referral is a compliance item, not optional).
+              Agency: ______________  Consent signed: __________  Invited: __________
+              N/A only if no goal implicates an outside agency — state which
+              goal was checked and why it doesn't: ________________________
+
+SCORE: ___ / 7 items pass. Any single FAIL = plan is not Indicator-13-compliant
+this cycle, regardless of how strong the other six items are.
+```
+
+## 2. Course-of-study / credit-audit template
+
+Run at the start of every year for grades 9–12, not just at annual review. On-track thresholds:
+
+- **End of 9th grade:** ≥5.0 full-year credits earned AND ≤1 core-subject semester F. Either threshold missed = primary graduation-risk flag, ranked above any single IEP goal's own progress trend.
+- **10th–12th grade:** remaining credits needed ÷ remaining years enrolled = required annual pace. Compare against the district's standard annual pace (commonly 6.0 credits/year for a 24-credit diploma). Anything above standard pace needs an explicit remediation plan (credit recovery, summer term, or a 5th year), not a hope that the student "catches up."
+
+```
+STUDENT: _____________________  GRADE: _____  DISTRICT DIPLOMA REQUIREMENT: 24.0 credits
+
+Credits earned to date: _____  Credits remaining: _____
+Years of enrollment remaining: _____
+Required annual pace = credits remaining ÷ years remaining = _____ credits/year
+Standard annual pace (district) = _____ credits/year
+Pace gap = required − standard = _____ (0 or negative = on track without intervention)
+
+Core-subject semester Fs to date: _____ (list course + term)
+  ________________________________________________
+
+ON-TRACK DETERMINATION (9th grade only): earned ≥5.0 AND ≤1 core F?  YES / NO
+IF NO — this is the primary graduation-risk flag for the caseload this year.
+
+REMEDIATION PLAN IF PACE GAP > 0:
+[ ] Credit-recovery block, ___ semester(s), starting term: __________
+[ ] Summer term enrollment, subject(s): __________
+[ ] Course substitution/waiver request filed: __________
+[ ] 5th-year plan discussed with family: Y / N
+
+COURSE OF STUDY, NEXT 2 YEARS (must reasonably enable both the credit
+pace above and the Section 1 postsecondary goal(s)):
+  Year N:   ________________________  co-teaching model per period: ______
+  Year N+1: ________________________  co-teaching model per period: ______
+```
+
+Worked numbers (reconciling example, matches the SKILL.md worked example):
+3.0 credits earned of 6.0 standard-pace target at end of 9th grade, 21.0 credits
+remaining, 3 years of enrollment left → required pace = 21.0 ÷ 3 = 7.0 credits/year,
+against a standard pace of 6.0/year → pace gap = +1.0 credit/year for each of the
+3 remaining years, a 3.0-credit total shortfall. A recovery block covering only
+2 of the 3 remaining years (2 semesters/year × 2 years × 0.5 credit each = 2.0
+additional credits) is not enough — it leaves the plan 1.0 credit short overall.
+Closing it requires one credit-recovery block each semester across all 3 remaining
+years (Years 2–4): 2 semesters/year × 3 years × 0.5 credit each = 3.0 additional
+credits, matching the 3.0-credit shortfall exactly.
+
+## 3. Co-teaching model selection table
+
+Assign per general-ed period based on that period's activity structure, not once for the whole schedule. Re-assign when the activity type changes (e.g., a unit shifts from lecture to lab).
+
+| Model | Best-fit activity | Content owner | Access/modification owner | Overuse signal |
+|---|---|---|---|---|
+| One teach / one observe | Early in a placement, data collection on a specific behavior or skill | General-ed teacher | This role (data collector) | Used past week 2 of a placement with no data being acted on |
+| One teach / one assist | Lecture-heavy content delivery, new-concept introduction | General-ed teacher | This role (circulates, prompts) | Run every period regardless of activity — becomes a paraprofessional-style default that wastes the co-teacher's content expertise |
+| Station teaching | Skills practice, rotating small groups | Split by station | Split by station | Stations not actually differentiated by need — same worksheet at every station |
+| Parallel teaching | Skills practice, discussion needing smaller groups | Both, split roster | Both, split roster | Group composition never varies — same low/high split every time defeats the purpose |
+| Alternative teaching | Small reteach or pre-teach group pulled from the main group | General-ed teacher (main group) | This role (small group) | Same students pulled every time it's used, turning "alternative" into a de facto separate placement |
+| Team teaching | Both teachers co-deliver the same content simultaneously | Shared | Shared | Attempted before the co-teaching relationship has planning time in common — collapses into one teacher leading and one observing |
+
+Weekly assignment example for a co-taught Algebra I section:
+- Monday (new concept, lecture) → one teach / one assist
+- Tuesday–Wednesday (skills practice) → station teaching, 3 stations
+- Thursday (reteach for a flagged subgroup) → alternative teaching
+- Friday (quiz + discussion) → parallel teaching, split by current mastery check

--- a/roles/special-education-teacher-secondary/references/red-flags.md
+++ b/roles/special-education-teacher-secondary/references/red-flags.md
@@ -1,0 +1,61 @@
+# Red Flags — Special Education Teacher, Secondary
+
+### Postsecondary goal text identical, word-for-word, to last year's IEP despite a transition-assessment date on file more than 12 months old
+- **Usually means:** the team copy-pasted the prior goal at the annual review instead of re-administering the transition assessment Indicator 13 requires; second most likely, the assessment was re-given but the goal-writer never updated the language to reflect new results.
+- **First question:** "What changed in the student's stated interests or work-sample results since the last assessment, and where does that show up in this goal?"
+- **Data to pull:** transition-assessment administration log (dates, instrument) cross-referenced against the IEP's postsecondary-goal revision history.
+
+### Transition section uses activity verbs ("explore," "learn about," "become aware of") anywhere in the postsecondary goal itself
+- **Usually means:** the goal was drafted as a classroom activity description, not an Indicator 13 outcome statement — the single most commonly cited defect in state monitoring.
+- **First question:** "If we deleted this goal and a reviewer only had the course of study, would they know what setting or occupation this student is heading toward?"
+- **Data to pull:** the exact goal-statement text as it appears in the IEP transition page.
+
+### Goal-quality items complete but no dated evidence of the student's own meeting invitation in the file
+- **Usually means:** the team treated the substantive goal-writing as the compliance task and skipped the procedural paperwork trail — the actual failure point in most Indicator 13 reviews; second, the invitation was sent verbally and never documented.
+- **First question:** "Where's the dated notice showing this student was invited to their own IEP meeting?"
+- **Data to pull:** prior-written-notice / meeting-invitation log for the current annual review.
+
+### A named occupational or vocational goal with no participating-agency invitation on file
+- **Usually means:** the team wrote an employment goal implicating an outside agency (VR, developmental disabilities services) without following through on the consent-based invitation Indicator 13 requires; second, consent was requested but never returned and the gap wasn't escalated.
+- **First question:** "Which agency does this employment goal point to, and where's the invitation with parent consent?"
+- **Data to pull:** IEP transition-services page cross-checked against the agency-invitation/consent form.
+
+### 9th grader at first progress report below 5.0 full-year credits earned or carrying more than one core-course semester F
+- **Usually means:** the student is already off the on-track pace the 9th-grade indicator predicts on; second, credits are on pace but a single high-weight core F is masking a specific-course problem (usually Algebra I or English 9) rather than a general one.
+- **First question:** "Which specific course is the F in, and does the remaining 3-year schedule actually get this student to 24 credits?"
+- **Data to pull:** current transcript with per-course grade history and a recalculated remaining-credits-per-year pace.
+
+### Credit-recovery block added to the course of study with no recalculated annual pace shown
+- **Usually means:** the team added recovery seat time as a gesture without checking whether it mathematically closes the shortfall; second, the pace was calculated once at goal-setting and never rechecked after a subsequent semester F.
+- **First question:** "Remaining credits divided by remaining years — what number does that produce, and does the schedule deliver it?"
+- **Data to pull:** course-of-study credit ledger for the current and remaining school years.
+
+### Alternate-assessment (AA-AAAS) participation decision documented with no separate, dated diploma-track acknowledgment
+- **Usually means:** the meeting bundled the assessment-track and diploma-track decisions into one conversation and the family left believing the alternate assessment forecloses a regular diploma; second, the acknowledgment exists verbally but was never captured in writing.
+- **First question:** "Where's the separate written statement telling this family the diploma track is still open?"
+- **Data to pull:** alternate-assessment participation form and the family-acknowledgment document, checked for two distinct signatures/dates.
+
+### Co-teaching log shows the identical model recorded for every period across a full grading period
+- **Usually means:** the team picked one model (usually one-teach/one-assist) at the start of the year and never revisited it against the day's activity type; second, the log itself is a formality and doesn't reflect what's actually happening in the room.
+- **First question:** "Walk me through what happened in this class on a lecture day versus a skills-practice day — did the model actually change?"
+- **Data to pull:** weekly co-teaching schedule log by class period and activity type for the current grading period.
+
+### Caseload count at or above the state cap with no feasibility note in the file
+- **Usually means:** the caseload grew past the state ceiling (e.g., Ohio's 24 for high school, California's 28 base/32 waived, NYC's 38 for secondary resource, New Mexico's 50) without anyone flagging it to the team or administration; second, a waiver was obtained but not documented.
+- **First question:** "Is this caseload count above the state cap, and if so, where's the waiver or the feasibility conversation on record?"
+- **Data to pull:** current caseload roster count against the state's published cap and any waiver documentation.
+
+### Age-of-majority rights-transfer notice dated within 90 days of the student turning 18 (or the state's applicable age)
+- **Usually means:** the notice was treated as a same-meeting formality instead of the ≥12-month-out scheduled trigger it's supposed to be; second, the student's birthdate was miscalculated against the state's specific age-of-majority threshold (19 in Alabama/Nebraska, 21 in Mississippi).
+- **First question:** "What was this student's exact age when the rights-transfer notice was given, and was it scheduled a year ahead or reacted to?"
+- **Data to pull:** IEP procedural-safeguards notice log with the notification date and the student's date of birth.
+
+### Disciplinary removal exceeding 10 cumulative school days in the year with no manifestation-determination review on file
+- **Usually means:** the placement change proceeded on a discipline track without the legally required review of whether the behavior was a manifestation of the disability; second, a review occurred but wasn't documented within the required timeframe.
+- **First question:** "How many cumulative days has this student been removed this year, and where's the manifestation-determination paperwork?"
+- **Data to pull:** disciplinary-removal log (dates, cumulative day count) and the manifestation-determination review record.
+
+### A single generic interest inventory administered once at age 14 is still the only transition assessment on file at age 17
+- **Usually means:** the team treated the transition assessment as a one-time intake step instead of the annually re-administered evidentiary base Indicator 13 requires; second, additional assessment happened informally (teacher observation, work-based learning feedback) but was never logged as a formal instrument.
+- **First question:** "What transition assessment was given this year, specifically — not what's on file from three years ago?"
+- **Data to pull:** transition-assessment administration log showing instrument type and date for each year since age 14.

--- a/roles/special-education-teacher-secondary/references/vocabulary.md
+++ b/roles/special-education-teacher-secondary/references/vocabulary.md
@@ -1,0 +1,99 @@
+# Vocabulary — Special Education Teacher, Secondary
+
+Terms of art generalists routinely misuse — not because the words are obscure, but because the word looks like ordinary English and invites a plain-language reading that skips the compliance content underneath.
+
+### Indicator 13
+
+**Definition:** The specific IDEA State Performance Plan monitoring indicator that audits transition-plan compliance via a seven-item checklist (postsecondary goals, transition assessment, course of study, an annual transition-linked goal, and the two invitation items) — not a general label for "the transition section of the IEP."
+
+**In use:** "This file won't pass an Indicator 13 review — the postsecondary goals are outcome-worded, but there's no dated evidence of the student's meeting invitation."
+
+**Misuse note:** Generalists use "Indicator 13" as a synonym for "the transition plan is in there somewhere." Being present isn't the same as being compliant — a single missing checklist item (usually one of the two invitation items, not a goal) fails the whole audit regardless of how strong everything else is.
+
+### Postsecondary goal
+
+**Definition:** An Indicator 13 goal statement that must be outcome-worded and tied to a named setting, program, or occupation ("will complete the Automotive Technology certificate program at X") — distinct from an activity statement describing what the student will do in school ("will explore career options").
+
+**In use:** "Change 'will explore employment options' to a postsecondary goal that names an actual field or setting, or it reads as activity language on review."
+
+**Misuse note:** Generalists treat any transition-related sentence in the IEP as "the postsecondary goal." Activity-verb phrasing ("explore," "learn about," "become aware of") reads as reasonable to a non-specialist because it describes something the student will visibly do — the giveaway that it's still activity language, not outcome language, is that it names no setting, program, or occupation the student is heading toward. See `references/red-flags.md` for how this shows up in state monitoring.
+
+### Participating agency
+
+**Definition:** An outside organization (most often Vocational Rehabilitation) that must be invited to the IEP meeting, with parental consent documented, whenever a postsecondary goal implicates services that agency provides — a specific procedural trigger, not a discretionary courtesy invite.
+
+**In use:** "The employment goal names the automotive service sector, so a Vocational Rehabilitation invitation with consent is now a required item, not an optional add."
+
+**Misuse note:** Generalists read "participating agency" as "any agency someone thought to mention" and treat the invitation as good practice rather than a compliance requirement that a reviewer will specifically check for whenever an occupational goal is on file.
+
+### Course of study
+
+**Definition:** The multi-year sequence of courses in the IEP that must be shown to reasonably enable both the stated postsecondary goal(s) and close any identified credit-pace gap — a planning artifact cross-checked against two things at once, not a copy of the student's class schedule.
+
+**In use:** "The course of study lists the right electives for the automotive goal, but it doesn't show the credit-recovery block that closes the pace gap from 9th grade."
+
+**Misuse note:** Generalists treat "course of study" as interchangeable with "schedule" or "class list," and file it without checking whether the sequence actually resolves the credit math — a course of study can name all the right classes and still not add up to graduation on time.
+
+### Age of majority (rights transfer)
+
+**Definition:** The scheduled procedural trigger — beginning at least 12 months before the student reaches the age at which IDEA rights transfer to them (18 in most states; 19 in Alabama and Nebraska; 21 in Mississippi) — requiring documented notice of which rights are transferring, not the birthday itself.
+
+**In use:** "Age of majority isn't next month's paperwork — it needs to be on this year's agenda now, a full year out."
+
+**Misuse note:** Generalists treat it as an event to react to near the birthday rather than a deadline to schedule a year ahead; a notice dated within 90 days of the birthday is itself a red flag that the trigger was handled reactively instead of on schedule.
+
+### Manifestation determination
+
+**Definition:** The specific, legally required review — triggered once disciplinary removal exceeds 10 cumulative school days in a year — of whether the behavior underlying a disciplinary placement change was a manifestation of the student's disability, run before finalizing any such placement change.
+
+**In use:** "Before that placement change goes through, run the manifestation determination — cumulative removals just crossed 10 days."
+
+**Misuse note:** Generalists conflate it with an informal "let's talk about why this happened" conversation, or assume it only applies to a single long suspension rather than the cumulative day count across the year, which is the actual trigger.
+
+### Alternate assessment (AA-AAAS)
+
+**Definition:** The 1%-cap alternate state assessment for students with the most significant cognitive disabilities — a participation decision that is legally decoupled from the diploma-track decision, meaning selecting it does not by itself foreclose a later attempt at a regular diploma.
+
+**In use:** "Document the AA-AAAS participation decision and the diploma-track acknowledgment as two separate, separately dated items — not one bundled conversation."
+
+**Misuse note:** Generalists tell families the alternate assessment "means" the alternate diploma track, treating one decision as automatically implying the other. Even when the case manager did mention the tracks are separate, a reviewer checking the file afterward has no way to confirm it unless the acknowledgment is a distinct, separately dated document — a single bundled signature line reads as a compliance gap regardless of what was said out loud in the room.
+
+### On-track indicator (9th-grade on-track)
+
+**Definition:** The specific, empirically validated flag — fewer than 5.0 full-year credits earned or more than one core-course semester F by the end of 9th grade — used as the primary graduation-risk signal for a caseload, distinct from and a stronger predictor than the student's own IEP goal-progress trend line.
+
+**In use:** "He's making progress on his IEP goals, but he's below the on-track indicator — 3.0 credits and two core Fs — so he's still the caseload's top graduation-risk flag."
+
+**Misuse note:** Generalists use "on track" loosely to mean "doing okay" or infer it from IEP progress data. The indicator is a specific credit/GPA threshold pulled from the transcript, checked independently of goal progress, and it outranks goal-trend data as a graduation predictor.
+
+### Co-teaching model (by name)
+
+**Definition:** One of Cook & Friend's six named delivery structures — one teach/one observe, one teach/one assist, station, parallel, alternative, team — each matched to a specific classroom activity type (e.g., station teaching for skills-practice rotation, one-teach/one-assist for lecture), not a single default arrangement used regardless of the day's activity.
+
+**In use:** "Log which model ran each day this week — one-teach/one-assist on lecture days, station teaching on practice days — not just 'co-taught' across the board."
+
+**Misuse note:** Generalists say "we co-teach that period" as if it names a single fixed arrangement. Running the same model every day regardless of activity — usually one-teach/one-assist by default — is itself a documented overuse pattern that wastes the content co-teacher's planning time without matching delivery to need.
+
+### Credit-recovery pace gap
+
+**Definition:** The specific arithmetic result of (remaining credits needed ÷ remaining years enrolled) minus the district's standard annual credit pace — a number that determines whether a proposed remediation (credit recovery, summer term, 5th year) actually closes the shortfall, not just gestures at it.
+
+**In use:** "One credit-recovery block a semester only closes the gap if it runs every remaining year — recalculate it: a 1.0/year gap over 3 remaining years is a 3.0-credit shortfall, so a plan covering only 2 of those years is still 1.0 credit short."
+
+**Misuse note:** Generalists add a credit-recovery block as a general remedy without recalculating whether the added credits actually close the specific numeric gap across *every* remaining year, not just some of them; a plan that covers fewer years than the student has left is a red flag that the fix was never checked against the full shortfall it's supposed to solve.
+
+### Age-appropriate transition assessment
+
+**Definition:** The specific evidentiary instrument (interest inventory, work-sample, adaptive-behavior scale) underlying a postsecondary goal, which Indicator 13 requires be re-administered annually — not a one-time intake step completed once and left on file for subsequent years.
+
+**In use:** "The interest inventory on file is from age 14 — this student is 17 now, so it needs to be re-administered before this year's goal is finalized, not just cited from three years ago."
+
+**Misuse note:** Generalists treat the transition assessment as a single intake event completed once at the start of secondary school. A goal built on an assessment more than 12 months old fails Indicator 13 the same way a missing assessment does, even though "something's on file."
+
+### SDLMI (Self-Determined Learning Model of Instruction)
+
+**Definition:** A specific, named curriculum for teaching goal-setting and self-advocacy skills, meant to be applied to the student's own stated transition goal — not a generic label for any self-advocacy worksheet or activity.
+
+**In use:** "Tie the SDLMI sessions to his actual employment goal — have him set and track a goal about the automotive placement, not a generic 'my strengths' worksheet."
+
+**Misuse note:** Generalists cite "SDLMI" as a checkbox justification for any goal-setting activity, including disconnected worksheets unrelated to the student's actual stated transition goal — the overuse failure mode is running the curriculum's name without its substance.


### PR DESCRIPTION
Rubric score: 17/18

Resolution rationale:

special-education-teacher (25-2059.00) is deliberately grade-band-agnostic, asserting the core craft (PLAAFP, measurable goals, accommodation-vs-modification, LRE, procedural compliance) "doesn't change by grade band; only the content of the goals does." That equivalence held for the granularity test with elementary/middle content but breaks for secondary specifically: IDEA requires transition services (postsecondary goals in training/education/employment/independent living, a coordinated course-of-study tied to diploma-track and graduation requirements, age-appropriate transition assessment, and transfer of educational rights at the age of majority) beginning no later than age 16 — a mandatory IEP component and compliance deadline that simply does not exist for elementary/middle-band caseloads. None of this appears in special-education-teacher's decision framework, tools, or worked example (a 4th-grade reading-fluency goal). Practitioner-nod: a secondary case manager would say transition planning, diploma-track/exit-exam interaction, and age-of-majority rights transfer are central, distinguishing parts of the job. Counterfactual: an agent given only the parent skill would write a procedurally incomplete secondary IEP — omitting required transition-services content — which is a wrong decision, not merely less detail. Non-derivability: the specific compliance triggers (age-16 transition mandate, Indicator 13 checklist items, postsecondary-goal wording requirements, age-of-majority notice) can't be regenerated from the general skill or the role title. This mirrors the precedent already set by special-education-teacher-preschool, which was split out for its own genuinely distinct band-specific decisions (Part C-to-B transition clock, ECO-organized PLAAFP, developmental-delay SD thresholds, embedded instruction, staffing-ratio LRE test) under the same parent. A reasonable parent exists (special-education-teacher, which already documents the shared core craft and explicitly defers band-specific content), so verdict is new_leaf rather than new_parent. Proposed slug follows the existing `special-education-teacher-preschool` naming convention, substituting the O*NET band descriptor (secondary) consistent with the directory's kebab-case pattern.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `special-education-teacher-secondary` role focused on transition-compliant IEPs and other secondary-only decisions (Indicator 13).

- **New Features**
  - `special-education-teacher-secondary` (leaf of `special-education-teacher`, `25-2058.00`): SKILL plus `playbook`, `red-flags`, `vocabulary`; includes Indicator 13 checklist, course-of-study/credit audit, co-teaching model picker, and age-of-majority notice timing.
  - Repo metadata: updated `data/roles.json`, `README.md`, and `ROADMAP.md` to add this role, mark 25-2058.00 as drafted, reflect 829 roles (80.6% O*NET coverage), Education at 56/68, and “other” count at 174.

<sup>Written for commit 43a3d08cb6916fa5343b9f694426708165f8451c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

