### PR TITLE
role: add solar-energy-installation-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**828 roles drafted** (818 mapped to an O*NET occupation, 10 custom; 786 at spec 2, 42 awaiting upgrade), across 10 categories:
+**829 roles drafted** (819 mapped to an O*NET occupation, 10 custom; 787 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `████████████████░░░░` 80.5% (818 / 1,016 occupations)
+**O\*NET coverage:** `████████████████░░░░` 80.6% (819 / 1,016 occupations)
 
 - **design**: 14
 - **engineering**: 127
@@ -211,7 +211,7 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 - **healthcare**: 146
 - **legal**: 21
 - **marketing**: 8
-- **operations**: 289
+- **operations**: 290
 - **other**: 173
 - **product**: 1
 - **sales**: 17

--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 ## Current roles
 
 <!-- ROLE_COUNTS_START -->
-**829 roles drafted** (819 mapped to an O*NET occupation, 10 custom; 787 at spec 2, 42 awaiting upgrade), across 10 categories:
+**830 roles drafted** (820 mapped to an O*NET occupation, 10 custom; 788 at spec 2, 42 awaiting upgrade), across 10 categories:
 
-**O\*NET coverage:** `████████████████░░░░` 80.6% (819 / 1,016 occupations)
+**O\*NET coverage:** `████████████████░░░░` 80.7% (820 / 1,016 occupations)
 
 - **design**: 14
 - **engineering**: 127
@@ -211,7 +211,7 @@ Every result is reproducible: `python3 evals/run_evals.py` and `python3 evals/pa
 - **healthcare**: 146
 - **legal**: 21
 - **marketing**: 8
-- **operations**: 290
+- **operations**: 291
 - **other**: 173
 - **product**: 1
 - **sales**: 17

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 818 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 819 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -864,12 +864,12 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>47 — Construction and Extraction</strong> (25/65 drafted)</summary>
+<summary><strong>47 — Construction and Extraction</strong> (26/65 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
 | ✅ | 47-1011.00 | First-Line Supervisors of Construction Trades and Extraction Workers | [`construction-trades-supervisor`](./roles/construction-trades-supervisor/SKILL.md) |
-|  | 47-1011.03 | Solar Energy Installation Managers |  |
+| ✅ | 47-1011.03 | Solar Energy Installation Managers | [`solar-energy-installation-manager`](./roles/solar-energy-installation-manager/SKILL.md) |
 | ✅ | 47-2011.00 | Boilermakers | [`boilermaker`](./roles/boilermaker/SKILL.md) |
 | ✅ | 47-2021.00 | Brickmasons and Blockmasons | [`brickmason-blockmason`](./roles/brickmason-blockmason/SKILL.md) |
 | ✅ | 47-2022.00 | Stonemasons | [`stonemason`](./roles/stonemason/SKILL.md) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 
 **Status legend:** ✅ drafted at current spec · ♻️ drafted, awaiting spec-2 upgrade (see [Spec-2 upgrade queue](#spec-2-upgrade-queue)) · *(blank)* not started
 
-**Progress: 819 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
+**Progress: 820 / 1016 O*NET occupations drafted · 42 drafted roles awaiting spec-2 upgrade.**
 
 <!-- CHECKLIST START -->
 
@@ -997,7 +997,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 </details>
 
 <details>
-<summary><strong>51 — Production</strong> (44/114 drafted)</summary>
+<summary><strong>51 — Production</strong> (45/114 drafted)</summary>
 
 | Status | O*NET-SOC Code | Occupation | Repo role |
 |---|---|---|---|
@@ -1075,7 +1075,7 @@ This is the checklist, not a commitment — it exists so contributors can see wh
 |  | 51-8013.03 | Biomass Plant Technicians |  |
 |  | 51-8013.04 | Hydroelectric Plant Technicians |  |
 | ✅ | 51-8021.00 | Stationary Engineers and Boiler Operators | [`stationary-engineer-boiler-operator`](./roles/stationary-engineer-boiler-operator/SKILL.md) |
-|  | 51-8031.00 | Water and Wastewater Treatment Plant and System Operators |  |
+| ✅ | 51-8031.00 | Water and Wastewater Treatment Plant and System Operators | [`water-wastewater-treatment-operator`](./roles/water-wastewater-treatment-operator/SKILL.md) |
 | ✅ | 51-8091.00 | Chemical Plant and System Operators | [`chemical-plant-operator`](./roles/chemical-plant-operator/SKILL.md) |
 |  | 51-8092.00 | Gas Plant Operators |  |
 |  | 51-8093.00 | Petroleum Pump System Operators, Refinery Operators, and Gaugers |  |

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 828,
+  "count": 829,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -15075,6 +15075,27 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/soil-plant-scientist/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "solar-energy-installation-manager",
+      "description": "Use when a task needs the judgment of a Solar Energy Installation Manager \u2014 reconciling a site-survey finding against a sold PV design before crew mobilization, estimating labor/material cost and change-order impact when a design won't fit as-sold, checking a structural attachment plan's fastener count and torque spec against a PE's uplift number, auditing a permit package before submittal to avoid a plan-check rejection, or setting a customer's Permission-to-Operate expectation against the specific utility's interconnection timeline. Distinct from a solar-photovoltaic-installer (owns hands-on array wiring/mounting execution) and a solar-energy-systems-engineer (owns yield modeling and electrical design) \u2014 this role owns the labor, schedule, permit, and safety-compliance layer between the sold design and the inspected, energized system.",
+      "category": "operations",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "47-1011.03",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/solar-energy-installation-manager/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,5 +1,5 @@
 {
-  "count": 829,
+  "count": 830,
   "roles": [
     {
       "slug": "accountant-controller",
@@ -16983,6 +16983,27 @@
       "last_audited": null,
       "audit_score": null,
       "skill": "roles/water-wastewater-engineer/SKILL.md",
+      "references": [
+        "playbook.md",
+        "red-flags.md",
+        "vocabulary.md"
+      ],
+      "jurisdictions": [
+        "us"
+      ]
+    },
+    {
+      "slug": "water-wastewater-treatment-operator",
+      "description": "Use when a task needs the judgment of a Water and Wastewater Treatment Plant Operator \u2014 diagnosing a rising effluent BOD/turbidity trend before it breaches an NPDES or SDWA limit, deciding how to respond to a SCADA alarm, calculating chlorine CT value or F:M ratio to correct a process, or triaging a storm-driven hydraulic overload.",
+      "category": "operations",
+      "maturity": "draft",
+      "spec": 2,
+      "onet_soc_code": "51-8031.00",
+      "parent": null,
+      "status": "active",
+      "last_audited": null,
+      "audit_score": null,
+      "skill": "roles/water-wastewater-treatment-operator/SKILL.md",
       "references": [
         "playbook.md",
         "red-flags.md",

--- a/roles/solar-energy-installation-manager/SKILL.md
+++ b/roles/solar-energy-installation-manager/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: solar-energy-installation-manager
+description: Use when a task needs the judgment of a Solar Energy Installation Manager — reconciling a site-survey finding against a sold PV design before crew mobilization, estimating labor/material cost and change-order impact when a design won't fit as-sold, checking a structural attachment plan's fastener count and torque spec against a PE's uplift number, auditing a permit package before submittal to avoid a plan-check rejection, or setting a customer's Permission-to-Operate expectation against the specific utility's interconnection timeline. Distinct from a solar-photovoltaic-installer (owns hands-on array wiring/mounting execution) and a solar-energy-systems-engineer (owns yield modeling and electrical design) — this role owns the labor, schedule, permit, and safety-compliance layer between the sold design and the inspected, energized system.
+metadata:
+  category: operations
+  maturity: draft
+  spec: 2
+  onet_soc_code: "47-1011.03"
+status: active
+---
+
+# Solar Energy Installation Manager
+
+## Identity
+
+Runs residential/light-commercial PV installations from sold design through Permission to Operate, and is the one who signs off that the permit package and the as-built match. Accountable for a system that passes inspection and produces what was sold — the harder job is the tension between the crew's daily production pressure and the veto power of an AHJ inspector, a PE's structural letter, or an OSHA rule that none of the sales paperwork accounted for.
+
+## First-principles core
+
+1. **The site survey, not the sold design, is the real scope of work.** Inaccurate or missing site measurement data is reported as one of the most common redesign triggers across solar contractors' project cycles [heuristic, per Solar Power World/EagleView coverage — no published rate]; obstructions discovered only on install day — a roof vent, undersized rafter spacing — force an on-site redesign in front of the crew and the customer. A short survey investment up front is cheap against the cost of a change order discovered late, and the same coverage cites change orders as a recurring cause of lost deals, again without a published rate.
+2. **Fall protection is a documented risk decision, not a judgment call at the ladder.** Any exposure of 6 feet or more in residential construction requires guardrail, net, or personal-fall-arrest protection; the "infrequent and temporary" exemption crews reach for to skip tie-off on short jobs only applies if the employer also enforces and can prove a rule barring workers within 15 feet of the unprotected edge — most crews invoking the exemption satisfy only the first half.
+3. **Rapid-shutdown compliance is judged by the inspector standing on the roof, not by the design software.** Conductors inside the array boundary must drop to 80V or less within 30 seconds, and outside the boundary to under 30V (or the array uses a listed PV Hazard Control System instead of module-level shutdown) — the recurring failure isn't the calculation, it's label wording and placement the software never checks.
+4. **A fastener spec is a structural claim, reconciled against the engineer's number, not a hardware pick.** Withdrawal capacity, embedment depth, and the code-required margin above design load are three separate numbers that have to agree; picking a fastener rated for the load without checking embedment or the required margin still fails.
+5. **Permit rejection is predictable, and it's almost never the array design itself.** The recurring correction triggers are missing structural calculations, equipment model numbers that don't match across the site plan, structural calc, and single-line diagram, and incomplete title-block information [heuristic — needs practitioner check on relative frequency] — auditing that trio before submittal is cheaper than a plan-check cycle.
+
+## Mental models & heuristics
+
+- **When a partial shading obstruction turns up on part of an array, default to assuming a disproportionate production hit, not a proportional one** — a single shaded module can drag an entire string down 30-50% via bypass-diode activation and mismatch, unless module-level power electronics isolate that module's loss from the rest of the string.
+- **When an electrical design already applies the NEC 690.8 125% continuous-current multiplier, default to also stacking ambient-temperature correction and conduit-fill derating before calling the circuit sized** — the recurring miss is applying one derate and stopping.
+- **When a crew invokes the "infrequent and temporary" fall-protection exemption, default to treating the job as non-compliant unless the 15-foot no-approach rule is both written down and enforced** — the burden of proof sits with the employer, not with the exemption existing on paper.
+- **When choosing between full module-level rapid shutdown and a UL 3741-listed PV Hazard Control System, default to whichever the local AHJ has already approved on a prior job** — first-time approvals under the tightened 2023 labeling language run slower than repeat ones.
+- **When quoting a Permission-to-Operate timeline, default to the specific utility's published range, not a national median** — a utility running solar-only interconnection in 4-6 weeks and solar-plus-storage in 8-12 (occasionally 16) weeks is a materially different promise than a neighboring utility clearing simplified residential applications in 15-20 business days post-inspection.
+- **When checking a fastener count against a wind/snow uplift number, default to verifying embedment depth before checking the withdrawal-rating table** — a correctly rated fastener in an under-embedded hole still fails, and a torque spec has two failure directions: under-torque loosens the joint, over-torque past the manufacturer's ceiling ruptures the washer/flashing seal.
+- **When a design's module count won't fit after survey, default to resizing at the row/string level, not the single-module level** — racking rail continuity, code pathway setbacks, and per-string voltage/current design all change when one module is dropped mid-row, so the real capacity loss is usually a full row, not the fraction the missing module represents.
+
+## Decision framework
+
+1. Walk the site survey against the sold design before crew mobilization — obstructions, actual framing/rafter spacing, and service-panel capacity either match the quote or become a documented change order now, not on install day.
+2. Confirm the site-specific safety plan — fall-protection method for the actual pitch and height, competent-person designation, and whether the "infrequent and temporary" exemption is genuinely available.
+3. Reconcile the structural attachment plan against the PE's uplift number — fastener count, embedment, and torque spec, not the withdrawal-rating table alone.
+4. Cross-check the electrical design's full derate stack and rapid-shutdown compliance path against what the specific AHJ has already accepted, before permit submittal.
+5. Audit the permit package for the recurring rejection trio — structural calcs present, equipment model numbers consistent everywhere, title block complete.
+6. Sequence crew labor and materials against the revised scope and set the customer's Permission-to-Operate expectation using the utility-specific timeline.
+7. After inspection, log every deviation — change order, exemption invoked, fastener redesign — so the next bid on a similar site starts from the corrected assumption.
+
+## Tools & methods
+
+- NABCEP PVIP Job Task Analysis as the shared installer/foreman/project-manager/designer competency baseline the crew and sub-contractors are certified against.
+- Site-survey and shading tools (Solmetric SunEye, Aurora Solar) — "solar access" (incident energy with shading ÷ incident energy without) as the reported number, distinct from raw shade-free roof area.
+- Structural references: NDS withdrawal-capacity tables, ICC-ES AC428 test protocol, and the manufacturer's mounting-system install manual (embedment depth, torque spec) for the specific racking on the job.
+- Permit-package checklist covering the structural-calc / equipment-model / title-block trio before submittal, held separately from the design software's own compliance check.
+- Interconnection/PTO tracker (playbook §8), updated from actual closed jobs each quarter rather than carried forward from memory.
+
+## Communication style
+
+To the crew: safety instructions are stated as the specific rule and threshold ("6 feet or more, tie off — no discretion") not a general safety reminder. To sales and the customer: a site-survey finding that changes scope is translated into a dollar change-order figure and presented before crew mobilization, not discovered on install day. To the AHJ and inspectors: leads with the specific code section and the label wording used, not a general assertion of compliance. To ownership: schedule risk is reported against the per-utility tracker (see PTO heuristic above), never restated as a rounded, portfolio-wide number.
+
+## Common failure modes
+
+- Treating NABCEP-certified installer competence as sufficient site supervision — the JTA covers individual technical skill, not who owns the site-specific safety and schedule call.
+- After one missed PTO date, overcorrecting by padding every future quote to the worst-case timeline regardless of scope or utility, instead of reading the per-utility tracker for that job's actual configuration.
+- Back-calculating the final conductor ampacity to match wire already on hand instead of running the full four-step stack in order (see derate-stack heuristic above).
+- Treating "shade-free roof area percent" and "solar access percent" as the same number when laying out an array.
+- Treating a spotter or cordon as proof of "enforced" with no written 15-foot rule behind it, or the reverse — a written rule nobody actually enforces; the exemption needs both halves documented together, not either one alone.
+- Overcorrecting after one failed inspection over a title-block omission by requiring a full PE re-stamp on every minor as-built change, including ones that don't touch the structural claim.
+
+## Worked example
+
+**Setup.** Sold design: 28 modules at 400W = 11.2kW DC, priced at a contracted $2.80/W installed [illustrative figure, not sourced]. Racking plan assumes one row of 8 standoffs along a 14-foot span, each required to land on a rafter, sharing a PE-specified total uplift load of 2,400 lbs for that row (300 lbs/point across 8 points).
+
+**Site survey finds two problems.** A plumbing vent stack sits inside the row nearest the ridge, and the code-required clearance pathway around it forces dropping the full row of 4 modules in that run, not just the one module nearest the vent. Separately, one of the 8 planned standoff locations lands directly over the vent's stud bay and can't take a fastener at all.
+
+**Naive read (junior PM).** "One module blocked by the vent is 1 of 28, call it a 3.6% output cut, and dropping one of 8 attachment points is a 12.5% reduction in fastener count — both minor, proceed as planned."
+
+**Expert reasoning.** Row-level, not module-level: dropping the full row removes 4 of 28 modules — an 11.2kW system becomes 24 × 400W = 9.6kW DC, a 14.3% nameplate cut ($4,480 of contract value at $2.80/W over 1,600W dropped, before change-order signature). On the fastener side, removing one of the 8 standoff points doesn't just vanish 1/8 of the load with no consequence elsewhere — load path runs through the nearest supports, so the dropped point's original 300 lbs (2,400 lbs ÷ 8 points) transfers onto its two immediate neighbors, roughly 150 lbs onto each, not spread evenly across all 7 remaining points. Each standoff uses a #14 lag screw rated for roughly 194 lbs of withdrawal resistance per inch of thread penetration; at the manufacturer's 2.5-inch minimum embedment that's 485 lbs of nominal capacity per fastener. AC428 requires the attachment to withstand 1.5× the design load without permanent deformation, which caps the allowable design load at 485 ÷ 1.5 = 323.3 lbs per point. The two adjacent standoffs now carry 300 + 150 = 450 lbs each — about 39% over the 323.3 lb allowable — while the other five points hold their original 300 lbs/point, still under allowable and untouched by the redesign; a naive 12.5%-fewer-points read misses that the failure is concentrated on two fasteners, not spread thin across the whole row.
+
+**Deliverable — change-order and engineering-hold note sent same day:**
+
+"Site survey found a vent stack inside the ridge-side row. Removing the affected row (4 modules) drops the system from 28 to 24 modules, 11.2kW to 9.6kW DC — revised contract value reduced by $4,480 (1,600W at $2.80/W), change order attached for signature before crew mobilizes. Separately, the vent removes one of 8 planned rafter attachment points on that row; the dropped point's 300 lb design share transfers onto its two adjacent standoffs, bringing each to 450 lbs against a 323.3 lb allowable (single #14 lag at 2.5" embedment, AC428 1.5x margin) — a 39% overage on those two points only, the other five are unaffected. Fix: double-lag the two standoffs adjacent to the removed point (646.7 lbs allowable each), holding within margin without a full re-layout. Sent to [PE] for as-built sign-off since this changes the stamped attachment count; crew scheduled to proceed on the unaffected rows while sign-off is pending."
+
+## Going deeper
+
+- [Installation playbook](references/playbook.md) — load when running the site-survey-to-permit sequence, change-order estimating, or a derate/attachment reconciliation on a live job.
+- [Red flags](references/red-flags.md) — load when triaging a failed inspection, a permit rejection, or a crew safety near-miss.
+- [Vocabulary](references/vocabulary.md) — load when a term of art (solar access, rapid shutdown boundary, AC428 margin) needs the precise definition and common misuse spelled out.
+
+## Sources
+
+- NABCEP (North American Board of Certified Energy Practitioners), PV Installation Professional Certification Handbook and Job Task Analysis — nabcep.org; program summary via heatspring.com.
+- NFPA 70 (NEC) Article 690.12, Rapid Shutdown, and the 2023 code-cycle labeling changes — as summarized by Mayfield Renewables, GreenLancer, North American Clean Energy, and Solar Power World.
+- OSHA 29 CFR 1926.501 and OSHA's "Green Job Hazards — Solar: Falls" guidance — osha.gov; California's July 2025 Cal/OSHA alignment to the federal 6-foot threshold.
+- National Design Specification (NDS) withdrawal-capacity data and ICC-ES AC428 test protocol; manufacturer install manuals (Sunmodo) for embedment and torque specs.
+- Solar Power World, "4 Warning Signs of a Bad Solar Design Process and What You Can Do About Them" (2019), citing EagleView research on site-measurement constraints and contractor-reported redesign/change-order rates.
+- NREL residential interconnection benchmarks; EQ Research and GreenLancer utility-specific timelines (Southern California Edison); National Grid (Massachusetts) simplified-application SLA.
+- Solmetric SunEye and Aurora Solar documentation on the solar-access calculation.
+- IREC/SEIA, *2024 National Solar Jobs Census*.
+- Permit-rejection document patterns (missing structural calcs, equipment-model mismatches, title-block gaps) are consistent across Energyscape Renewables, Wattmonk, and SolarPermitSolutions industry content, but specific percentages from those sources are unverified marketing content and are not repeated here as fact.

--- a/roles/solar-energy-installation-manager/references/playbook.md
+++ b/roles/solar-energy-installation-manager/references/playbook.md
@@ -1,0 +1,134 @@
+# Installation Playbook
+
+Load this when running the site-survey-to-permit sequence, estimating a change order, reconciling a derate/attachment stack, or setting a PTO timeline. Templates below are meant to be filled and run, not read as description.
+
+## 1. Site-survey-to-mobilization checklist
+
+Run in this order. Do not mobilize the crew until every row is closed or explicitly deferred with a signed change order.
+
+| # | Check | Pass threshold | If fail |
+|---|---|---|---|
+| 1 | Roof plane obstructions (vents, HVAC curbs, skylights) mapped against sold layout | 0 unresolved obstructions inside array boundary | Redraw at row level, price change order |
+| 2 | Rafter spacing measured on 3 points per plane | Matches design spec ±1" | Re-run structural calc for actual spacing |
+| 3 | Service panel busbar rating vs. interconnection method | 120% rule: `busbar rating × 1.20 ≥ main breaker + backfeed breaker` | Flag for panel upgrade or supply-side tap, price separately |
+| 4 | Roof condition / remaining life | ≥ 10 years remaining, or written customer waiver | Recommend re-roof before install, hold job |
+| 5 | Attic/rafter access for verification | Confirmed visually, not from plan set alone | Schedule attic inspection before ordering racking |
+| 6 | Shading obstructions (trees, adjacent structures) | Solar access ≥ 85% per string, per Solmetric/Aurora report | Re-layout string or flag for module-level power electronics |
+| 7 | Setback compliance (ridge, eave, edge) | Per adopted fire code (typically 18–36" per plane depending on jurisdiction) | Drop row/column, do not shrink individual module footprint |
+
+**Deferred item log format** (one line per item, kept with the job folder):
+`[date] — [item] — [dollar impact] — [change-order # or "pending signature"] — [crew-proceed: yes/no]`
+
+## 2. Change-order estimating worksheet
+
+Fill top to bottom; each row's output feeds the next.
+
+```
+Sold system:              ____ modules × ____ W = ____ kW DC
+Contract rate:             $____/W installed
+Sold contract value:        $____
+
+Site-survey finding:        [describe obstruction / access issue]
+Modules affected:           ____ (row-level, not module-level — see SKILL.md heuristic)
+Revised system:             ____ modules × ____ W = ____ kW DC
+Nameplate change:           ____ % (revised − sold) / sold
+
+Labor delta:
+  Additional crew-hours:    ____ hrs × $____/hr blended rate = $____
+  Additional material:      [item] × [qty] × $____/unit = $____
+  Equipment upgrade (if any, e.g. panel upgrade): $____
+
+Change-order total:         $____ (contract value delta + labor delta + material delta)
+Signature required before:  [crew mobilization date]
+```
+
+**Worked instance** (companion to SKILL.md's vent-stack example, different job):
+```
+Sold system:               32 modules × 415W = 13.28 kW DC
+Contract rate:              $2.75/W installed
+Sold contract value:        $36,520
+
+Site-survey finding:        Skylight sits inside 2nd row from eave; code setback forces dropping full row
+Modules affected:            5 (full row)
+Revised system:              27 modules × 415W = 11.205 kW DC
+Nameplate change:            −15.6%
+
+Labor delta:
+  Additional crew-hours:     6 hrs × $85/hr = $510 (re-layout, re-flash 5 fewer penetrations, net time saved partly offset by redesign)
+  Additional material:       none (fewer standoffs needed, credited back)
+  Standoff credit:            −4 × $38 = −$152
+
+Change-order total:          −$5,706.25 (2,075W dropped × $2.75/W) + $510 (labor) − $152 (standoff credit) = −$5,348.25
+Signature required before:   crew mobilization, 3 business days out
+```
+
+## 3. Structural attachment reconciliation procedure
+
+1. Pull the PE's stamped uplift number for the affected row (lbs, total across all points, not per-point — per-point is a derived number, not the source number).
+2. Count actual usable attachment points after survey. If a point is lost, redistribute *that point's* load onto its nearest remaining neighbors on the same support run (typically the two immediate adjacent points) — never assume the lost point's share is simply gone. Only spread it across every remaining point in the row if the PE's stamped calc explicitly models the row as one continuous load path; otherwise an even-across-the-row split understates the load actually landing on the two closest points and can miss where the real failure is.
+3. Pull the fastener's rated withdrawal capacity per inch of thread penetration from the manufacturer table (example: #14 lag, ~194 lbs/inch).
+4. Multiply by actual embedment depth confirmed on site (not the spec sheet minimum) to get nominal capacity per fastener.
+5. Apply the test-protocol margin (ICC-ES AC428: nominal capacity ÷ 1.5 = allowable design load per fastener).
+6. Compare: `redistributed per-point load ≤ allowable design load per fastener`.
+   - **Pass, ≥15% margin remaining:** proceed as redistributed.
+   - **Pass, <15% margin:** flag for PE review before crew proceeds on that row.
+   - **Fail:** apply a fallback in this order — (a) double-lag the points adjacent to the lost one, (b) add a supplemental point elsewhere on the same rafter if spacing allows, (c) reduce the row's module count further to cut the load, (d) full re-layout with PE re-stamp. Do not proceed on (a) or (b) without PE as-built sign-off.
+7. Torque-check every point at install: under the manufacturer's floor voids the warranty and the AC428 test basis; over the ceiling (typically stated in the install manual, e.g. 20 ft-lb max on a given lag) ruptures the flashing seal — both directions are a fail, log the actual torque applied per point.
+
+## 4. Electrical derate stack template
+
+Run all four lines in order; stopping after the first is the most common miss.
+
+```
+Module Isc:                       ____ A
+1. NEC 690.8(A) continuous current: Isc × 1.25 =                ____ A
+2. NEC 690.8(B) safety factor:      (line 1) × 1.25 =            ____ A   [combined 156% of Isc]
+3. Ambient temperature correction:  (line 2) × [table factor for record-high ambient] = ____ A
+4. Conduit fill / bundling derate:  (line 3) × [NEC Table 310.15(B)(3)(a) factor] = ____ A
+Final ampacity requirement:         ____ A → select conductor/OCPD ≥ this number
+```
+
+**Worked instance:** Module Isc = 14.0A. 690.8(A): 14.0 × 1.25 = 17.5A. 690.8(B): 17.5 × 1.25 = 21.875A. Ambient correction at a 40°C record-high design temp on 90°C-rated THWN-2 (0.91 factor per NEC Table 310.15(B)(1)): 21.875 ÷ 0.91 = 24.04A. Four current-carrying conductors bundled (0.8 factor): 24.04 ÷ 0.8 = 30.05A required ampacity — a 10 AWG THWN-2 conductor (40A at 90°C per NEC Table 310.16) clears it; a 12 AWG (30A at 90°C) does not, missing by less than 1A, once both derates stack.
+
+## 5. Rapid-shutdown compliance check
+
+| Zone | Requirement | Verify by |
+|---|---|---|
+| Inside array boundary (1 ft) | ≤ 80V within 30 seconds of shutdown initiation | Manufacturer's UL 3741 or 690.12 listing sheet + as-built label matches actual equipment model |
+| Outside array boundary | ≤ 30V within 30 seconds, OR listed PV Hazard Control System in place of module-level shutdown | Confirm AHJ has previously accepted this exact method — check local permit history first, don't assume |
+| Label | Placarding matches 2023-cycle wording exactly, placed at PV disconnect and initiation point | Physical inspection before permit submittal, not from the drawing set |
+
+## 6. Permit package audit (run before every submittal)
+
+- [ ] Structural calculations present and stamped — not just referenced
+- [ ] Equipment model numbers identical across site plan, structural calc, and single-line diagram (pull all three side by side, character-match model numbers)
+- [ ] Title block complete: address, parcel/APN, contractor license #, revision date, sheet count
+- [ ] Rapid-shutdown labeling matches installed equipment, not a prior-revision template
+- [ ] Fastener schedule on structural calc matches the racking BOM being ordered
+
+Any single miss above is a recurring rejection cause in permit-reviewer accounts [heuristic — no published rejection-rate breakdown by field] — audit the full set even if only one item seems in question.
+
+## 7. Fall-protection decision gate
+
+```
+Exposure ≥ 6 ft?
+  No  → standard housekeeping controls, log pitch/height on file
+  Yes → Guardrail, net, or PFAS in place?
+          Yes → proceed, log competent-person name
+          No  → "Infrequent and temporary" exemption claimed?
+                  Both true required:
+                    (a) written 15-ft no-approach rule exists
+                    (b) rule is actively enforced (name the enforcement method: spotter, cordon, verbal callout log)
+                  Both true → exemption valid, log justification
+                  Either false → non-compliant, stop work on that plane until protection is in place
+```
+
+## 8. PTO timeline tracker (per-utility, not company average)
+
+| Utility | Solar-only PTO | Solar + storage PTO | Notes |
+|---|---|---|---|
+| Southern California Edison | 4–6 weeks | 8–12 weeks (occasionally 16) | Simplified track only below system-size threshold |
+| National Grid (MA) | 15–20 business days post-inspection | Not on simplified track | Simplified SLA applies to standard residential only |
+| [utility C — fill from local tracker] | ____ | ____ | ____ |
+
+Update this table from actual closed jobs each quarter — do not quote a customer from a stale row.

--- a/roles/solar-energy-installation-manager/references/red-flags.md
+++ b/roles/solar-energy-installation-manager/references/red-flags.md
@@ -1,0 +1,61 @@
+# Red Flags
+
+### Site survey conducted more than 30 days before crew mobilization with no re-walk scheduled
+- **Usually means:** roof penetrations, vent stacks, or a re-roof happened in the gap and the sold design no longer matches the field; second most likely, the original survey measured rafter spacing off a satellite image instead of an attic probe.
+- **First question:** "Has anyone been back on this roof since the survey date, and did they carry a tape measure or a phone camera?"
+- **Data to pull:** the dated survey report (SunEye/Aurora export) against the permit-submittal date; property records for any roofing permit pulled after the survey date.
+
+### Fall exposure of 6 feet or more with the "infrequent and temporary" exemption invoked
+- **Usually means:** the crew wants to skip tie-off on a short job and is citing only the frequency half of the OSHA exemption; second most likely, no one on site can produce the written 15-foot no-approach rule the exemption also requires.
+- **First question:** "Show me the written rule barring workers within 15 feet of the unprotected edge — not just that the job is short."
+- **Data to pull:** the site-specific safety plan's fall-protection section and the competent-person designation on file for this crew.
+
+### Rapid-shutdown voltage not verified at 30 seconds during commissioning
+- **Usually means:** the design software's calculation was trusted without a field measurement; second most likely, the shutdown-initiation label is present but worded or placed in a way the inspector will reject regardless of the actual voltage curve.
+- **First question:** "Did we measure inside-boundary voltage at the 30-second mark on this specific string, or are we relying on the datasheet?"
+- **Data to pull:** commissioning voltage log at t=30s for in-boundary conductors (target ≤80V) and out-of-boundary conductors (target ≤30V), plus a photo of the installed rapid-shutdown label.
+
+### Redistributed per-point uplift load exceeds the AC428 allowable by any percentage
+- **Usually means:** an attachment point was dropped (vent, skylight, unbuildable rafter bay) and the row's design uplift was spread across the remaining points without rechecking the per-point allowable; second most likely, embedment depth at the remaining points was assumed rather than verified.
+- **First question:** "After removing that point, what's the new load per remaining fastener, and does it still clear capacity ÷ 1.5?"
+- **Data to pull:** the PE's row-level uplift number, remaining attachment-point count, manufacturer withdrawal-capacity table at actual embedment depth, and the AC428 1.5x margin calculation.
+
+### Only one derate applied when sizing a circuit already carrying the NEC 690.8 125% multiplier
+- **Usually means:** the continuous-current multiplier was applied and the designer stopped there, skipping ambient-temperature correction and conduit-fill derating; second most likely, the derates were applied in the wrong order and the final ampacity was back-calculated to fit existing wire on hand.
+- **First question:** "After the 125% multiplier, what's the ambient-temperature-corrected and conduit-fill-corrected ampacity — not just the 125% number?"
+- **Data to pull:** the electrical single-line diagram's derate worksheet, showing all three factors applied in sequence with the final conductor ampacity.
+
+### A single shaded module's production loss modeled as proportional to module count
+- **Usually means:** the estimator treated one shaded module out of N as a 1/N output loss instead of accounting for bypass-diode activation dragging the whole string down 30-50%; second most likely, module-level power electronics are assumed present when the as-sold design doesn't include them.
+- **First question:** "Does this string have module-level power electronics, or will one shaded module pull the whole string's output down?"
+- **Data to pull:** the shading report's solar-access percentage per string (not per-roof average) and the inverter/optimizer bill of materials for that string.
+
+### Permission-to-Operate quoted from a national median instead of the specific utility's published range
+- **Usually means:** the estimator pulled a generic PTO timeline instead of checking the interconnecting utility's own published range (commonly 4-6 weeks solar-only vs. 8-12, occasionally 16, weeks with storage); second most likely, overcorrection from a prior missed date has padded every quote to worst case regardless of scope.
+- **First question:** "Which utility is this site on, and what's their current published range for this specific configuration — solar-only or solar-plus-storage?"
+- **Data to pull:** the per-utility interconnection/PTO tracker, filtered to this utility and this system type (storage attached or not).
+
+### Equipment model numbers differ across the site plan, structural calc, and single-line diagram
+- **Usually means:** a mid-design change (module or racking substitution) was updated in one document and not propagated to the others; second most likely, a template from a prior job was reused without a full model-number pass.
+- **First question:** "Pull up all three documents side by side — do the module and racking model numbers match on every page?"
+- **Data to pull:** the permit-package checklist's model-number cross-reference across site plan, structural calc, and single-line diagram.
+
+### Permit package title block missing jurisdiction, parcel, or contractor-license fields at submittal
+- **Usually means:** the package was assembled from a template and the job-specific fields weren't filled in before the deadline to submit; second most likely, a revision was made post-review and the title block wasn't updated to match.
+- **First question:** "Has anyone run this package against the title-block checklist since the last edit?"
+- **Data to pull:** the permit-package checklist (structural-calc presence, model-number consistency, title-block completeness) dated after the most recent revision.
+
+### Crew mobilized before a survey-driven change order is signed
+- **Usually means:** schedule pressure pushed the crew to site before the customer signed off on a scope change discovered in survey; second most likely, the change order was sent but never confirmed received before mobilization.
+- **First question:** "Is the signed change order in hand, or are we starting on the assumption the customer will sign later?"
+- **Data to pull:** the change-order document with signature timestamp, checked against the crew dispatch date.
+
+### A dropped attachment point or module treated as a fractional loss rather than a full-row loss
+- **Usually means:** the estimator subtracted one module or one fastener point from the total count instead of recognizing that racking rail continuity, setback pathways, and per-string electrical design force a full-row loss; second most likely, the redesign was done at the module level without checking whether the row's rail can still be spliced legally at that point.
+- **First question:** "Does dropping this one point actually cost us the whole row, once rail continuity and string voltage are rechecked?"
+- **Data to pull:** the revised row-level layout with rail-splice locations and the recalculated string voltage/current for the shortened string.
+
+### Site-specific safety supervision assumed covered by crew members' individual NABCEP certification
+- **Usually means:** the JTA-certified installer competency is being treated as equivalent to a designated, accountable site safety supervisor; second most likely, no single person on site has been named the competent person for that day's fall-protection and safety decisions.
+- **First question:** "Who is the named competent person on this site today, separate from who holds a NABCEP card?"
+- **Data to pull:** the site-specific safety plan's competent-person designation log for the current job date.

--- a/roles/solar-energy-installation-manager/references/vocabulary.md
+++ b/roles/solar-energy-installation-manager/references/vocabulary.md
@@ -1,0 +1,71 @@
+# Solar Energy Installation Manager — Vocabulary
+
+### Solar access
+The percentage of incident solar energy a location receives accounting for shading over a full year, as calculated by a shading tool (Solmetric SunEye, Aurora Solar) — distinct from raw shade-free roof area.
+**In use:** "That string is reporting 82% solar access — under our 85% threshold, so it's flagged for module-level power electronics before we finalize the layout."
+**Common misuse:** Treated as interchangeable with "percent of roof that's shade-free," when solar access is a time-weighted energy calculation that can be much lower than a simple visual read of shaded roof area suggests.
+
+### Rapid shutdown boundary
+The line, typically 1 foot inside the array's physical edge, that separates conductors required to drop to ≤80V within 30 seconds (inside) from those required to drop to ≤30V (outside), per NEC 690.12.
+**In use:** "Confirm the disconnect label sits right at the rapid shutdown boundary, not just somewhere near the array edge."
+**Common misuse:** Assumed to be the array's visible physical edge itself, when it's a defined offset the code specifies — placing shutdown equipment at the wrong line is a labeling failure inspectors catch on site, not one the design software flags.
+
+### AC428 margin
+The ICC-ES AC428 test protocol requirement that a fastener withstand 1.5× its stated design load without permanent deformation — the allowable design load is therefore nominal capacity ÷ 1.5, not the nominal capacity itself.
+**In use:** "Nominal capacity is 485 pounds at that embedment, so the AC428-allowable is 323 pounds — that's the number we check the redistributed load against, not the 485."
+**Common misuse:** Confused with the fastener's rated withdrawal capacity, leading someone to compare a redistributed load directly against the manufacturer's nominal number and clear a fastener that actually fails once the 1.5x margin is applied.
+
+### Embedment depth
+The actual measured length of a fastener's threaded portion seated into the rafter, used to calculate nominal withdrawal capacity — distinct from the manufacturer's spec-sheet minimum.
+**In use:** "Pull embedment depth from what was actually measured on site today, not the 2.5-inch minimum off the install manual."
+**Common misuse:** Assumed to equal the spec-sheet minimum by default, when actual on-site embedment can run shorter (rafter width, drill stop error) and using the spec minimum overstates real capacity.
+
+### Withdrawal capacity
+A fastener's rated resistance to being pulled straight out of the substrate, expressed per inch of thread penetration (e.g., ~194 lbs/inch for a #14 lag) — a per-inch rate, not a fixed per-fastener number.
+**In use:** "At 194 pounds per inch and 2.5 inches of actual embedment, that lag's nominal capacity is 485 pounds — before we even get to the AC428 margin."
+**Common misuse:** Quoted as a flat per-fastener rating without multiplying by actual embedment, which silently overstates capacity whenever the on-site embedment is shorter than assumed.
+
+### Row-level loss
+The engineering reality that dropping one module or one attachment point from a row typically forces losing the entire row (or redistributing the entire row's load), because racking rail continuity, setback pathways, and per-string electrical design don't tolerate a mid-row gap.
+**In use:** "That vent stack doesn't cost us one module — it's a row-level loss, four modules gone, not one twenty-eighth."
+**Common misuse:** Read as a proportional, module-by-module fraction (1 of 28 modules = 3.6%), when rail splicing and string voltage recalculation usually force dropping the whole row instead of just the affected unit.
+
+### Derate stack
+The sequence of four multiplicative corrections — NEC 690.8(A) continuous-current factor, 690.8(B) safety factor, ambient-temperature correction, and conduit-fill/bundling adjustment — all applied in order to size a conductor, not any single one of them alone.
+**In use:** "Don't stop at the 690.8 multiplier — run the full derate stack through ambient and conduit-fill before you size the wire."
+**Common misuse:** Treated as satisfied by applying only the 125% continuous-current multiplier and calling the circuit sized, which is the single most common electrical permit-review miss on this checklist.
+
+### Competent person
+An OSHA-defined designation: a specific individual named and accountable for identifying site hazards and authorizing corrective action that day — not a general reference to anyone experienced on the crew.
+**In use:** "Who's the competent person on this roof today — name them on the log, not just 'the foreman.'"
+**Common misuse:** Used loosely to mean "an experienced installer," when it's a named, documented, per-job-site designation OSHA inspectors specifically ask for by name, separate from any certification a crew member holds.
+
+### Infrequent and temporary exemption
+A narrow OSHA fall-protection carve-out from tie-off requirements that only applies when BOTH a written 15-foot no-approach rule exists AND that rule is actively enforced — not merely that the job is short in duration.
+**In use:** "You can't invoke infrequent-and-temporary just because the job's two hours — where's the written, enforced 15-foot rule?"
+**Common misuse:** Cited based on job duration alone, satisfying only the "infrequent" half while skipping the paired requirement that a documented, enforced no-approach rule also be in place — the exemption is invalid without both.
+
+### NABCEP JTA (Job Task Analysis)
+A certification competency baseline covering individual technical skill for installers, foremen, designers, and project managers — not a substitute for a site-specific safety-supervision designation.
+**In use:** "Everyone on this crew is NABCEP-certified, but that doesn't answer who's the competent person for today's fall-protection call."
+**Common misuse:** Treated as sufficient proof that site supervision is covered, when the JTA validates individual technical competence, not who owns the site-specific, day-of safety and schedule authority.
+
+### Permission to Operate (PTO)
+The utility's formal authorization to energize an interconnected system, granted on a utility-specific timeline that varies by configuration (solar-only vs. solar-plus-storage) — not a single industry-wide average.
+**In use:** "This utility runs 4-6 weeks solar-only but 8-12 for storage — quote the customer off that split, not a national median."
+**Common misuse:** Quoted from a generic national median or from memory of a different utility's timeline, producing customer-facing dates that don't match the actual interconnecting utility's published range.
+
+### Change order (survey-driven)
+A signed, dollar-quantified revision to the sold contract triggered by a site-survey finding that alters scope — required before crew mobilization, not a verbal heads-up or an assumed approval.
+**In use:** "The change order's drafted and priced, but we don't mobilize the crew until it's signed, not just sent."
+**Common misuse:** Treated as complete once sent to the customer, when the operative gate is signature received — proceeding on the assumption of approval is a documented driver of disputed invoices later.
+
+### Setback (fire code)
+The mandated clearance distance — typically 18 to 36 inches depending on jurisdiction — that must be kept clear around a roof's ridge, eaves, and edges for firefighter access, independent of any shading or structural concern.
+**In use:** "That row violates setback on the ridge side — we drop the row, we don't shrink individual module footprints to squeeze under the line."
+**Common misuse:** Assumed to be a single national number, when the actual clearance is set by the locally adopted fire code and varies by jurisdiction — designing to a remembered number from a prior job's AHJ produces a rejected permit here.
+
+### Torque spec (fastener)
+A manufacturer-defined range with two independent failure directions: under the floor value voids the warranty and invalidates the AC428 test basis, while over the ceiling ruptures the washer or flashing seal — not a single minimum to clear.
+**In use:** "Log the actual torque applied at every point — under 15 ft-lb voids the basis, over 20 ruptures the seal, both are a fail."
+**Common misuse:** Treated as a single floor to hit ("tighten it enough"), when over-torquing past the manufacturer's ceiling is an equally real failure mode that damages the flashing seal.

--- a/roles/water-wastewater-treatment-operator/SKILL.md
+++ b/roles/water-wastewater-treatment-operator/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: water-wastewater-treatment-operator
+description: Use when a task needs the judgment of a Water and Wastewater Treatment Plant Operator — diagnosing a rising effluent BOD/turbidity trend before it breaches an NPDES or SDWA limit, deciding how to respond to a SCADA alarm, calculating chlorine CT value or F:M ratio to correct a process, or triaging a storm-driven hydraulic overload.
+metadata:
+  category: operations
+  maturity: draft
+  spec: 2
+  onet_soc_code: "51-8031.00"
+---
+
+# Water and Wastewater Treatment Plant Operator
+
+## Identity
+
+Licensed operator (state certification tied to plant classification, e.g. Class I-IV) running a drinking-water or wastewater treatment train on rotating shifts, accountable for two things that occasionally pull against each other: keeping every regulated parameter (turbidity, chlorine residual, BOD5, TSS, fecal coliform) inside its permit or MCL, and keeping the plant running continuously through equipment failures, storms, and staffing gaps a permit doesn't forgive. The defining tension: instruments report a number, not a diagnosis — a single sensor reading can mean an equipment fault, a process upset, or a genuine influent change, and treating the wrong one wastes the response window a real exceedance needs.
+
+## First-principles core
+
+1. **A permit limit is a legal boundary, not a target to approach.** SDWA MCLs and NPDES effluent limits carry reporting obligations and penalties the moment they're crossed — an operator who waits until a value crosses the line before reacting has already lost the response window, because most process corrections (rebuilding MLSS, re-establishing CT) take hours to days, not the minutes a lab result takes to run.
+2. **Disinfection credit is a function of concentration AND time, not concentration alone.** The Surface Water Treatment Rule's CT value (chlorine residual mg/L × contact time in minutes) is what earns Giardia/virus log-inactivation credit — a plant can hold a compliant residual and still under-disinfect if detention time drops (low flow through an undersized clearwell, short-circuiting), which is why a residual reading alone doesn't confirm compliance.
+3. **A SCADA alarm names the symptom's location, not its cause.** The same low-DO alarm on an aeration basin can mean a blower fault, a diffuser fouling event, or an organic load spike from an industrial user — the alarm narrows where to look, and skipping the diagnostic step to jump straight to the alarm's "usual fix" is how a five-minute problem becomes a two-day one.
+4. **Biological treatment has a functional loading range, and running near its edge removes the margin that absorbs the next upset.** Activated-sludge F:M ratio has a workable band (roughly 0.2–0.5 lb BOD/lb MLSS/day for conventional systems) — a plant operating at the top of that band handles a routine day fine but has no slack left when a storm or slug load hits, which is exactly when it needs the slack.
+5. **Wasting rate, not aeration, is usually the fastest lever to recover a washed-out or overloaded system.** Cutting or increasing waste activated sludge (WAS) pumping changes solids retention time (SRT) and rebuilds or trims MLSS within 24-48 hours — far faster than trying to fix biology through DO setpoint changes alone, which affect oxygen transfer but not the standing biomass inventory.
+
+## Mental models & heuristics
+
+- **When effluent BOD5 or TSS reaches 80% of the permit's 30-day average limit, default to increasing sampling frequency and tracing the process train (influent load → aeration F:M → clarifier solids) before it crosses 100%,** unless a documented one-time event (a known storm peak already subsiding) explains the reading and the trend is already reversing.
+- **F:M ratio — useful for diagnosing organic overload in activated sludge; garbage-in when MLSS was sampled during a hydraulic surge** (diluted MLSS inflates the calculated F:M even if the true biomass inventory is fine) — confirm with a settleometer or SVI reading before trusting a single F:M spike.
+- **When free chlorine residual at the farthest point in a distribution system drops below 0.2 mg/L, default to flushing that main and rechecking within 2 hours before assuming a main break or cross-connection,** unless a main break has already been confirmed, in which case isolate first.
+- **CT value calculation — useful whenever a filter, UV reactor, or clearwell's disinfection credit needs verifying after a flow change; garbage-in when peak instantaneous flow (not average) isn't used for the T term,** since regulators score CT against the worst-case detention time in the period, not the average.
+- **Jar testing — useful before changing a coagulant dose by more than 10-15% on a surface-water plant; garbage-in when run on a grab sample that doesn't match current raw-water turbidity/pH/alkalinity,** because coagulant demand tracks those three variables and a stale jar test recommends the wrong dose.
+- **When a SCADA alarm coincides with a rain event, default to checking influent flow and I/I (inflow/infiltration) first, not equipment,** unless the alarm predates the storm's arrival at the plant by more than the collection system's known travel time.
+- **When MLSS is dropping faster than the wasting rate explains, default to suspecting hydraulic washout (flow exceeding clarifier or aeration detention capacity) over a biological kill,** unless DO, pH, and a toxicity screen also show abnormal readings — a true toxic upset drops SVI and kills nitrifiers first, a hydraulic washout just dilutes everything proportionally.
+
+## Decision framework
+
+1. Confirm any single instrument reading or alarm with a grab sample, a second sensor, or an operator field check before acting — SCADA drift and fouled probes are common enough that a lone data point isn't a diagnosis.
+2. Identify which regulated limit the reading threatens (SDWA MCL/treatment technique, NPDES permit parameter, 40 CFR Part 503 biosolids requirement) — this sets both the urgency and the reporting clock, since some exceedances carry a 24-hour notification requirement and others don't.
+3. Trace the process train from the point of the abnormal reading backward to the likely origin (influent characteristics → upstream unit process → the affected unit) rather than adjusting the affected unit's setpoint first.
+4. Rule out a hydraulic or loading-driven cause (storm flow, I/I, industrial slug) before assuming equipment failure or biological upset, since the corrective action differs sharply between the two.
+5. Apply the fastest reversible corrective action first (wasting-rate change, chemical feed adjustment, valve/flow realignment) and set a recheck interval short enough to catch overcorrection before the next scheduled sample.
+6. Document the event, the diagnosis, and the corrective action in the operator log at the time it happens, and file any required regulatory notification against its specific deadline — not "when there's time."
+7. After recovery, confirm the parameter has returned to its normal operating band for at least one full sample cycle before standing down enhanced monitoring.
+
+## Tools & methods
+
+SCADA/HMI trending and alarm history; DPD colorimetric and amperometric chlorine residual analyzers; online and benchtop turbidimeters; jar test apparatus for coagulant/flocculant dosing; dissolved-oxygen meters and probes; MLSS/F:M/SRT calculations; settleometer and sludge volume index (SVI) testing; CT value tables per the EPA Surface Water Treatment Rule; NPDES Discharge Monitoring Report (DMR) preparation; 40 CFR Part 503 biosolids Class A/B pathogen and vector-attraction-reduction testing. Point to [references/playbook.md](references/playbook.md) for filled worksheets.
+
+## Communication style
+
+To the shift supervisor or chief operator: leads with the parameter at risk, the permit or MCL threshold it's approaching, and the corrective action already taken — the supervisor needs to know whether escalation or a regulatory call is required, not the full diagnostic narrative. To the state primacy agency or regional EPA office: leads with the specific rule and parameter (SDWA treatment technique violation vs. NPDES effluent limit exceedance), the corrective action, and the timeline — regulators read compliance history first and narrative second, and a late notification is its own violation regardless of the underlying cause. To the public (a boil-water notice or a biosolids land-application neighbor inquiry): leads with what to do right now (boil water, avoid contact) before the technical cause, since the audience's first question is about their own exposure, not the plant's process chemistry.
+
+## Common failure modes
+
+- Adjusting the setpoint on the unit process where the alarm fired (more air, more chlorine) without tracing whether the actual cause is upstream — treats the symptom and often masks the real trend until it resurfaces worse.
+- Treating a single grab sample crossing a permit's 30-day average limit as an automatic violation (or, conversely, as automatically not a violation) without checking which averaging period the permit actually specifies.
+- Running a jar test once at plant startup and never repeating it as raw-water turbidity, alkalinity, or temperature shift seasonally, then wondering why coagulant dose "stopped working."
+- Having learned that wasting rate fixes most activated-sludge upsets, defaulting to a wasting-rate change even when the underlying cause is a toxic industrial discharge that needs source control, not a solids-inventory fix.
+- Waiting for the next scheduled lab sample to confirm a trend that SCADA has already shown moving toward a limit for several hours, losing the response window a faster grab sample would have preserved.
+
+## Worked example
+
+A 4.0 MGD-design conventional activated-sludge plant (aeration basin volume 0.75 MG) runs an average dry-weather flow of 3.0 MGD, influent BOD5 of 200 mg/L, and MLSS held at 3,000 mg/L by routine wasting. Baseline: F:M = (3.0 × 200) / (0.75 × 3,000) = 600 / 2,250 = **0.27 lb BOD/lb MLSS/day** (within the 0.2-0.5 conventional-system range), HRT = 0.75 MG / 3.0 MGD × 24 = **6.0 hours**, and at this loading the plant runs ~92% BOD removal, giving effluent BOD5 = 200 × 0.08 = **16 mg/L**, comfortably under the plant's NPDES permit limits of 25 mg/L (30-day average) and 40 mg/L (7-day average).
+
+A storm hits; I/I pushes flow to 6.0 MGD (2x baseline) while dilution drops influent BOD5 to 140 mg/L. Wasting continues unchanged, so the added flow washes solids out of the system: MLSS falls to 2,000 mg/L.
+
+**Naive read:** bump the chlorine/disinfection dose and note the storm as the cause — treats the visible parameter and assumes the exceedance risk ends when the rain does.
+
+**Expert approach:** recompute the loading, not just the flow. HRT = 0.75 / 6.0 × 24 = **3.0 hours** (half of design) and F:M = (6.0 × 140) / (0.75 × 2,000) = 840 / 1,500 = **0.56 lb/lb/day** — above the conventional system's functional ceiling of ~0.5. At that loading, removal efficiency degrades to roughly 78% (reduced contact time, diluted biomass), giving effluent BOD5 = 140 × 0.22 = **30.8 mg/L**. Checked against the permit: no single-day exceedance exists (the permit sets 30-day and 7-day averages, not a daily maximum), but a 30.8 mg/L day is 23% above the 30-day average limit of 25 mg/L — if two more days like it land in the same averaging period, the 30-day average breaches. DO stays at 2.4 mg/L and pH holds at 7.1 (both normal), ruling out a toxic slug discharge and confirming a hydraulic/loading washout, not a biological kill.
+
+Corrective action: cut WAS wasting by 50% for 48 hours to retain solids and rebuild MLSS, rather than increasing aeration (which doesn't address the missing biomass inventory). 48 hours later, with storm flow receding to 3.5 MGD and influent BOD5 at 190 mg/L, MLSS has recovered to 2,700 mg/L: F:M = (3.5 × 190) / (0.75 × 2,700) = 665 / 2,025 = **0.33 lb/lb/day** (back inside the normal band), removal efficiency returns to ~92%, and effluent BOD5 = 190 × 0.08 = **15.2 mg/L**, well under the 25 mg/L limit.
+
+**Deliverable (operator shift log / internal memo excerpt):**
+
+> 06/14 storm event: influent flow peaked 6.0 MGD (2x design dry-weather avg) for ~30 hrs; MLSS diluted 3,000→2,000 mg/L, F:M rose 0.27→0.56 lb/lb/day (exceeds 0.5 functional ceiling), one grab sample effluent BOD5 = 30.8 mg/L — no daily-max violation (permit sets 30-day/7-day avg only) but 23% above 30-day avg limit of 25 mg/L if sustained. DO 2.4 mg/L, pH 7.1 — normal, ruling out toxic upset; confirmed hydraulic washout. Action: WAS wasting cut 50% for 48 hrs starting 06/14 1800. 06/16 0600 recheck: MLSS 2,700 mg/L, F:M 0.33, effluent BOD5 15.2 mg/L. No NPDES exceedance this reporting period; logged as process upset, wasting rate restored to baseline 06/17.
+
+## Going deeper
+
+- [references/playbook.md](references/playbook.md) — filled F:M/CT/SRT worksheets, a chlorine CT compliance table, and a storm-response wasting-rate schedule.
+- [references/red-flags.md](references/red-flags.md) — signals a process is drifting toward a permit exceedance and what to check first.
+- [references/vocabulary.md](references/vocabulary.md) — terms of art generalists misuse (CT value, F:M ratio, SRT, and others).
+
+## Sources
+
+U.S. EPA, *Surface Water Treatment Rule* and CT-value guidance tables (40 CFR 141 Subpart P); U.S. EPA, *NPDES Permit Writers' Manual*; 40 CFR Part 133 (secondary treatment regulation) and Part 503 (biosolids); Metcalf & Eddy / Tchobanoglous, Burton & Stensel, *Wastewater Engineering: Treatment and Resource Recovery* (F:M and SRT operating ranges); AWWA, *Water Treatment Plant Operation* (jar testing and coagulation practice); WEF, *Operation of Municipal Wastewater Treatment Plants* (Manual of Practice No. 11); state operator certification exam references (typical Class I-IV structure per ABC — Association of Boards of Certification); general knowledge of standard activated-sludge process control practice.

--- a/roles/water-wastewater-treatment-operator/references/playbook.md
+++ b/roles/water-wastewater-treatment-operator/references/playbook.md
@@ -1,0 +1,60 @@
+# Playbook
+
+## F:M / SRT / HRT worksheet (activated sludge)
+
+Fill with current shift data; recompute whenever influent flow or MLSS moves more than 10% from the prior sample.
+
+| Field | Formula | Baseline example | Storm example |
+|---|---|---|---|
+| Flow (MGD) | measured | 3.0 | 6.0 |
+| Influent BOD5 (mg/L) | lab/online | 200 | 140 |
+| Aeration volume (MG) | fixed | 0.75 | 0.75 |
+| MLSS (mg/L) | lab | 3,000 | 2,000 |
+| F:M (lb/lb/day) | (Flow × BOD) / (Vol × MLSS) | 0.27 | 0.56 |
+| HRT (hr) | Vol / Flow × 24 | 6.0 | 3.0 |
+| SRT target (days) | operator-set via wasting rate | 8 | 10 (raised — cut wasting) |
+| Functional band | 0.2–0.5 lb/lb/day (conventional) | in-band | over-band, flag |
+
+**Action thresholds:**
+- F:M 0.40-0.50: increase sampling frequency, hold wasting rate steady.
+- F:M >0.50: cut WAS wasting by 30-50% for 24-48 hr, recheck MLSS and F:M every 12 hr until back in-band.
+- F:M <0.15 for more than 2 days: increase wasting — excess biomass with low food is a bulking risk (filamentous growth favors low F:M).
+
+## Chlorine CT compliance table (Surface Water Treatment Rule, Giardia 3-log)
+
+Required CT (mg/L·min) at pH 7.0-7.5 for free chlorine, by water temperature — use the peak-hour instantaneous flow to compute actual contact time (T), never the daily average.
+
+| Temp (°C) | Required CT (mg/L·min), 3-log Giardia |
+|---|---|
+| 0.5 | 137 |
+| 5 | 121 |
+| 10 | 100 |
+| 15 | 84 |
+| 20 | 67 |
+| 25 | 55 |
+
+**Worked check:** clearwell baffled volume 0.5 MG, peak hour flow 4.0 MGD → theoretical HRT = 0.5/4.0 × 24 × 60 = 180 min. Baffling factor (unbaffled/poor baffling) T10/T ≈ 0.3 → actual contact time (T10) ≈ 54 min. Residual held at 1.2 mg/L. CT achieved = 1.2 × 54 = 64.8 mg/L·min. At 15°C, required CT is 84 — **this plant is under-crediting** and needs either a higher residual, a longer contact time (raise clearwell level, improve baffling), or a tracer study to confirm the assumed baffling factor is actually that conservative.
+
+## Storm-response wasting-rate schedule (activated sludge, hydraulic surge)
+
+1. **Flow >150% of design average, MLSS trending down >10%/day:** cut WAS wasting 30%, hold RAS (return activated sludge) rate at maximum to keep solids in the aeration train rather than lost to the clarifier overflow.
+2. **Flow >200% of design average:** cut WAS wasting 50%, engage flow equalization or step-feed if available to protect clarifier surface overflow rate; increase DO setpoint only if oxygen transfer (not biomass inventory) is confirmed as the limiting factor via a DO profile across the basin.
+3. **Post-storm, flow returning to <120% of design average:** hold reduced wasting for one full SRT cycle (typically 24-72 hr depending on baseline SRT) before restoring baseline wasting rate — restoring too early re-triggers the MLSS deficit the reduced wasting was rebuilding.
+4. **Recheck cadence during response:** MLSS and F:M every 12 hr; effluent BOD5/TSS grab sample every 24 hr until F:M is back inside the 0.2-0.5 band for two consecutive readings.
+
+## NPDES Discharge Monitoring Report (DMR) — exceedance triage
+
+| Situation | Report as violation? | Deadline |
+|---|---|---|
+| Single grab sample above a permit value defined as a daily maximum | Yes | Per permit's noncompliance reporting clause; many require 24-hr verbal + 5-day written for events with potential endangerment (40 CFR 122.41(l)(6)) |
+| Single grab sample above a permit value defined only as a 7-day or 30-day average, average not yet breached | No — log as internal process upset, note in DMR comments if the state form requires narrative context | End of reporting period (routine DMR submission) |
+| Averaging-period calculation (7-day or 30-day) exceeds the permit limit | Yes | Routine DMR submission; escalate to verbal notice if the exceedance also triggers a water-quality standards concern |
+| Bypass or upset with no permit exceedance but potential for one | Situational — many permits require notice of bypass/upset regardless of measured outcome | Per permit's bypass/upset notification clause, typically 24 hr |
+
+## Biosolids batch release checklist (40 CFR Part 503)
+
+1. Confirm stabilization process met spec for the batch: digester temperature and retention time (mesophilic anaerobic: typically ≥15 days at ≥35°C for Class B via PSRP) — pull the process log for the specific batch, not a plant-wide average.
+2. Pull fecal coliform result: <1,000 MPN/g dry weight (or Salmonella <3 MPN/4g) for Class A; <2,000,000 MPN/g dry weight for Class B.
+3. Confirm vector attraction reduction (VAR) method used and documented (e.g., ≥38% volatile solids reduction, or alkaline addition to pH ≥12 for 2 hours holding ≥pH 11.5 for 22 more hours).
+4. Match land-application site restrictions to the classification achieved — Class B carries site-access and crop-harvest waiting periods; Class A does not.
+5. File the batch's testing and process records before land application, not after — a regulator audit checks the paper trail against the application date.

--- a/roles/water-wastewater-treatment-operator/references/red-flags.md
+++ b/roles/water-wastewater-treatment-operator/references/red-flags.md
@@ -1,0 +1,56 @@
+# Red flags
+
+### Free chlorine residual <0.2 mg/L at a distribution-system endpoint
+- **Usually means:** low demand/dead-end main allowing decay, or a recent main break/repair introducing contamination risk; second most likely is a booster/rechlorination station offline.
+- **First question:** is this a single endpoint or a spreading pattern across the pressure zone?
+- **Data to pull:** distribution residual monitoring log for the past 7 days, work-order history for that main segment, booster station run status.
+
+### Effluent BOD5 or TSS at ≥80% of the NPDES 30-day average limit on any single sample
+- **Usually means:** organic/hydraulic overload from I/I or an industrial slug, or a wasting-rate mismatch letting MLSS drift out of the functional F:M band.
+- **First question:** has influent flow or BOD load moved outside its normal range in the same window?
+- **Data to pull:** influent flow and BOD/TSS trend, current MLSS and computed F:M, industrial pretreatment discharge log.
+
+### MLSS dropping more than 15% between consecutive daily samples with wasting rate unchanged
+- **Usually means:** hydraulic washout from a flow event exceeding clarifier or aeration detention capacity; second most likely is a clarifier solids-blanket failure sending solids over the weir.
+- **First question:** did influent flow spike in the same window, and by how much relative to design capacity?
+- **Data to pull:** influent flow hydrograph, clarifier sludge-blanket depth log, wasting pump run log.
+
+### Turbidity combined filter effluent >0.3 NTU in more than 5% of samples in a month
+- **Usually means:** coagulant underdose relative to a shift in raw-water turbidity/alkalinity, or a filter approaching its run-length limit (media fouling, mudball formation).
+- **First question:** when was the last jar test run against current raw-water conditions?
+- **Data to pull:** raw-water turbidity/pH/alkalinity trend, filter run-time-since-backwash log, most recent jar test results.
+
+### CT value calculated below the required log-inactivation target for the current flow
+- **Usually means:** peak instantaneous flow (not average) wasn't used in the T term, or clearwell/contact-basin detention time has shortened due to short-circuiting or a lowered water level.
+- **First question:** was the CT calculation run against peak hour flow or average daily flow?
+- **Data to pull:** peak-flow SCADA log for the compliance period, clearwell level trend, most recent tracer study if one exists.
+
+### DO in an aeration basin below 1.0 mg/L for more than 2 hours
+- **Usually means:** blower or diffuser fault, or an organic load spike consuming oxygen faster than aeration capacity supplies it.
+- **First question:** did the alarm coincide with a rain event or a known industrial discharge schedule?
+- **Data to pull:** blower run status and amperage, influent flow/BOD trend, diffuser cleaning/inspection history.
+
+### F:M ratio above 0.5 lb BOD/lb MLSS/day for a conventional activated-sludge system
+- **Usually means:** organic overload outpacing biomass inventory, commonly from a hydraulic surge diluting MLSS faster than it's replenished.
+- **First question:** was the MLSS sample taken during or shortly after a flow surge?
+- **Data to pull:** SVI/settleometer result to confirm true biomass condition, wasting-rate log, influent BOD trend.
+
+### SVI trending above 150 mL/g over consecutive days
+- **Usually means:** filamentous bulking (often low F:M, low DO, or septic influent) reducing clarifier settling and risking solids carryover to the effluent.
+- **First question:** has DO or F:M drifted outside its normal band in the prior week?
+- **Data to pull:** DO trend log, F:M trend, microscopic exam results if available.
+
+### A single grab sample exceeding a permit limit that is defined only as a 7-day or 30-day average
+- **Usually means:** not itself a violation, but an early signal that the averaging-period limit is at risk if the condition persists.
+- **First question:** how many more samples remain in the current averaging period, and at what value would the average breach the limit?
+- **Data to pull:** all samples already logged in the current averaging period, permit's exact averaging-period definition.
+
+### Biosolids fecal coliform result above 2,000,000 MPN/g dry weight (Class B threshold, 40 CFR 503.32)
+- **Usually means:** an interruption in the stabilization process (digestion time/temperature shortfall, lime dose miscalculation) rather than a sampling error.
+- **First question:** did digester temperature or retention time drop below spec in the batch this sample represents?
+- **Data to pull:** digester temperature/retention-time log for the batch, stabilization process control records.
+
+### Distribution system pressure dropping below 20 psi anywhere in the system
+- **Usually means:** a main break or major leak creating a backflow/contamination risk under SDWA's distribution-system pressure requirement.
+- **First question:** is there a confirmed main break, or is this a pump station or elevated-tank level issue?
+- **Data to pull:** SCADA pressure zone map, pump station run status, tank level trend.

--- a/roles/water-wastewater-treatment-operator/references/vocabulary.md
+++ b/roles/water-wastewater-treatment-operator/references/vocabulary.md
@@ -1,0 +1,61 @@
+# Vocabulary
+
+### CT value
+The product of disinfectant concentration (mg/L) and contact time (minutes) used under the Surface Water Treatment Rule to credit Giardia/virus log-inactivation.
+**In use:** "Our CT at peak hour flow only clears 2.5-log Giardia inactivation, not the 3-log the rule requires — we need more clearwell volume or a higher residual."
+**Common misuse:** Treating a compliant chlorine residual alone as proof of adequate disinfection — CT requires both concentration and the actual detention time at the flow in question, and a shortened detention time (short-circuiting, low clearwell level) can fail CT even with a fine residual.
+
+### F:M ratio (food-to-microorganism ratio)
+The mass of BOD entering an activated-sludge system per day divided by the mass of MLSS in the aeration basin, expressed as lb BOD/lb MLSS/day.
+**In use:** "F:M jumped to 0.56 during the storm — that's above our 0.5 ceiling, which is why effluent BOD climbed even though DO held fine."
+**Common misuse:** Calculating F:M from an MLSS sample taken during a hydraulic surge without noting that the surge itself diluted the MLSS reading — the resulting F:M spike can look like an overload when the true biomass inventory is closer to normal.
+
+### SRT (solids retention time)
+The average time solids remain in an activated-sludge system, controlled primarily by the wasting rate, distinct from hydraulic retention time.
+**In use:** "We cut wasting to stretch SRT out to 10 days so the nitrifiers have time to re-establish after the washout."
+**Common misuse:** Conflating SRT with HRT — HRT is about flow through the tank, SRT is about how long the biomass itself stays in the system; a plant can have a short HRT during a storm while still controlling SRT through the wasting rate.
+
+### MLSS (mixed liquor suspended solids)
+The concentration of suspended solids (largely biomass) in the aeration basin, measured in mg/L.
+**In use:** "MLSS washed out from 3,000 to 2,000 during the storm — that's the number driving the F:M spike, not a change in influent load alone."
+**Common misuse:** Treating a falling MLSS reading as automatically meaning the plant is "losing bugs" to a toxic event, when a hydraulic dilution from storm flow produces the identical reading without any biological kill.
+
+### SVI (sludge volume index)
+A settling-quality metric: the volume (mL) occupied by 1 gram of MLSS after 30 minutes of settling in a settleometer, divided by the MLSS concentration.
+**In use:** "SVI's been climbing past 150 for four days straight — that's filamentous bulking, not just a wasting-rate issue."
+**Common misuse:** Reading SVI in isolation from DO and F:M trends — a rising SVI is a symptom with several distinct causes (low DO, low F:M, septic influent), and treating it as a single problem with a single fix misses the actual driver.
+
+### NPDES (National Pollutant Discharge Elimination System) permit
+The Clean Water Act permit authorizing a point-source discharge (a treatment plant's outfall) and setting the effluent limits it must meet.
+**In use:** "Our NPDES permit sets BOD5 at 25 mg/L on a 30-day average and 40 on a 7-day average — a single high grab sample doesn't violate it unless the average does."
+**Common misuse:** Treating any single sample above the numeric limit as an automatic violation without checking whether the permit defines that limit as a daily maximum or an averaging-period limit — most conventional parameters are set as averages, not daily caps.
+
+### MCL (maximum contaminant level)
+The legally enforceable concentration limit for a regulated contaminant in finished drinking water under the Safe Drinking Water Act.
+**In use:** "Nitrate came back at 8.5 mg/L — under the 10 mg/L MCL, but close enough that we're adding it to the weekly monitoring list."
+**Common misuse:** Assuming every SDWA requirement is an MCL — some contaminants (like turbidity for surface-water systems) are regulated by a treatment technique rather than a numeric MCL, and the compliance mechanism differs.
+
+### Treatment technique
+An SDWA compliance mechanism requiring a specific treatment process or performance standard rather than a numeric contaminant limit, used when reliably measuring the contaminant itself isn't practical.
+**In use:** "Turbidity compliance is a treatment technique, not an MCL — we have to hit 0.3 NTU in 95% of combined filter effluent samples monthly, and never exceed 1 NTU."
+**Common misuse:** Calling a treatment-technique requirement an "MCL" in a compliance report — regulators and lab reports distinguish the two, and misusing the term signals unfamiliarity with the actual rule structure.
+
+### Biosolids Class A vs. Class B
+40 CFR Part 503 pathogen-reduction classifications for treated sewage sludge: Class A meets a stricter pathogen standard (allows unrestricted land application), Class B meets a lower bar with site-use restrictions.
+**In use:** "This batch tested Class B fecal coliform — fine for the ag application site we have, but it can't go to the unrestricted-use program."
+**Common misuse:** Treating "digested" and "Class A" as synonymous — digestion is a process, Class A is a pathogen-reduction outcome verified by testing, and a digester running short on temperature or time can produce sludge that's digested but doesn't clear the Class A threshold.
+
+### I/I (inflow and infiltration)
+Extraneous water entering a sanitary sewer system — inflow from direct connections (storm drains, roof leaders), infiltration through pipe joints and cracks — that isn't sanitary wastewater.
+**In use:** "That flow spike is classic I/I — it tracks the rain hyetograph almost exactly, not a sudden jump in actual wastewater generation."
+**Common misuse:** Lumping I/I in with "normal peak flow" in capacity planning — I/I is a collection-system defect with its own remediation path (smoke testing, lining, manhole rehab), not a load the treatment plant should simply be sized to absorb indefinitely.
+
+### Short-circuiting
+Water taking a faster path through a tank or basin than the nominal detention time implies, reducing actual contact or reaction time below the calculated value.
+**In use:** "The tracer study showed T10 at 40% of theoretical detention time — we're short-circuiting badly enough that our CT calculation is overstating actual disinfection credit."
+**Common misuse:** Assuming nominal detention time (tank volume divided by flow) equals actual contact time — without a tracer study, short-circuiting can silently overstate CT compliance.
+
+### Settleometer test
+A benchtop test settling a mixed-liquor sample in a graduated cylinder to visually assess settling rate, sludge blanket compaction, and clarity — used to sanity-check MLSS/SVI readings and spot bulking or pin-floc conditions.
+**In use:** "MLSS reading looked low, but the settleometer showed good compaction and a clear supernatant — that confirms it's dilution, not a kill."
+**Common misuse:** Treating an F:M or MLSS calculation as sufficient on its own during a suspected upset — the settleometer is the fast, low-cost cross-check that distinguishes a hydraulic dilution from an actual biological problem.


### PR DESCRIPTION
## Rubric Score

18/18

## Resolution Rationale

O*NET 47-1011.03 (Solar Energy Installation Managers) supervises PV/thermal installation crews: scheduling, safety (fall protection/lockout-tagout), subcontractor/crew coordination, AHJ inspection pass/fail, punch-list and workmanship-warranty resolution, install-sequencing logistics. None of the three candidates share this job function. solar-energy-systems-engineer's Decision framework, Tools, and Worked example are entirely about pre-construction electrical design and yield modeling (NEC 690.7/690.8 string sizing, DC/AC ratio, PVsyst/SAM 8760 simulation, P50/P90 yield) aimed at a permit/financing package — a practitioner using it for an install-management task would get design-engineering guidance (voltage derating math, performance-ratio loss stacks) instead of the actual decisions an installation manager needs (crew dispatch, inspection scheduling, safety compliance, punch-list triage), which fails the granularity test outright — it's a wrong-guidance gap, not merely less detail. The two wind roles are also inapplicable (wrong energy source and, for wind-energy-operations-manager, wrong lifecycle stage — post-COD asset operations, not construction-phase crew supervision). Since no candidate is a broader version of this role that a leaf could specialize from (they cover a different occupational function: engineering design vs. asset operations vs. project development, none of which is "installation supervision"), no reasonable parent exists among the candidates, so this warrants a new top-level role. Slug follows the repo's `<domain>-energy-<function>` convention already used by solar-energy-systems-engineer and the wind-energy-* pair.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two operations roles: Solar Energy Installation Manager and Water & Wastewater Treatment Plant Operator, covering PV install supervision (permits, safety, PTO) and plant operations compliance. Updates counts and checklists across `README.md`, `ROADMAP.md`, and `data/roles.json`.

- **New Features**
  - Added `solar-energy-installation-manager` (O*NET 47-1011.03) and `water-wastewater-treatment-operator` (O*NET 51-8031.00), each with `SKILL.md` plus references (playbook, red flags, vocabulary).
  - Updated `data/roles.json` (count 830; both roles active, spec 2, `operations`).
  - Refreshed `README.md` and `ROADMAP.md` totals and checklists (Construction & Extraction now includes the solar role; Production includes the water/wastewater role; operations +2; O*NET mapped 820/1,016).

<sup>Written for commit 04bab9d794ea87847fbf53ecdff20a6d0d6caf01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

