### PR TITLE
docs: update CONTEXT.md after group 47 completion

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -1,14 +1,14 @@
 # CONTEXT
 
 ## Current Task
-2026-07-12 session: continued mass role-drafting via Workflow-tool orchestration, groups 49/43/53/33/41/39 all done (91 roles added, lint clean, each batch committed+pushed). 828/1016 drafted. Only groups 47 (36 roles) and 51 (63 roles, biggest) remain. Runbook: `docs/onet-fill-remaining.md`.
+2026-07-14 session: ran group 47 (36 Construction/Extraction roles) via Workflow-tool orchestration — all 36 added, 0 skipped, lint clean, committed+pushed to main (25d70b5). 854/1016 drafted (≈84.1%). Only group 51 (63 roles, Production, biggest) remains. Runbook: `docs/onet-fill-remaining.md`.
 
 ## Key Decisions
-- Confirmed with user before each Workflow launch this session (multi-agent cost) — ask before firing, don't auto-chain.
-- Small-batch lint fixes handled inline by the ops agent each time (banned phrases: "Best Practices" in bailiff citation, "utilize" substring in resident-director) — no roles dropped across 6 batches.
+- Confirmed direct-to-main push convention with user (matches AGENTS.md/prior batches) despite session's default branch instructions pointing elsewhere — keep pushing role batches straight to main.
+- Left commit 25d70b5's author identity as-is (user declined a rewrite of already-shared main history); set git config (user.email noreply@anthropic.com, user.name Claude) so future commits are correctly attributed.
 - Same skip conventions as before: "All Other" catch-alls and O*NET group 55 (Military) excluded.
 
 ## Next Steps
-- Resume via `docs/onet-fill-remaining.md`: group 47 (36 roles) next, then 51 (63, biggest, do last).
+- Resume via `docs/onet-fill-remaining.md`: group 51 (63 roles, Production, do last) is the only group left.
 - Known bug still open: `roles/critical-care-nurse/` mismapped to code 29-1141.01 (Acute Care Nurses) instead of its titled 29-1141.03 — needs rename/split pass.
-- Haven't bumped npm version this session (still v0.5.0) — bump/tag/push once 47+51 land, per Release section in the runbook.
+- Haven't bumped npm version this session (still v0.5.0) — bump/tag/push once group 51 lands, per Release section in the runbook.


### PR DESCRIPTION
## Summary

Update session progress tracking in `docs/CONTEXT.md` following successful completion of group 47 (Construction/Extraction roles).

## Changes

- **Current Task**: Updated from group 49/43/53/33/41/39 completion to group 47 completion (36 roles added, commit 25d70b5)
  - Progress: 828/1016 → 854/1016 drafted (≈84.1%)
  - Only group 51 (63 roles, Production) remains
  
- **Key Decisions**: Clarified two important conventions:
  1. Direct-to-main push convention confirmed (matches prior batches despite session default branch instructions)
  2. Git config set for future commits (user.email: noreply@anthropic.com, user.name: Claude); existing commit 25d70b5 left as-is per user request
  
- **Next Steps**: Simplified to reflect single remaining group
  - Group 51 (63 roles, Production) is the only group left to draft
  - Version bump deferred until group 51 lands

## Context

This is a documentation-only update reflecting actual progress made in the session. No code changes, no role additions in this commit — purely updating the session context file to accurately reflect where the work stands for the next session.

## Test Plan

N/A — documentation update only.

https://claude.ai/code/session_01W83MD6wQKC1jv7j5obu4jS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated docs/CONTEXT.md to reflect completion of group 47 (36 Construction/Extraction roles) and simplify next steps. Progress is now 854/1016 (~84%); confirms direct-to-main push and future git author config, and notes that only group 51 (63 Production roles) remains.

<sup>Written for commit 7074ca84bfe64aa047a2279ba12b346394fa8d8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wonsukchoi/domain-experts/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

